### PR TITLE
[WIP] Akka.Http.Core shim

### DIFF
--- a/Akka.Management.sln
+++ b/Akka.Management.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Management", "src\mana
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Management.Tests", "src\management\Akka.Management.Tests\Akka.Management.Tests.csproj", "{5FD15B48-DECC-4742-AB9C-6F8517B12C6D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Http.Shim", "src\management\Akka.Http.Shim\Akka.Http.Shim.csproj", "{DC9C497E-4B8D-4D32-A1D5-569E349BDE17}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{5FD15B48-DECC-4742-AB9C-6F8517B12C6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5FD15B48-DECC-4742-AB9C-6F8517B12C6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5FD15B48-DECC-4742-AB9C-6F8517B12C6D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC9C497E-4B8D-4D32-A1D5-569E349BDE17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC9C497E-4B8D-4D32-A1D5-569E349BDE17}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC9C497E-4B8D-4D32-A1D5-569E349BDE17}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC9C497E-4B8D-4D32-A1D5-569E349BDE17}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -39,6 +45,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{C251CBCC-A7F4-40DC-9B93-F3FE514FD7DE} = {9B10ADF5-60D1-4EED-9E98-9CB2E1E84E98}
 		{5FD15B48-DECC-4742-AB9C-6F8517B12C6D} = {9B10ADF5-60D1-4EED-9E98-9CB2E1E84E98}
+		{DC9C497E-4B8D-4D32-A1D5-569E349BDE17} = {9B10ADF5-60D1-4EED-9E98-9CB2E1E84E98}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B99E6BB8-642A-4A68-86DF-69567CBA700A}

