### PR TITLE
Fix erroneous failing probes after cluster formed.

### DIFF
--- a/Akka.Management.sln
+++ b/Akka.Management.sln
@@ -36,6 +36,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Discovery.AwsApi.Integ
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Management.Cluster.Bootstrap.Tests", "src\cluster.bootstrap\Akka.Management.Cluster.Bootstrap.Tests\Akka.Management.Cluster.Bootstrap.Tests.csproj", "{5EEC076D-CD09-4093-B473-7BE8D66D698B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StressTest", "src\cluster.bootstrap\examples\StressTest\StressTest.csproj", "{3ADFF0D4-D17F-4850-B021-0A53B09811C0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{24FEBA95-1FC2-4AC2-8386-6AB13AE87056}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -78,6 +82,10 @@ Global
 		{5EEC076D-CD09-4093-B473-7BE8D66D698B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5EEC076D-CD09-4093-B473-7BE8D66D698B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5EEC076D-CD09-4093-B473-7BE8D66D698B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3ADFF0D4-D17F-4850-B021-0A53B09811C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3ADFF0D4-D17F-4850-B021-0A53B09811C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3ADFF0D4-D17F-4850-B021-0A53B09811C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3ADFF0D4-D17F-4850-B021-0A53B09811C0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -92,6 +100,8 @@ Global
 		{1EE92CD1-D24A-48A7-919E-6BAB3357704B} = {52ACBC5B-D5F0-4FEA-A27B-0A8577204E64}
 		{6D56E8D4-9453-48A6-BF95-FD209FC9E6C6} = {52ACBC5B-D5F0-4FEA-A27B-0A8577204E64}
 		{5EEC076D-CD09-4093-B473-7BE8D66D698B} = {012DD1B7-8531-464D-B3DF-467E3F2AE2CF}
+		{24FEBA95-1FC2-4AC2-8386-6AB13AE87056} = {012DD1B7-8531-464D-B3DF-467E3F2AE2CF}
+		{3ADFF0D4-D17F-4850-B021-0A53B09811C0} = {24FEBA95-1FC2-4AC2-8386-6AB13AE87056}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B99E6BB8-642A-4A68-86DF-69567CBA700A}

--- a/src/cluster.bootstrap/examples/StressTest/MockDiscovery.cs
+++ b/src/cluster.bootstrap/examples/StressTest/MockDiscovery.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Discovery;
+using Akka.Event;
+using Akka.Util;
+
+namespace StressTest
+{
+    public class MockDiscovery : ServiceDiscovery
+    {
+        private static readonly AtomicReference<ImmutableDictionary<Lookup, Func<ActorSystem, Task<Resolved>>>>
+            Data = new AtomicReference<ImmutableDictionary<Lookup, Func<ActorSystem, Task<Resolved>>>>(ImmutableDictionary<Lookup, Func<ActorSystem, Task<Resolved>>>.Empty);
+
+        public static void Set(Lookup name, Func<ActorSystem, Task<Resolved>> to)
+        {
+            while (true)
+            {
+                var d = Data.Value;
+                if (Data.CompareAndSet(d, d.SetItem(name, to)))
+                    break;
+            }
+        }
+
+        public static void Set(Lookup name, Func<Task<Resolved>> to)
+            => Set(name, _ => to());
+
+        public static void Remove(Lookup name)
+        {
+            while (true)
+            {
+                var d = Data.Value;
+                if (Data.CompareAndSet(d, d.Remove(name)))
+                    break;
+            }
+        }
+
+        private readonly ActorSystem _system;
+        private readonly ILoggingAdapter _log;
+
+        public MockDiscovery(ActorSystem system)
+        {
+            _system = system;
+            _log = Logging.GetLogger(system, GetType());
+        }
+
+        public override Task<Resolved> Lookup(Lookup query, TimeSpan resolveTimeout)
+        {
+            if (Data.Value.TryGetValue(query, out var res))
+            {
+                var items = res(_system);
+                _log.Info("Mock-resolved [{0}] to [{1}:{2}]", query, items, items.Result);
+                return items;
+            }
+
+            _log.Info(
+                "No mock-data for [{0}], resolving as 'null'. Current mocks: {1}", 
+                query, 
+                string.Join(", ", Data.Value.Select(kvp => $"{kvp.Key.Protocol} {kvp.Key.ServiceName} {kvp.Key.PortName}"))) ;
+            return Task.FromResult(new Resolved(query.ServiceName, null));
+        }
+    }
+}

--- a/src/cluster.bootstrap/examples/StressTest/Program.cs
+++ b/src/cluster.bootstrap/examples/StressTest/Program.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace StressTest
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            int clusterSize = 30;
+            int scaledDownsize = 5;
+            if (args.Length > 0)
+            {
+                var arg = args[0].ToLowerInvariant();
+                if(arg.Equals("--help") || arg.Equals("-h") || arg.Equals("/h"))
+                {
+                    Usage();
+                    return;
+                }
+                if(!int.TryParse(arg, out clusterSize) || clusterSize < 2)
+                {
+                    Console.WriteLine("First argument must be an integer and greater than 1.");
+                    Usage();
+                    return;
+                }
+            }
+            if(args.Length > 1)
+            {
+                if(!int.TryParse(args[1], out scaledDownsize) || scaledDownsize < 1)
+                {
+                    Console.WriteLine("Second argument must be an integer and greater than 0.");
+                    Usage();
+                    return;
+                }
+                if(scaledDownsize >= clusterSize)
+                {
+                    Console.WriteLine("Second argument must be smaller than the first argument.");
+                    Usage();
+                    return;
+                }
+            } else if(scaledDownsize >= clusterSize)
+            {
+                scaledDownsize = clusterSize - 1;
+            }
+            
+            Console.WriteLine($"Running stress test with initial cluster size {clusterSize} and scaling down to {scaledDownsize}.");
+            var test = new StressTest(clusterSize, scaledDownsize);
+            await test.StartTest();
+        }
+
+        static void Usage()
+        {
+            Console.WriteLine(@"
+StressTest
+
+This simple stress test will attempt to:
+  - Create an Akka.NET cluster of a certain size using Akka.Management.Cluster.Bootstrap to 
+    wire the cluster together, and
+  - Scale down the cluster down in a rapid manner.
+
+Usage: 
+    StressTest.exe [cluster-size] [scaled-down-size]
+
+cluster-size     : Size of the initial cluster the stress test will try to form. Default: 30, minimum of 2
+scaled-down-size : Size of the final cluster to scale down to after initial cluster has formed.
+                   Must be smaller than cluster-size. Default: 5, minimum of 1");
+        }
+    }
+}

