### PR TITLE
[WIP] Introduce Akka Management module

### DIFF
--- a/src/management/Akka.Management/Akka.Management.csproj
+++ b/src/management/Akka.Management/Akka.Management.csproj
@@ -1,12 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(LibraryFramework)</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <Description>Your description here.</Description>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Cluster" Version="$(AkkaVersion)" />
+    <EmbeddedResource Include="Resources\reference.conf" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka" Version="$(AkkaVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/management/Akka.Management/Akka/Predef.cs
+++ b/src/management/Akka.Management/Akka/Predef.cs
@@ -1,0 +1,10 @@
+﻿namespace Akka
+{
+    public static class Predef
+    {
+        /// <summary>
+        /// Identity function to conform with the JVM API
+        /// </summary>
+        public static T Identity<T>(T x) => x;
+    }
+}

--- a/src/management/Akka.Management/AkkaManagement.cs
+++ b/src/management/Akka.Management/AkkaManagement.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Http.Dsl;
+using Akka.Util;
+using static Akka.Predef;
+
+namespace Akka.Management
+{
+    using Route = Akka.Http.Dsl.Server.Route;
+    
+    public class AkkaManagement : IExtension
+    {
+        private readonly ILoggingAdapter _log;
+        private readonly ExtendedActorSystem _system;
+        private readonly ImmutableList<ManagementRouteProvider> _routeProviders;
+        private readonly AtomicReference<Task<ServerBinding>> _bindingFuture = new AtomicReference<Task<ServerBinding>>();
+
+        public AkkaManagementSettings Settings { get; }
+
+        public AkkaManagement(ExtendedActorSystem system)
+        {
+            _system = system;
+            _log = Logging.GetLogger(system, GetType());
+
+            system.Settings.InjectTopLevelFallback(AkkaManagementProvider.DefaultConfiguration());
+            Settings = new AkkaManagementSettings(system.Settings.Config);
+
+            _routeProviders = LoadRouteProviders().ToImmutableList();
+        }
+
+        public static AkkaManagement Get(ActorSystem system) => system.WithExtension<AkkaManagement, AkkaManagementProvider>();
+
+        /// <summary>
+        /// <para>Get the routes for the HTTP management endpoint.</para>
+        /// <para>This method can be used to embed the Akka management routes in an existing Akka HTTP server.</para>
+        /// </summary>
+        public Route[] Routes() => PrepareCombinedRoutes(ProviderSettings());
+
+        /// <summary>
+        /// <para>Amend the <see cref="ManagementRouteProviderSettings"/> and get the routes for the HTTP management endpoint.</para>
+        /// <para>Use this when adding authentication and HTTPS.</para>
+        /// <para>This method can be used to embed the Akka management routes in an existing Akka HTTP server.</para>
+        /// </summary>
+        public Route[] Routes(Func<ManagementRouteProviderSettings, ManagementRouteProviderSettings> transformSettings) =>
+            PrepareCombinedRoutes(transformSettings(ProviderSettings()));
+
+        /// <summary>
+        /// Start an Akka HTTP server to serve the HTTP management endpoint.
+        /// </summary>
+        public Task Start() => Start(Identity);
+
+        /// <summary>
+        /// <para>Amend the <see cref="ManagementRouteProviderSettings"/> and start an Akka HTTP server to serve the HTTP management endpoint.</para>
+        /// <para>Use this when adding authentication and HTTPS.</para>
+        /// </summary>
+        public async Task<Uri> Start(Func<ManagementRouteProviderSettings, ManagementRouteProviderSettings> transformSettings)
+        {
+            var serverBindingPromise = new TaskCompletionSource<ServerBinding>();
+
+            if (!_bindingFuture.CompareAndSet(null, serverBindingPromise.Task)) 
+                return null;
+            
+            try
+            {
+                var effectiveBindHostname = Settings.Http.EffectiveBindHostname;
+                var effectiveBindPort = Settings.Http.EffectiveBindPort;
+                var effectiveProviderSettings = transformSettings(ProviderSettings());
+
+                _log.Info("Binding Akka Management (HTTP) endpoint to: {0}:{1}", effectiveBindHostname, effectiveBindPort);
+
+                var combinedRoutes = PrepareCombinedRoutes(effectiveProviderSettings);
+                    
+                var serverBinding = await _system.Http().BindAndHandle(
+                    combinedRoutes,
+                    effectiveBindHostname,
+                    effectiveBindPort);
+
+                serverBindingPromise.SetResult(serverBinding);
+
+                var boundPort = ((DnsEndPoint)serverBinding.LocalAddress).Port;
+                _log.Info("Bound Akka Management (HTTP) endpoint to: {0}:{1}", effectiveBindHostname, boundPort);
+
+                return effectiveProviderSettings.SelfBaseUri.WithPort(boundPort);
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex.Message);
+                throw new InvalidOperationException("Failed to start Akka Management HTTP endpoint.", ex);
+            }
+        }
+
+        public Task<Done> Stop()
+        {
+            while (true)
+            {
+                var binding = _bindingFuture.Value;
+                if (binding == null)
+                {
+                    return Task.FromResult(Done.Instance);
+                }
+
+                if (!_bindingFuture.CompareAndSet(binding, null))
+                {
+                    // retry, CAS was not successful, someone else completed the stop()
+                    continue;
+                }
+
+                var stopFuture = binding.Map(_ => _.Unbind()).Map(_ => Done.Instance);
+                return stopFuture;
+            }
+        }
+
+        private ManagementRouteProviderSettings ProviderSettings()
+        {
+            // port is on purpose never inferred from protocol, because this HTTP endpoint is not the "main" one for the app
+            const string protocol = "http"; // changed to "https" if ManagementRouteProviderSettings.withHttpsConnectionContext is use
+
+            var basePath = !string.IsNullOrWhiteSpace(Settings.Http.BasePath) ? Settings.Http.BasePath + "/" : string.Empty;
+            var selfBaseUri = new Uri($"{protocol}://{Settings.Http.Hostname}:{Settings.Http.Port}{basePath}");
+            return ManagementRouteProviderSettings.Create(selfBaseUri, Settings.Http.RouteProvidersReadOnly);
+        }
+
+        private Route[] PrepareCombinedRoutes(ManagementRouteProviderSettings providerSettings)
+        {
+            // TODO
+            static Route[] WrapWithAuthenticatorIfPresent(Route[] inner)
+            {
+                return inner;
+            }
+
+            var combinedRoutes = _routeProviders
+                .Select(provider =>
+                {
+                    _log.Info("Including HTTP management routes for {0}", Logging.SimpleName(provider));
+                    return provider.Routes(providerSettings);
+                })
+                .SelectMany(route => route)
+                .ToArray();
+
+            return combinedRoutes.Length > 0
+                ? WrapWithAuthenticatorIfPresent(combinedRoutes)
+                : throw new ArgumentException("No routes configured for akka management! Double check your `akka.management.http.routes` config.");
+        }
+
+        private IEnumerable<ManagementRouteProvider> LoadRouteProviders()
+        {
+            foreach (var (name, fqcn) in Settings.Http.RouteProviders)
+            {
+                var dynamic = DynamicAccess.CreateInstanceFor<ManagementRouteProvider>(fqcn, null);
+                var instanceTry = dynamic.RecoverWith(ex => ex is TypeLoadException || ex is MissingMethodException
+                    ? DynamicAccess.CreateInstanceFor<ManagementRouteProvider>(fqcn, _system)
+                    : dynamic);
+
+                yield return instanceTry.IsSuccess switch
+                {
+                    true => instanceTry.Get(),
+                    false when instanceTry.Failure.Value is TypeLoadException || instanceTry.Failure.Value is MissingMethodException =>
+                        throw new ArgumentException(nameof(fqcn), $"[{fqcn}] is not a 'ManagementRouteProvider'"),
+                    _ => throw new Exception($"While trying to load route provider extension [{name} = {fqcn}]", instanceTry.Failure.Value)
+                };
+            }
+        }
+    }
+
+    public class AkkaManagementProvider : ExtensionIdProvider<AkkaManagement>
+    {
+        public override AkkaManagement CreateExtension(ExtendedActorSystem system) => new AkkaManagement(system);
+
+        /// <summary>
+        /// Returns a default configuration for the Akka Management module.
+        /// </summary>
+        public static Config DefaultConfiguration() => ConfigurationFactory.FromResource<AkkaManagement>("Akka.Management.Resources.reference.conf");
+    }
+}