--- a/src/management/Akka.Http.Shim/Akka.Http.Shim.csproj
+++ b/src/management/Akka.Http.Shim/Akka.Http.Shim.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(LibraryFramework)</TargetFramework>
+    <RootNamespace>Akka.Http</RootNamespace>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Resources\reference.conf" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\reference.conf" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka" Version="$(AkkaVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/management/Akka.Http.Shim/Dsl/Http.cs
+++ b/src/management/Akka.Http.Shim/Dsl/Http.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Annotations;
+using Akka.Configuration;
+using Akka.Http.Dsl.Settings;
+using Akka.Http.Internal;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Akka.Http.Dsl
+{
+    using HttpRequest = Model.HttpRequest;
+    using HttpResponse = Model.HttpResponse;
+
+    public sealed class HttpExt : IExtension
+    {
+        private readonly Config _config;
+        private readonly ExtendedActorSystem _system;
+
+        public HttpExt(Config config, ExtendedActorSystem system)
+        {
+            _config = config;
+            _system = system;
+        }
+
+        /// <summary>
+        /// Main entry point to create a server binding.
+        /// </summary>
+        /// <param name="hostname">The interface to bind to.</param>
+        /// <param name="port">The port to bind to or `0` if the port should be automatically assigned.</param>
+        public ServerBuilder NewServerAt(string hostname, int port) =>
+            ServerBuilder.Create(hostname, port, _system);
+
+        /// <summary>
+        /// Convenience method which starts a new HTTP server at the given endpoint and uses the given `handler`
+        /// for processing all incoming connections.
+        /// </summary>
+        public async Task<ServerBinding> BindAndHandleAsync(Func<HttpRequest, Task<HttpResponse>> handler, string hostname, int port, ServerSettings settings)
+        {
+            var host = WebHost.CreateDefaultBuilder()
+                .SuppressStatusMessages(true)
+                .ConfigureServices(services =>
+                {
+                    services.AddLogging(builder => builder.AddFilter("Microsoft", LogLevel.None));
+                    services.AddRouting();
+                })
+                .Configure(app =>
+                {
+                    static bool Predicate(HttpContext context) =>
+                        context.Request.Path.StartsWithSegments("", out var remaining); // && string.IsNullOrEmpty(remaining);
+
+                    app.UseMiddleware<HttpRequestMiddleware>();
+                    
+                    // Actual middleware that turns an Akka HttpResponse into an AspNetCore HttpResponse
+                    app.MapWhen(Predicate, b => b.Run(async context =>
+                    {
+                        var response = await handler(context.Features.Get<HttpRequest>());
+                        if (response != null)
+                        {
+                            context.Response.StatusCode = response.Status;
+                            context.Response.ContentType = response.Entity.ContentType;
+                            await context.Response.WriteAsync(response.Entity.DataBytes.ToString());
+                        }
+                    }));
+
+                    // TODO: for debugging purposes only, remove
+                    app.Run(context => context.Response.WriteAsync("Akka-Http middleware seems to be ready."));
+                })
+                .UseUrls($"http://{hostname}:{port}")
+                .Build();
+
+            // Start listening...
+            await host.StartAsync();
+
+            return new ServerBinding(
+                new DnsEndPoint(hostname, port),
+                async timeout =>
+                {
+                    await host.StopAsync(timeout);
+                    return HttpServerTerminated.Instance;
+                });
+        }
+    }
+
+    public class Http : ExtensionIdProvider<HttpExt>
+    {
+        public new static HttpExt Get(ActorSystem system) => system.WithExtension<HttpExt, Http>();
+
+        public override HttpExt CreateExtension(ExtendedActorSystem system) =>
+            new HttpExt(system.Settings.Config.GetConfig("akka.http"), system);
+    }
+
+    /// <summary>
+    /// Type used to carry meaningful information when server termination has completed successfully.
+    /// </summary>
+    [DoNotInherit]
+    public abstract class HttpTerminated
+    {
+    }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    public sealed class HttpServerTerminated : HttpTerminated
+    {
+        public static readonly HttpServerTerminated Instance = new HttpServerTerminated();
+
+        private HttpServerTerminated()
+        {
+        }
+    }
+}

--- a/src/management/Akka.Http.Shim/Dsl/Model/ContentTypes.cs
+++ b/src/management/Akka.Http.Shim/Dsl/Model/ContentTypes.cs
@@ -1,0 +1,16 @@
+namespace Akka.Http.Dsl.Model
+{
+    /// <summary>
+    /// Contains the set of predefined content-types for convenience.
+    /// </summary>
+    public static class ContentTypes
+    {
+        public static readonly string ApplicationJson = "application/json";
+        public static readonly string ApplicationOctetStream = "application/octet-stream";
+        public static readonly string ApplicationXWwwFormUrlencoded = "application/x-www-form-urlencoded";
+        public static readonly string TextPlainUtf8 = "text/plain;charset=utf-8";
+        public static readonly string TextHtmlUtf8 = "text/html;charset=utf-8";
+        public static readonly string TextXmlUtf8 = "text/xml;charset=utf-8";
+        public static readonly string TextCsvUtf8 = "text/csv;charset=utf-8";
+    }
+}

--- a/src/management/Akka.Http.Shim/Dsl/Model/HttpEntity.cs
+++ b/src/management/Akka.Http.Shim/Dsl/Model/HttpEntity.cs
@@ -1,0 +1,76 @@
+using Akka.Annotations;
+using Akka.IO;
+
+namespace Akka.Http.Dsl.Model
+{
+    /// <summary>
+    /// Represents the entity of an Http message.
+    /// An entity consists of the content-type of the data and the actual data itself.
+    /// </summary>
+    [DoNotInherit]
+    public abstract class HttpEntity
+    {
+        /// <summary>
+        /// The `ContentType` associated with this entity.
+        /// </summary>
+        public string ContentType { get; }
+
+        /// <summary>
+        /// The data of this entity.
+        /// </summary>
+        public ByteString DataBytes { get; }
+
+        /// <summary>
+        /// Creates a copy of this HttpEntity with the `contentType` overridden with the given one.
+        /// </summary>
+        public abstract HttpEntity WithContentType(string contentType);
+
+        public static HttpEntity Empty => new RequestEntity(null, ByteString.Empty);
+
+        public static HttpEntity Create(string content) => Create("text/plain(UTF-8)", content);
+
+        public static HttpEntity Create(ByteString data) => Create("application/octet-stream", data);
+
+        public static HttpEntity Create(string contentType, string content) =>
+            string.IsNullOrEmpty(content) ? Empty : Create(contentType, ByteString.FromString(content));
+
+        public static HttpEntity Create(string contentType, ByteString data) =>
+            new RequestEntity(contentType, data);
+
+        protected HttpEntity(string contentType, ByteString dataBytes)
+        {
+            ContentType = contentType;
+            DataBytes = dataBytes;
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="HttpEntity"/> that can be used for requests.
+    /// Note that all entities that can be used for requests can also be used for responses (but not the other way around).
+    /// </summary>
+    public class RequestEntity : ResponseEntity
+    {
+        public RequestEntity(string contentType, ByteString dataBytes)
+            : base(contentType, dataBytes)
+        { }
+    }
+
+    /// <summary>
+    /// An <see cref="HttpEntity"/> that can be used for responses.
+    /// Note that all entities that can be used for requests can also be used for responses (but not the other way around).
+    /// </summary>
+    public class ResponseEntity : HttpEntity
+    {
+        public new static ResponseEntity Empty => new ResponseEntity(null, ByteString.Empty);
+
+        public ResponseEntity(string contentType, ByteString dataBytes)
+            : base(contentType, dataBytes)
+        { }
+
+        public override HttpEntity WithContentType(string contentType) =>
+            contentType == ContentType ? this : Copy(contentType);
+
+        private ResponseEntity Copy(string contentType = null, ByteString data = null) =>
+            new ResponseEntity(contentType ?? ContentType, data ?? DataBytes);
+    }
+}

--- a/src/management/Akka.Http.Shim/Dsl/Model/HttpHeader.cs
+++ b/src/management/Akka.Http.Shim/Dsl/Model/HttpHeader.cs
@@ -1,0 +1,39 @@
+using Akka.Annotations;
+
+namespace Akka.Http.Dsl.Model
+{
+    /// <summary>
+    /// The base type representing Http headers. All actual header values will be instances
+    /// of one of the subtypes defined in the `headers` packages. Unknown headers will be subtypes
+    /// of <see cref="RawHeader"/>. Not for user extension.
+    /// </summary>
+    [DoNotInherit]
+    public abstract class HttpHeader
+    {
+        /// <summary>
+        /// Returns the name of the header.
+        /// </summary>
+        public abstract string Name { get; }
+        
+        /// <summary>
+        /// Returns the String representation of the value of the header.
+        /// </summary>
+        public abstract string Value { get; }
+    }
+
+    [DoNotInherit]
+    public sealed class RawHeader : HttpHeader
+    {
+        private RawHeader(string name, string value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        public override string Name { get; }
+        public override string Value { get; }
+
+        public static RawHeader Create(string name, string value) =>
+            new RawHeader(name, value);
+    }
+}

--- a/src/management/Akka.Http.Shim/Dsl/Model/HttpMessage.cs
+++ b/src/management/Akka.Http.Shim/Dsl/Model/HttpMessage.cs
@@ -1,0 +1,154 @@
+using System.Collections.Immutable;
+using Akka.Annotations;
+using Akka.IO;
+
+namespace Akka.Http.Dsl.Model
+{
+    /// <summary>
+    /// The base type for an Http message (request or response).
+    /// </summary>
+    [DoNotInherit]
+    public abstract class HttpMessage<T>
+    {
+        /// <summary>
+        /// The entity of this message.
+        /// </summary>
+        public abstract ResponseEntity Entity { get; }
+
+        /// <summary>
+        /// Returns a copy of this message with the entity set to the given one.
+        /// </summary>
+        public abstract T WithEntity(RequestEntity entity);
+
+        public T WithEntity(string content) =>
+            WithEntity((RequestEntity)HttpEntity.Create(content));
+
+        public T WithEntity(ByteString bytes) =>
+            WithEntity((RequestEntity)HttpEntity.Create(bytes));
+
+        public T WithEntity(string contentType, string content) =>
+            WithEntity((RequestEntity)HttpEntity.Create(contentType, content));
+    }
+
+    /// <summary>
+    /// The immutable HTTP request model.
+    /// </summary>
+    public sealed class HttpRequest : HttpMessage<HttpRequest>
+    {
+        /// <summary>
+        /// Returns the Http method of this request.
+        /// </summary>
+        public string Method { get; }
+
+        /// <summary>
+        /// Returns the Uri of this request.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Returns the entity of this request.
+        /// </summary>
+        public override ResponseEntity Entity { get; }
+
+        /// <summary>
+        /// Returns a default request to be modified using the `WithX` methods.
+        /// </summary>
+        public static HttpRequest Create(string method, string path, ResponseEntity entity = null) =>
+            new HttpRequest(method, path, entity);
+
+        private HttpRequest(string method, string path, ResponseEntity entity)
+        {
+            Method = method;
+            Path = path;
+            Entity = entity;
+        }
+
+        /// <inheritdoc />
+        public override HttpRequest WithEntity(RequestEntity entity) => Copy(entity: entity);
+
+        /// <summary>
+        /// Returns a copy of this instance with a new method.
+        /// </summary>
+        public HttpRequest WithMethod(string method) => Copy(method: method);
+
+        /// <summary>
+        /// Returns a copy of this instance with a new Uri.
+        /// </summary>
+        public HttpRequest WithPath(string path) => Copy(path: path);
+
+        private HttpRequest Copy(string method = null, string path = null,RequestEntity entity = null) =>
+            new HttpRequest(method ?? Method, path ?? Path, entity ?? Entity);
+    }
+
+    /// <summary>
+    /// The immutable HTTP response model.
+    /// </summary>
+    public sealed class HttpResponse : HttpMessage<HttpResponse>
+    {
+        /// <summary>
+        /// Returns the status-code of this response.
+        /// </summary>
+        public int Status { get; }
+
+        /// <summary>
+        /// An enumerable containing the headers of this message.
+        /// </summary>
+        public ImmutableList<HttpHeader> Headers { get; }
+
+        /// <summary>
+        /// Returns the entity of this request.
+        /// </summary>
+        public override ResponseEntity Entity { get; }
+
+        public string Protocol { get; }
+
+        /// <summary>
+        /// Returns a default response to be changed using the `WithX` methods.
+        /// </summary>
+        public static HttpResponse Create(int status = 200, ImmutableList<HttpHeader> headers = null, ResponseEntity entity = null, string protocol = "HTTP/1.1") =>
+            new HttpResponse(status, headers, entity ?? ResponseEntity.Empty, protocol);
+
+        private HttpResponse(int status, ImmutableList<HttpHeader> headers, ResponseEntity entity, string protocol)
+        {
+            Status = status;
+            Headers = headers;
+            Entity = entity;
+            Protocol = protocol;
+        }
+
+        /// <inheritdoc />
+        public override HttpResponse WithEntity(RequestEntity entity) => Copy(entity: entity);
+
+        /// <summary>
+        /// Returns a copy of this instance with a new status-code.
+        /// </summary>
+        public HttpResponse WithStatus(int statusCode) => Copy(statusCode);
+
+        private HttpResponse Copy(
+            int? status = null, 
+            ImmutableList<HttpHeader> headers = null, 
+            ResponseEntity entity = null,
+            string protocol = null) => 
+            new HttpResponse(status ?? Status, headers ?? Headers, entity ?? Entity, protocol ?? Protocol);
+
+        private bool Equals(HttpResponse other) => Status == other.Status &&
+           Equals(Headers, other.Headers) &&
+           Equals(Entity, other.Entity) &&
+           Protocol == other.Protocol;
+
+        public override bool Equals(object obj) => 
+            ReferenceEquals(this, obj) || obj is HttpResponse other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Status;
+                hashCode = (hashCode * 397) ^ (Headers != null ? Headers.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Entity != null ? Entity.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Protocol != null ? Protocol.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/management/Akka.Http.Shim/Dsl/ServerBinding.cs
+++ b/src/management/Akka.Http.Shim/Dsl/ServerBinding.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.Http.Dsl
+{
+    /// <summary>
+    /// Represents a prospective HTTP server binding.
+    /// </summary>
+    public class ServerBinding
+    {
+        private readonly Func<TimeSpan, Task<HttpTerminated>> _terminateAction;
+        private readonly TaskCompletionSource<TimeSpan> _whenTerminationSignalIssued = new TaskCompletionSource<TimeSpan>();
+        private readonly TaskCompletionSource<HttpTerminated> _whenTerminated = new TaskCompletionSource<HttpTerminated>();
+        
+        // no support for unbind, not a concept in aspnet core
+        private static Func<Task> UnbindAction => () => Task.CompletedTask;
+
+        /// <summary>
+        /// The local address of the endpoint bound by the materialization of the `connections`
+        /// </summary>
+        public EndPoint LocalAddress { get; }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServerBinding"/> class.
+        /// </summary>
+        public ServerBinding(EndPoint localAddress, Func<TimeSpan, Task<HttpTerminated>> terminateAction)
+        {
+            LocalAddress = localAddress;
+            _terminateAction = terminateAction;
+        }
+
+        /// <summary>
+        /// Completes when <see cref="Terminate"/> is called and server termination is in progress.
+        /// Can be useful to make parts of your application aware that termination has been issued,
+        /// and they have <see cref="TimeSpan"/> time remaining to clean-up before the server will forcefully close
+        /// existing connections.
+        /// </summary>
+        public Task<TimeSpan> WhenTerminationSignalIssued => _whenTerminationSignalIssued.Task;
+
+        /// <summary>
+        /// This <see cref="Task"/> completes when the termination process, as initiated by an <see cref="Terminate"/> call has completed.
+        /// </summary>
+        public Task<HttpTerminated> WhenTerminated => _whenTerminated.Task;
+
+        /// <summary>
+        /// Asynchronously triggers the unbinding of the port that was bound by the materialization of the `connections`.
+        /// The produced <see cref="Task"/>> is fulfilled when the unbinding has been completed.
+        /// </summary>
+        public Task<Done> Unbind() => UnbindAction().Map(_ => Done.Instance);
+
+        /// <summary>
+        /// Triggers "graceful" termination request being handled on this connection.
+        /// </summary>
+        /// <param name="hardDeadline">timeout after which all requests and connections shall be forcefully terminated</param>
+        public async Task<HttpTerminated> Terminate(TimeSpan hardDeadline)
+        {
+            _whenTerminationSignalIssued.TrySetResult(hardDeadline);
+            await UnbindAction();
+            var terminate = await _terminateAction(hardDeadline);
+            _whenTerminated.TrySetResult(terminate);
+            return WhenTerminated.Result;
+        }
+
+        /// <summary>
+        /// Adds this <see cref="ServerBinding"/> to the actor system's coordinated shutdown, so that <see cref="Unbind"/>
+        /// and <see cref="Terminate"/> get called appropriately before the system is shut down.
+        /// </summary>
+        /// <param name="hardTerminationDeadline">timeout after which all requests and connections shall be forcefully terminated</param>
+        /// <param name="system">TBD</param>
+        public ServerBinding AddToCoordinatedShutdown(TimeSpan hardTerminationDeadline, ActorSystem system)
+        {
+            var shutdown = CoordinatedShutdown.Get(system);
+            shutdown.AddTask(CoordinatedShutdown.PhaseServiceUnbind, $"http-unbind-{LocalAddress}", Unbind);
+            shutdown.AddTask(CoordinatedShutdown.PhaseServiceRequestsDone, $"http-terminate-{LocalAddress}", async () =>
+            {
+                await Terminate(hardTerminationDeadline);
+                return Done.Instance;
+            });            
+            return this;
+        }
+    }
+}

--- a/src/management/Akka.Http.Shim/Dsl/ServerBuilder.cs
+++ b/src/management/Akka.Http.Shim/Dsl/ServerBuilder.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Http.Dsl.Model;
+using Akka.Http.Dsl.Settings;
+
+namespace Akka.Http.Dsl
+{
+    /// <summary>
+    /// <para>Builder API to create server bindings.</para>
+    /// <para>Use <see cref="HttpExt.NewServerAt"/> to create a new server builder, use methods to customize settings,
+    /// and then call one of the bind* methods to bind a server.</para>
+    /// </summary>
+    public sealed class ServerBuilder
+    {
+        private readonly ActorSystem _system;
+        private readonly HttpExt _http;
+
+        public string Hostname { get; }
+        public int Port { get; }
+        public ILoggingAdapter Log { get; }
+        public ServerSettings Settings { get; }
+
+        internal static ServerBuilder Create(string hostname, int port, ExtendedActorSystem system) =>
+            new ServerBuilder(hostname, port, system.Log, ServerSettings.Create(system), system);
+
+        private ServerBuilder(string hostname, int port, ILoggingAdapter log, ServerSettings settings, ActorSystem system)
+        {
+            _system = system;
+            _http = system.Http();
+
+            Hostname = hostname;
+            Port = port;
+            Log = log;
+            Settings = settings;
+        }
+
+        /// <summary>
+        /// Change interface to bind to
+        /// </summary>
+        public ServerBuilder OnInterface(string newInterface) => Copy(newInterface);
+
+        /// <summary>
+        /// Change port to bind to
+        /// </summary>
+        public ServerBuilder OnPort(int newPort) => Copy(port: newPort);
+
+        /// <summary>
+        /// Use a custom logger
+        /// </summary>
+        public ServerBuilder LogTo(ILoggingAdapter log) => Copy(log: log);
+
+        /// <summary>
+        /// Use custom <see cref="ServerSettings"/> for the binding.
+        /// </summary>
+        public ServerBuilder WithSettings(ServerSettings settings) => Copy(settings: settings);
+
+        /// <summary>
+        /// Bind a new HTTP server and use the given asynchronous `handler` for processing all incoming connections.
+        /// </summary>
+        public Task<ServerBinding> Bind(Func<HttpRequest, Task<HttpResponse>> handler) =>
+            _http.BindAndHandleAsync(handler, Hostname, Port, Settings);
+        
+        /// <summary>
+        /// Bind a new HTTP server at the given endpoint and uses the given `handler` for processing all incoming connections.
+        /// </summary>
+        public Task<ServerBinding> BindSync(Func<HttpRequest, HttpResponse> handler) =>
+            _http.BindAndHandleAsync(req => Task.FromResult(handler(req)), Hostname, Port, Settings);
+
+        private ServerBuilder Copy(
+            string hostname = null,
+            int? port = null,
+            ILoggingAdapter log = null,
+            ServerSettings settings = null,
+            ExtendedActorSystem system = null) => new ServerBuilder(hostname ?? Hostname, port ?? Port, log ?? Log, settings ?? Settings, system ?? _system);
+    }
+}

--- a/src/management/Akka.Http.Shim/Dsl/Settings/ServerSettings.cs
+++ b/src/management/Akka.Http.Shim/Dsl/Settings/ServerSettings.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Net;
+using Akka.Actor;
+using Akka.Annotations;
+using Akka.Configuration;
+
+namespace Akka.Http.Dsl.Settings
+{
+    [InternalApi]
+    public sealed class ServerSettings
+    {
+        public string ServerHeader { get; }
+        public bool RemoteAddressAttribute { get; }
+        public int DefaultHttpPort { get; }
+        public int DefaultHttpsPort { get; }
+        public int TerminationDeadlineExceededResponse { get; }
+
+        public static ServerSettings Create(ExtendedActorSystem system)
+        {
+            // TODO
+            // var c = system.Settings.Config.GetConfig("akka.http.server");
+            //
+            // return new ServerSettings(
+            //     c.GetString("server-header"),
+            //     c.GetBoolean("remote-address-attribute"),
+            //     c.GetInt("default-http-port"),
+            //     c.GetInt("default-https-port"),
+            //     TerminationDeadlineExceededResponseFrom(c));
+
+            return new ServerSettings("", false, 80, 443, 503);
+        }
+
+        private ServerSettings(string serverHeader, bool remoteAddressAttribute, int defaultHttpPort, int defaultHttpsPort, int terminationDeadlineExceededResponse)
+        {
+            ServerHeader = serverHeader;
+            RemoteAddressAttribute = remoteAddressAttribute;
+            DefaultHttpPort = defaultHttpPort;
+            DefaultHttpsPort = defaultHttpsPort;
+            TerminationDeadlineExceededResponse = terminationDeadlineExceededResponse;
+        }
+
+        private static int TerminationDeadlineExceededResponseFrom(Config c)
+        {
+            var status = c.GetInt("termination-deadline-exceeded-response.status");
+            if (!Enum.IsDefined(typeof(HttpStatusCode), status))
+            {
+                throw new ArgumentException($"Illegal status code set for `termination-deadline-exceeded-response.status`, was: [{status}]");
+            }
+            return status;
+        }
+    }
+}

--- a/src/management/Akka.Http.Shim/Extensions/ActorSystemExtensions.cs
+++ b/src/management/Akka.Http.Shim/Extensions/ActorSystemExtensions.cs
@@ -1,0 +1,9 @@
+﻿using Akka.Actor;
+
+namespace Akka.Http.Dsl
+{
+    public static class HttpExtExtensions
+    {
+        public static HttpExt Http(this ActorSystem system) => system.WithExtension<HttpExt, Http>();
+    }
+}

--- a/src/management/Akka.Http.Shim/Extensions/TaskExtensions.cs
+++ b/src/management/Akka.Http.Shim/Extensions/TaskExtensions.cs
@@ -1,0 +1,38 @@
+namespace System.Threading.Tasks
+{
+    public static class TaskExtensions
+    {
+        public static Task<TResult> Map<TResult>(this Task source, Func<Task, TResult> selector)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (selector == null) throw new ArgumentNullException(nameof(selector));
+
+            return source.ContinueWith(selector, TaskContinuationOptions.NotOnCanceled);
+        }        
+
+        public static Task<TResult> Map<TSource, TResult>(this Task<TSource> source, Func<TSource, TResult> selector)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (selector == null) throw new ArgumentNullException(nameof(selector));
+
+            return source.ContinueWith(t => selector(t.Result), TaskContinuationOptions.NotOnCanceled);
+        }
+
+        public static Task WhenComplete<TSource>(this Task<TSource> source, Action<TSource, Exception> continuationAction) =>
+            source.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    var exception = t.Exception?.InnerExceptions != null && t.Exception.InnerExceptions.Count == 1
+                        ? t.Exception.InnerExceptions[0]
+                        : t.Exception;
+
+                    continuationAction(default, exception);
+                }
+                else
+                {
+                    continuationAction(t.Result, null);
+                }
+            }, TaskContinuationOptions.NotOnCanceled);
+    }
+}

--- a/src/management/Akka.Http.Shim/Extensions/UriExtensions.cs
+++ b/src/management/Akka.Http.Shim/Extensions/UriExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace System
+{
+    public static class UriExtensions
+    {
+        public static Uri WithPort(this Uri uri, int newPort)
+        {
+            var builder = new UriBuilder(uri) { Port = newPort };
+            return builder.Uri;
+        }
+    }
+}

--- a/src/management/Akka.Http.Shim/Internal/HttpRequestMiddleware.cs
+++ b/src/management/Akka.Http.Shim/Internal/HttpRequestMiddleware.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+using Akka.Http.Dsl.Model;
+using Akka.IO;
+using Microsoft.AspNetCore.Http;
+
+namespace Akka.Http.Internal
+{
+    /// <summary>
+    /// Middleware for transforming AspNetCore requests into Akka-Http requests.
+    /// </summary>
+    public class HttpRequestMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestMiddleware"/> class.
+        /// </summary>
+        /// <param name="next">The next middleware in the processing pipeline.</param>
+        public HttpRequestMiddleware(RequestDelegate next) => _next = next;
+
+        /// <summary>
+        /// The main invocation of the middleware component.
+        /// </summary>
+        /// <param name="context">The <see cref="HttpContext"/> in the pipeline.</param>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var input = new byte[Convert.ToInt32(context.Request.ContentLength)];
+            await context.Request.Body.ReadAsync(input, 0, input.Length);
+            
+            var request = Dsl.Model.HttpRequest.Create(
+                context.Request.Method, 
+                context.Request.Path.Value, 
+                new RequestEntity(context.Request.ContentType, ByteString.FromBytes(input)));
+            
+            // set the feature
+            context.Features.Set(request);
+            await _next(context);
+        }
+    }
+}

