### PR TITLE
fixed `build.fsx`

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -13,9 +13,9 @@ open Fake.DocFxHelper
 let configuration = "Release"
 
 // Metadata used when signing packages and DLLs
-let signingName = "My Library"
-let signingDescription = "My REALLY COOL Library"
-let signingUrl = "https://signing.is.cool/"
+let signingName = "Akka.Management"
+let signingDescription = "Akka.NET Cluster management and bootstrapping libraries"
+let signingUrl = "https://getakka.net/"
 
 // Read release notes and version
 let solutionFile = FindFirstMatchingFile "*.sln" __SOURCE_DIRECTORY__  // dynamically look up the solution
@@ -57,8 +57,8 @@ Target "Clean" (fun _ ->
 )
 
 Target "AssemblyInfo" (fun _ ->
-    XmlPokeInnerText "./src/common.props" "//Project/PropertyGroup/VersionPrefix" releaseNotes.AssemblyVersion    
-    XmlPokeInnerText "./src/common.props" "//Project/PropertyGroup/PackageReleaseNotes" (releaseNotes.Notes |> String.concat "\n")
+    XmlPokeInnerText "./src/Directory.Build.props" "//Project/PropertyGroup/VersionPrefix" releaseNotes.AssemblyVersion    
+    XmlPokeInnerText "./src/Directory.Build.props" "//Project/PropertyGroup/PackageReleaseNotes" (releaseNotes.Notes |> String.concat "\n")
 )
 
 Target "Build" (fun _ ->          

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,9 +27,9 @@
   <PropertyGroup>
     <LibraryFramework>netstandard2.0</LibraryFramework>
     <TestsNetCoreFramework>netcoreapp3.1</TestsNetCoreFramework>
-    <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.9.4</TestSdkVersion>
+    <AkkaVersion>1.4.20</AkkaVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/management/Akka.Management.Tests/Akka.Management.Tests.csproj
+++ b/src/management/Akka.Management.Tests/Akka.Management.Tests.csproj
@@ -8,7 +8,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
   </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\Akka.Management\Akka.Management.csproj" />

--- a/src/management/Akka.Management/Akka.Management.csproj
+++ b/src/management/Akka.Management/Akka.Management.csproj
@@ -5,4 +5,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Akka.Cluster" Version="$(AkkaVersion)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixed build system to write out to `Directory.Build.props` instead of `common.props`, which we renamed.