--- a/src/management/Akka.Management/AkkaManagementSettings.cs
+++ b/src/management/Akka.Management/AkkaManagementSettings.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
+using Akka.Configuration;
+
+namespace Akka.Management
+{
+    public class AkkaManagementSettings
+    {
+        public AkkaManagementSettings(Config config) => 
+            Http = new Http(config.GetConfig("akka.management"));
+
+        public Http Http { get; }
+    }
+
+    public class Http
+    {
+        public Http(Config managementConfig)
+        {
+            var cc = managementConfig.GetConfig("http");
+
+            var hostname = cc.GetString("hostname");
+            Hostname = hostname == "<hostname>" || string.IsNullOrWhiteSpace(hostname) ? IPAddress.Any.ToString() : hostname;
+
+            Port = cc.GetInt("port");
+            if (Port < 0 || Port > 65535)
+                throw new ArgumentException($"akka.management.http.port must be 0 through 65535 (was {Port})");
+
+            var effectiveBindHostname = cc.GetString("bind-hostname");
+            EffectiveBindHostname = !string.IsNullOrEmpty(effectiveBindHostname) ? effectiveBindHostname : Hostname;
+            
+            EffectiveBindPort = !int.TryParse(cc.GetString("bind-port"), out var effectiveBindPort) ? Port : effectiveBindPort;
+            if (EffectiveBindPort < 0 || EffectiveBindPort > 65535)
+                throw new ArgumentException($"akka.management.http.bind-port must be 0 through 65535 (was {EffectiveBindPort})");
+
+            BasePath = cc.GetString("base-path");
+
+            static bool IsValidFqcn(object value) => value != null && !string.IsNullOrWhiteSpace(value.ToString()) && value.ToString() != "null";
+
+            RouteProviders = cc.GetConfig("routes").AsEnumerable()
+                .Where(pair => IsValidFqcn(pair.Value.GetString()))
+                .Select(pair => new NamedRouteProvider(pair.Key, pair.Value.GetString()))
+                .ToImmutableList();
+
+            RouteProvidersReadOnly = cc.GetBoolean("route-providers-read-only");
+        }
+
+        public string Hostname { get; }
+
+        public int Port { get; }
+
+        public string EffectiveBindHostname { get; }
+
+        public int EffectiveBindPort { get; }
+
+        public string BasePath { get; }
+
+        public ImmutableList<NamedRouteProvider> RouteProviders { get; }
+
+        public bool RouteProvidersReadOnly { get; }
+    }
+
+    public sealed class NamedRouteProvider : IEquatable<NamedRouteProvider>
+    {
+        public string Name { get; }
+        public string FullyQualifiedClassName { get; }
+
+        public NamedRouteProvider(string name, string fullyQualifiedClassName)
+        {
+            Name = name;
+            FullyQualifiedClassName = fullyQualifiedClassName;
+        }
+
+        public void Deconstruct(out string name, out string fullyQualifiedClassName)
+        {
+            name = Name;
+            fullyQualifiedClassName = FullyQualifiedClassName;
+        }
+
+        public bool Equals(NamedRouteProvider other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Name == other.Name && FullyQualifiedClassName == other.FullyQualifiedClassName;
+        }
+
+        public override bool Equals(object obj) => 
+            ReferenceEquals(this, obj) || obj is NamedRouteProvider other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Name != null ? Name.GetHashCode() : 0) * 397) ^ (FullyQualifiedClassName != null ? FullyQualifiedClassName.GetHashCode() : 0);
+            }
+        }
+    }
+}