--- a/src/management/Akka.Http.Shim/Resources/reference.conf
+++ b/src/management/Akka.Http.Shim/Resources/reference.conf
@@ -1,0 +1,38 @@
+﻿########################################
+# akka-http-core Reference Config File #
+########################################
+
+# This is the reference config file that contains all the default settings.
+# Make your edits/overrides in your application.conf.
+
+akka.http {
+
+  server {
+    # The default value of the `Server` header to produce if no
+    # explicit `Server`-header was included in a response.
+    # If this value is the empty string and no header was included in
+    # the request, no `Server` header will be rendered at all.
+    server-header = akka-http/${akka.http.version}
+ 
+    # Default port to bind HTTP server to when no port was explicitly given.
+    default-http-port = 80
+
+    # Default port to bind HTTPS server to when no port was explicitly given.
+    default-https-port = 443
+
+    # Enables/disables the addition of a remote-address attribute in HttpRequest
+    # holding the clients (remote) IP address. 
+    remote-address-attribute = off
+
+    # When graceful termination is enabled and used invoked with a deadline,
+    # after the deadline passes pending requests will be replied to with a "terminating" http response,
+    # instead of delivering those requests to the user-handler.
+    # This response is configurable here using configuration, or via code in case more a sophisticated (e.g. with response entity)
+    # response is needed.
+    #
+    termination-deadline-exceeded-response {
+      # Status code of the "terminating" response to be automatically sent to pending requests once the termination deadline is exceeded.
+      status = 503 # ServiceUnavailable
+    }
+  }
+}