--- a/src/cluster.bootstrap/examples/StressTest/SocketUtil.cs
+++ b/src/cluster.bootstrap/examples/StressTest/SocketUtil.cs
@@ -1,0 +1,18 @@
+﻿using System.Net;
+using System.Net.Sockets;
+
+namespace StressTest
+{
+    public static class SocketUtil
+    {
+        public static IPEndPoint TemporaryTcpAddress(string hostName)
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                var endpoint = new IPEndPoint(IPAddress.Parse(hostName), 0);
+                socket.Bind(endpoint);
+                return (IPEndPoint) socket.LocalEndPoint;
+            }
+        }
+    }
+}

--- a/src/cluster.bootstrap/examples/StressTest/StressTest.cs
+++ b/src/cluster.bootstrap/examples/StressTest/StressTest.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster;
+using Akka.Configuration;
+using Akka.Discovery;
+using Akka.Management;
+using Akka.Management.Cluster.Bootstrap;
+using Akka.Util.Internal;
+
+namespace StressTest
+{
+    public class StressTest
+    {
+        private readonly int _clusterSize;
+        private readonly int _scaledSize;
+        
+        private readonly TimeSpan _timeout = TimeSpan.FromSeconds(5);
+        
+        private readonly ImmutableDictionary<string, int> _remotingPorts = ImmutableDictionary<string, int>.Empty;
+        private readonly ImmutableDictionary<string, int> _contactPointPorts = ImmutableDictionary<string, int>.Empty;
+
+        private readonly ImmutableList<string> _ids = ImmutableList<string>.Empty;
+        private readonly ImmutableList<ActorSystem> _systems = ImmutableList<ActorSystem>.Empty;
+        private readonly ImmutableList<ActorSystem> _scaledDownSystems;
+        private readonly ImmutableList<Akka.Cluster.Cluster> _clusters = ImmutableList<Akka.Cluster.Cluster>.Empty;
+        private readonly int _terminatedSystemCount;
+        
+        public StressTest(int clusterSize, int scaledSize)
+        {
+            _clusterSize = clusterSize;
+            _scaledSize = scaledSize;
+            
+            for (var i = 0; i < _clusterSize; i++)
+            {
+                _ids = _ids.Add(Guid.NewGuid().ToString()[..8]);
+            }
+
+            var sysName = "StressTest";
+            var targets = new List<ServiceDiscovery.ResolvedTarget>();
+            foreach (var id in _ids)
+            {
+                _remotingPorts = _remotingPorts.Add(id, SocketUtil.TemporaryTcpAddress("127.0.0.1").Port);
+                _contactPointPorts = _contactPointPorts.Add(id, SocketUtil.TemporaryTcpAddress("127.0.0.1").Port);
+                
+                var system = ActorSystem.Create(sysName, Config(id));
+                _systems = _systems.Add(system);
+
+                var cluster = Akka.Cluster.Cluster.Get(system);
+                _clusters = _clusters.Add(cluster);
+                
+                targets.Add(new ServiceDiscovery.ResolvedTarget(
+                    host: cluster.SelfAddress.Host, 
+                    port: _contactPointPorts[id], 
+                    address: IPAddress.Parse(cluster.SelfAddress.Host)));
+            }
+            
+            // prepare the "mock DNS"
+            var name = "service.svc.cluster.local";
+            MockDiscovery.Set(
+                new Lookup(name, "management-auto", "tcp2"),
+                () => Task.FromResult(new ServiceDiscovery.Resolved(name, targets)));
+            
+            _terminatedSystemCount = _clusterSize - _scaledSize;
+            _scaledDownSystems = _systems.Take(_scaledSize).ToImmutableList();
+        }
+        
+        private Config Config(string id)
+        {
+            var managementPort = _contactPointPorts[id];
+            var remotingPort = _remotingPorts[id];
+            
+            Console.WriteLine($"System [{id}]: management port: {managementPort}");
+            Console.WriteLine($"System [{id}]:   remoting port: {remotingPort}");
+
+            return ConfigurationFactory.ParseString($@"
+                akka {{
+                    loglevel = INFO
+                    # trigger autostart by loading the extension through config
+                    extensions = [""Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management.Cluster.Bootstrap""]
+                    actor.provider = cluster
+
+                    # this can be referred to in tests to use the mock discovery implementation
+                    discovery.mock-dns.class = ""StressTest.MockDiscovery, StressTest""
+                    
+                    remote.dot-netty.tcp.hostname = ""127.0.0.1""
+                    remote.dot-netty.tcp.port = {remotingPort}
+
+                    management {{
+                        http.port = {managementPort}
+                        http.hostname = ""127.0.0.1""
+                        cluster.bootstrap {{
+                            contact-point-discovery {{
+                                discovery-method = mock-dns
+                                service-name = ""service""
+                                port-name = ""management-auto""
+                                protocol = ""tcp2""
+                                service-namespace = ""svc.cluster.local""
+                                stable-margin = 4s
+                            }}
+                        }}
+                    }}
+                }}")
+                .WithFallback(ClusterBootstrap.DefaultConfiguration())
+                .WithFallback(AkkaManagementProvider.DefaultConfiguration());
+        }
+
+        public async Task StartTest()
+        {
+            Console.WriteLine($"======= Start forming cluster with {_clusterSize} member nodes.");
+            JoinDiscoveredDns();
+            Console.WriteLine("======= Cluster successfully created.");
+            Console.WriteLine("======= Waiting for 1 minute to see if any unwanted behaviour occurs.");
+            await Task.Delay(TimeSpan.FromMinutes(1));
+            
+            Console.WriteLine($"======= Scaling down cluster to {_scaledSize} member nodes.");
+            ScaleDown();
+            Console.WriteLine($"======= Cluster scaled down to {_scaledSize} successfully.");
+            Console.WriteLine("======= Waiting for 1 minute to see if any unwanted behaviour occurs.");
+            await Task.Delay(TimeSpan.FromMinutes(1));
+
+            Console.WriteLine("======= Shutting down all nodes.");
+            Terminate();
+            Console.WriteLine("======= All nodes shuts down successfully.");
+        }
+        
+        // join three DNS discovered nodes by forming new cluster (happy path)
+        private void JoinDiscoveredDns()
+        {
+            // All nodes should join
+            var cluster = _clusters[0];
+            
+            var complete = AwaitCondition(() =>
+                cluster.State.Members.Count == _clusterSize &&
+                    cluster.State.Members.Count(m => m.Status == MemberStatus.Up) == _clusterSize, 
+                _timeout * _clusterSize);
+
+            if(!complete)
+            {
+                var count = cluster.State.Members.Count;
+                var upCount = cluster.State.Members.Count(m => m.Status == MemberStatus.Up);
+                throw new Exception(
+                    $"Cluster failed to form after {_timeout * _clusterSize}. " +
+                    $"Cluster members: [{count}/{_clusterSize}]. " +
+                    $"Cluster up members: [{upCount}/{_clusterSize}]");
+            }
+        }
+        
+        private void ScaleDown()
+        {
+            var counter = new AtomicCounter(0);
+            
+            _systems
+                .Where(system => !_scaledDownSystems.Contains(system))
+                .ForEach(system =>
+                {
+                    CoordinatedShutdown.Get(system).Run(CoordinatedShutdown.ClrExitReason.Instance)
+                        .ContinueWith(_ =>
+                        {
+                            counter.GetAndIncrement();
+                        });
+                });
+            
+            var complete = AwaitCondition(() => counter.Current == _terminatedSystemCount, _timeout * _terminatedSystemCount);
+            if (!complete)
+                throw new Exception($"Cluster failed to scale down from {_clusterSize} to {_scaledSize} nodes " +
+                                    $"within {_timeout * _terminatedSystemCount}");
+        }
+
+        private void Terminate()
+        {
+            var counter = new AtomicCounter(0);
+            _scaledDownSystems
+                .ForEach(system => 
+                    CoordinatedShutdown.Get(system).Run(CoordinatedShutdown.ClrExitReason.Instance)
+                        .ContinueWith(_ => counter.GetAndIncrement()));
+
+            var complete = AwaitCondition(() => counter.Current == _scaledSize, _timeout * _scaledSize);
+            if (!complete)
+                throw new Exception($"Cluster did not shut down gracefully within {_timeout * _scaledSize}");
+        }
+
+        private bool AwaitCondition(Func<bool> condition, TimeSpan timeout)
+        {
+            var deadline = timeout.TotalMilliseconds;
+            var complete = false;
+            var watch = Stopwatch.StartNew();
+            while (!complete && watch.ElapsedMilliseconds < deadline)
+            {
+                complete = condition();
+                Thread.Sleep(100);
+            }
+            watch.Stop();
+            return complete;
+        }
+    }
+}

--- a/src/cluster.bootstrap/examples/StressTest/StressTest.csproj
+++ b/src/cluster.bootstrap/examples/StressTest/StressTest.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Akka.Management.Cluster.Bootstrap\Akka.Management.Cluster.Bootstrap.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes:
- Stop all timers when cluster bootstrap coordinator and probe actors are stopped.
- Ignore all probe reports after probe are stopped.
- Add spec to check that cluster bootstrap coordinator are stopped after cluster have formed.
- Add a simple stress test console program to test rapid cluster forming and scale down.

Initial observation:
- There is a limit on how many nodes can be forced to spin up in rapid succession. 
  - A 60 node cluster is still achieveable with some remoting heartbeat failures.
  - A 75 node cluster fails to form because of networking congestion causing a lot of association errors.
- A cluster with nodes larger than 20 that are scaled down rapidly might spam a lot of `AssociationError` and `InvalidAssociationException` warnings after it is scaled down, even when the cluster is scaled using graceful shutdown.
- Numbers may vary from one computer to another, tested using a Ryzen 9 3900X machine with 32 GB of memory.
- This will not represent behaviour in real world production environment since all of the actor systems are spun inside a single machine and process.