--- a/src/management/Akka.Management/Class1.cs
+++ b/src/management/Akka.Management/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace Akka.Management
-{
-    public class Class1
-    {
-    }
-}

--- a/src/management/Akka.Management/ManagementRouteProvider.cs
+++ b/src/management/Akka.Management/ManagementRouteProvider.cs
@@ -1,0 +1,16 @@
+﻿using Akka.Actor;
+using Akka.Http.Dsl.Server;
+
+namespace Akka.Management
+{
+    /// <summary>
+    /// Extend this abstract class in your extension in order to allow it to contribute routes to Akka Management starts its HTTP endpoint
+    /// </summary>
+    public abstract class ManagementRouteProvider : IExtension
+    {
+        /// <summary>
+        /// Routes to be exposed by Akka cluster management
+        /// </summary>
+        public abstract Route[] Routes(ManagementRouteProviderSettings settings);
+    }
+}

--- a/src/management/Akka.Management/ManagementRouteProviderSettings.cs
+++ b/src/management/Akka.Management/ManagementRouteProviderSettings.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Akka.Annotations;
+
+namespace Akka.Management
+{
+    /// <summary>
+    /// Settings object used to pass through information about the environment the routes will be running in,
+    /// from the component starting the actual HTTP server, to the <see cref="ManagementRouteProvider"/>.
+    /// 
+    /// Not for user extension.
+    /// </summary>
+    [DoNotInherit]
+    public abstract class ManagementRouteProviderSettings
+    {
+        /// <summary>
+        /// The "self" base Uri which points to the root of the HTTP server running the route provided by the Provider.
+        /// Can be used to introduce some self-awareness and/or links to "self" in the routes created by the Provider.
+        /// </summary>
+        public Uri SelfBaseUri { get; }
+
+        public bool ReadOnly { get; }
+
+        public static ManagementRouteProviderSettings Create(Uri selfBaseUri, bool readOnly) =>
+            new ManagementRouteProviderSettingsImpl(selfBaseUri, readOnly);
+
+        protected ManagementRouteProviderSettings(Uri selfBaseUri, bool readOnly)
+        {
+            SelfBaseUri = selfBaseUri;
+            ReadOnly = readOnly;
+        }
+
+        /// <summary>
+        /// Should only readOnly routes be provided. It is up to each provider to define what readOnly means.
+        /// </summary>
+        public abstract ManagementRouteProviderSettings WithReadOnly(bool readOnly);
+    }
+
+    [InternalApi]
+    public sealed class ManagementRouteProviderSettingsImpl : ManagementRouteProviderSettings
+    {
+        public ManagementRouteProviderSettingsImpl(Uri selfBaseUri, bool readOnly)
+            : base(selfBaseUri, readOnly)
+        { }
+
+        public override ManagementRouteProviderSettings WithReadOnly(bool readOnly) => Copy(readOnly: readOnly);
+
+        private ManagementRouteProviderSettings Copy(Uri selfBaseUri = null, bool? readOnly = null) =>
+            new ManagementRouteProviderSettingsImpl(
+                selfBaseUri: selfBaseUri ?? SelfBaseUri,
+                readOnly: readOnly ?? ReadOnly);
+    }
+}