### PR DESCRIPTION
The biggest, and probably only, obstacle for porting the `Akka Management` (and the other packages that build on top of it) is the absence of the `Akka Http` module in Akka.NET. 

As you know, `Akka Http` leverages StreamIO underneath, but AFAIK you guys are still working on it as part of the `Artery` port. So a few months back I thought of the next best thing that I could come up with: creating a shim of `Akka Http` on top of Kestrel. 

Obviously this will lack backpressure and all, but it'd allow to port pretty much the whole `Akka Http` and have a compatible surface API while keeping the Kestrel part as an implementation detail inside the `Http` extension. This way, it'll be pretty straightforward to swap this shim with a proper implementation of the `Akka Http` in the future.

Currently, it has most of the Core Dsl (so no routes or directives) ported, and already gives the ability to create a very simple web server. The following  sample `Program.cs` should work right off the bat with the code in this branch:

```csharp
internal class Program
{
    private static readonly HttpResponse NotFound = HttpResponse.Create()
        .WithStatus(404)
        .WithEntity("Unknown resource!");
    
    public static void Main(string[] _)
    {
        var system = ActorSystem.Create("HelloAkkaHttpServer");
        
        // sync handler
        static HttpResponse RequestHandler(HttpRequest request) => request.Path switch
        {
            "/" => HttpResponse.Create().WithEntity(ContentTypes.TextHtmlUtf8, "<html><body>Hello world!</body></html>"),
            "/ping" => HttpResponse.Create().WithEntity("PONG!"),
            _ => NotFound
        };            

        var bindingTask = Http.Get(system).NewServerAt("localhost", 8085).BindSync(RequestHandler);
        bindingTask.WhenComplete((binding, exception) =>
        {
            if (binding != null)
            {
                var address = (DnsEndPoint) binding.LocalAddress;
                system.Log.Info("Server online at http://{0}:{1}/",
                    address.Host,
                    address.Port);

                // make sure Akka HTTP is shut down in a proper way
                binding.AddToCoordinatedShutdown(10.Seconds(), system);
            }
            else
            {
                system.Log.Error(exception, "Failed to bind HTTP endpoint, terminating system...");
                system.Terminate();
            }
        });

        Console.ReadLine();
    }
}
```