--- a/src/management/Akka.Management/Resources/reference.conf
+++ b/src/management/Akka.Management/Resources/reference.conf
@@ -1,0 +1,71 @@
+﻿######################################################
+# Akka Http Cluster Management Reference Config File #
+######################################################
+
+# This is the reference config file that contains all the default settings.
+# Make your edits/overrides in your application.conf.
+
+akka.management {
+  http {
+    # The hostname where the HTTP Server for Http Cluster Management will be started.
+    # This defines the interface to use.
+    # InetAddress.getLocalHost.getHostAddress is used not overriden or empty
+    hostname = "<hostname>"
+
+    # The port where the HTTP Server for Http Cluster Management will be bound.
+    # The value will need to be from 0 to 65535.
+    port = 8558 # port pun, it "complements" 2552 which is often used for Akka remoting
+
+    # Use this setting to bind a network interface to a different hostname or ip
+    # than the HTTP Server for Http Cluster Management.
+    # Use "0.0.0.0" to bind to all interfaces.
+    # akka.management.http.hostname if empty
+    bind-hostname = ""
+
+    # Use this setting to bind a network interface to a different port
+    # than the HTTP Server for Http Cluster Management. This may be used
+    # when running akka nodes in a separated networks (under NATs or docker containers).
+    # Use 0 if you want a random available port.
+    #
+    # akka.management.http.port if empty
+    bind-port = ""
+
+    # path prefix for all management routes, usually best to keep the default value here. If
+    # specified, you'll want to use the same value for all nodes that use akka management so
+    # that they can know which path to access each other on.
+    base-path = ""
+
+    # Definition of management route providers which shall contribute routes to the management HTTP endpoint.
+    # Management route providers should be regular extensions that aditionally extend the
+    # `akka.management.scaladsl.ManagementRoutesProvider` or
+    # `akka.management.javadsl.ManagementRoutesProvider` interface.
+    #
+    # Libraries may register routes into the management routes by defining entries to this setting
+    # the library `reference.conf`:
+    #
+    # akka.management.http.routes {
+    #   name = "FQCN"
+    # }
+    #
+    # Where the `name` of the entry should be unique to allow different route providers to be registered
+    # by different libraries and applications.
+    #
+    # The FQCN is the fully qualified class name of the `ManagementRoutesProvider`.
+    #
+    # By default the `akka.management.HealthCheckRoutes` is enabled, see `health-checks` section of how
+    # configure specific readiness and liveness checks.
+    #
+    # Route providers included by a library (from reference.conf) can be excluded by an application
+    # by using "" or null as the FQCN of the named entry, for example:
+    #
+    # akka.management.http.routes {
+    #   health-checks = ""
+    # }
+    routes {
+    }
+
+    # Should Management route providers only expose read only endpoints? It is up to each route provider
+    # to adhere to this property
+    route-providers-read-only = true
+  }
+}


### PR DESCRIPTION
This is most of the core `Akka Manangement` module (healthchecks are missing, though) already ported. I started working on it a few months back but had to put it aside. Since it looks like you guys are starting to work on it I thought you might want to reuse some of this.

Anything related to `Akka Http` (including `routes` and `directives`, as part of the High Dsl) is missing, so it won't compile. Hence PR #7 , which could be an option.