### PR TITLE
Make Akka.Discovery.KubernetesApi Lookup method more robust

### DIFF
--- a/Akka.Management.sln
+++ b/Akka.Management.sln
@@ -56,6 +56,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Coordination.Kubernete
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Coordination.KubernetesApi.Tests", "src\coordination\kubernetes\Akka.Coordination.KubernetesApi.Tests\Akka.Coordination.KubernetesApi.Tests.csproj", "{BB9C1954-1CA5-430C-9942-601C0E625A81}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KubernetesCluster", "src\cluster.bootstrap\examples\discovery\kubernetes\src\KubernetesCluster\KubernetesCluster.csproj", "{27535BEC-07B4-47F0-80BA-B6AFC467F9E9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,6 +120,10 @@ Global
 		{BB9C1954-1CA5-430C-9942-601C0E625A81}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BB9C1954-1CA5-430C-9942-601C0E625A81}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BB9C1954-1CA5-430C-9942-601C0E625A81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27535BEC-07B4-47F0-80BA-B6AFC467F9E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27535BEC-07B4-47F0-80BA-B6AFC467F9E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27535BEC-07B4-47F0-80BA-B6AFC467F9E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27535BEC-07B4-47F0-80BA-B6AFC467F9E9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -141,6 +147,7 @@ Global
 		{6F76292F-324B-4636-BA8A-D4C39E62FCDC} = {FE96A0E5-1216-40CE-9CC8-5C491A5E6267}
 		{AC4B13D0-2CE7-4E91-9EE2-640F33AAD068} = {6F76292F-324B-4636-BA8A-D4C39E62FCDC}
 		{BB9C1954-1CA5-430C-9942-601C0E625A81} = {6F76292F-324B-4636-BA8A-D4C39E62FCDC}
+		{27535BEC-07B4-47F0-80BA-B6AFC467F9E9} = {24FEBA95-1FC2-4AC2-8386-6AB13AE87056}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B99E6BB8-642A-4A68-86DF-69567CBA700A}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -40,6 +40,7 @@ Update all AWSSDK versions</PackageReleaseNotes>
     <AkkaVersion>1.4.27</AkkaVersion>
     <AkkaDiscoveryVersion>1.4.25-beta</AkkaDiscoveryVersion>
     <KubernetesClientVersion>4.0.26</KubernetesClientVersion>
+    <PbmVersion>1.0.1</PbmVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/docker/docker-compose.yaml
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/docker/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: '3'
+
+services:
+  node1:
+    image: kubernetescluster:latest
+    networks:
+      cluster_net:
+        ipv4_address: 192.168.10.1
+    ports:
+      - "8558:8558"
+    environment:
+      ACTORSYSTEM: "ClusterSystem"
+      CLUSTER_PORT: 4053
+      CLUSTER_IP: "192.168.10.1"
+      AKKA__REMOTE__DOT_NETTY__TCP__HOSTNAME: "192.168.10.1"
+      AKKA__MANAGEMENT__HTTP__HOSTNAME: "192.168.10.1"
+
+  node2:
+    image: kubernetescluster:latest
+    networks:
+      cluster_net:
+        ipv4_address: 192.168.10.2
+    environment:
+      ACTORSYSTEM: "ClusterSystem"
+      CLUSTER_PORT: 4053
+      CLUSTER_IP: "192.168.10.2"
+      AKKA__REMOTE__DOT_NETTY__TCP__HOSTNAME: "192.168.10.2"
+      AKKA__MANAGEMENT__HTTP__HOSTNAME: "192.168.10.2"
+
+  node3:
+    image: kubernetescluster:latest
+    networks:
+      cluster_net:
+        ipv4_address: 192.168.10.3
+    environment:
+      ACTORSYSTEM: "ClusterSystem"
+      CLUSTER_PORT: 4053
+      CLUSTER_IP: "192.168.10.3"
+      AKKA__REMOTE__DOT_NETTY__TCP__HOSTNAME: "192.168.10.3"
+      AKKA__MANAGEMENT__HTTP__HOSTNAME: "192.168.10.3"
+
+networks:
+  cluster_net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.10.0/24
+          gateway: 192.168.10.100

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/k8s/clusterbootstrap.yaml
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/k8s/clusterbootstrap.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusterbootstrap
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clusterbootstrap
+  namespace: clusterbootstrap
+  labels:
+    app: clusterbootstrap
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusterbootstrap
+  namespace: clusterbootstrap
+  labels:
+    app: clusterbootstrap
+spec:
+  clusterIP: None
+  ports:
+  - port: 4053
+    name: akka-remote
+  - port: 8558 
+    name: management
+  selector:
+    app: clusterbootstrap
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  namespace: clusterbootstrap
+  name: clusterbootstrap
+  labels:
+    app: clusterbootstrap
+spec:
+  serviceName: clusterbootstrap
+  replicas: 10
+  selector:
+    matchLabels:
+      app: clusterbootstrap
+  template:
+    metadata:
+      labels:
+        app: clusterbootstrap
+    spec:
+      terminationGracePeriodSeconds: 35
+      dnsConfig:
+        options:
+        - name: use-vc
+      containers:
+      - name: clusterbootstrap
+        image: kubernetescluster:0.2.3
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "pbm 127.0.0.1:9110 cluster leave"]
+        env:
+        - name: ACTORSYSTEM
+          value: ClusterSys
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: CLUSTER_IP
+          value: "$(POD_NAME).clusterbootstrap"
+        livenessProbe:
+          tcpSocket:
+            port: 4053
+        ports:
+        - containerPort: 8558 
+        - containerPort: 4053
+          protocol: TCP

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/k8s/deploy.cmd
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/k8s/deploy.cmd
@@ -1,0 +1,3 @@
+set LOCAL=%~dp0
+kubectl apply -f "%~dp0/clusterbootstrap.yaml"
+kubectl get all -n clusterbootstrap

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/k8s/destroy.cmd
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/k8s/destroy.cmd
@@ -1,0 +1,1 @@
+kubectl delete ns clusterbootstrap

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/k8s/events.cmd
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/k8s/events.cmd
@@ -1,0 +1,1 @@
+kubectl get event -n clusterbootstrap

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/k8s/status.cmd
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/k8s/status.cmd
@@ -1,0 +1,1 @@
+kubectl get all -n clusterbootstrap

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/AkkaService.cs
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/AkkaService.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Bootstrap.Docker;
+using Akka.Cluster.Tools.PublishSubscribe;
+using Akka.Configuration;
+using Akka.DependencyInjection;
+using Akka.Event;
+using Akka.Management;
+using Akka.Management.Cluster.Bootstrap;
+using Akka.Util;
+using Akka.Util.Internal;
+using Microsoft.Extensions.Hosting;
+using Petabridge.Cmd.Cluster;
+using Petabridge.Cmd.Host;
+using Petabridge.Cmd.Remote;
+
+namespace KubernetesCluster
+{
+    public sealed class ChaosActor : ReceiveActor
+    {
+        public ChaosActor()
+        {
+            Receive<int>(i =>
+            {
+                switch (i)
+                {
+                    case 1: // graceful shutdown
+                        Context.System.Terminate();
+                        return;
+                    case 2: // crash
+                        Context.System.AsInstanceOf<ExtendedActorSystem>().Abort();
+                        return;
+                    default:
+                    {
+                        // do nothing
+                        break;
+                    }
+                }
+            });
+        }
+    }
+    
+    public class Subscriber : ReceiveActor
+    {
+        private readonly ILoggingAdapter log = Context.GetLogger();
+
+        public Subscriber()
+        {
+            var mediator = DistributedPubSub.Get(Context.System).Mediator;
+
+            // subscribe to the topic named "content"
+            mediator.Tell(new Subscribe("content", Self));
+
+            Receive<int>(s =>
+            {
+                log.Info($"Got {s}");
+                if (s % 2 == 0)
+                {
+                    mediator.Tell(new Publish("content", ThreadLocalRandom.Current.Next(0,10)));
+                }
+            });
+
+            Receive<SubscribeAck>(subscribeAck =>
+            {
+                if (subscribeAck.Subscribe.Topic.Equals("content")
+                    && subscribeAck.Subscribe.Ref.Equals(Self)
+                    && subscribeAck.Subscribe.Group == null)
+                {
+                    log.Info("subscribing");
+                }
+            });
+        }
+    }
+    
+    public class AkkaService: IHostedService
+    {
+        private ActorSystem _system;
+        public Task TerminationHandle => _system.WhenTerminated;
+        private readonly IServiceProvider _serviceProvider;
+
+        // needed to help guarantee clean shutdowns
+        private readonly IHostApplicationLifetime _lifetime;
+
+        public IActorRef ClusterListener {get; private set;}
+
+        public AkkaService(IServiceProvider serviceProvider, IHostApplicationLifetime lifetime)
+        {
+            _serviceProvider = serviceProvider;
+            _lifetime = lifetime;
+        }
+        
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            var config = ConfigurationFactory.ParseString(File.ReadAllText("app.conf"))
+                .BootstrapFromDocker();
+                
+            var bootstrap = BootstrapSetup.Create()
+                .WithConfig(config) // load HOCON
+                .WithActorRefProvider(ProviderSelection.Cluster.Instance); // launch Akka.Cluster
+
+            // enable DI support inside this ActorSystem, if needed
+            var diSetup = DependencyResolverSetup.Create(_serviceProvider);
+
+            // merge this setup (and any others) together into ActorSystemSetup
+            var actorSystemSetup = bootstrap.And(diSetup);
+            var systemName = Environment.GetEnvironmentVariable("ACTORSYSTEM")?.Trim();
+
+            _system = ActorSystem.Create(systemName, actorSystemSetup);
+
+            var chaos = _system.ActorOf(Props.Create<ChaosActor>(), "chaos");
+            var subscriber = _system.ActorOf(Props.Create(() => new Subscriber()), "subscriber");
+
+            // start https://cmd.petabridge.com/ for diagnostics and profit
+            var pbm = PetabridgeCmd.Get(_system); // start Pbm
+            pbm.RegisterCommandPalette(ClusterCommands.Instance);
+            pbm.RegisterCommandPalette(new RemoteCommands());
+            pbm.Start(); // begin listening for PBM management commands
+            
+            ClusterListener = _system.ActorOf(KubernetesCluster.ClusterListener.Props(), "listener");
+
+            
+            _system.WhenTerminated.ContinueWith(tr =>
+            {
+                _lifetime.StopApplication(); // when the ActorSystem terminates, terminate the process
+            });
+
+            var mediator = DistributedPubSub.Get(_system).Mediator;
+            
+            _system.Scheduler.Advanced.ScheduleRepeatedly(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), () =>
+            {
+               // mediator.Tell(new Publish("content", ThreadLocalRandom.Current.Next(0,10)));
+                chaos.Tell(ThreadLocalRandom.Current.Next(0,100));
+            });
+
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            await CoordinatedShutdown.Get(_system).Run(CoordinatedShutdown.ClrExitReason.Instance);
+        }
+    }
+}

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/ClusterListener.cs
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/ClusterListener.cs
@@ -1,0 +1,55 @@
+﻿using Akka.Actor;
+using Akka.Cluster;
+using Akka.Event;
+
+namespace KubernetesCluster
+{
+    public class ClusterListener : ReceiveActor
+    {
+        public static Props Props() => Akka.Actor.Props.Create(() => new ClusterListener());
+
+        public ClusterListener()
+        {
+             var log = Context.GetLogger();
+
+            var cluster = Akka.Cluster.Cluster.Get(Context.System);
+            cluster.Subscribe(
+                Self, 
+                ClusterEvent.SubscriptionInitialStateMode.InitialStateAsEvents, 
+                typeof(ClusterEvent.MemberStatusChange),
+                typeof(ClusterEvent.ReachabilityEvent));
+
+            Receive<ClusterEvent.ReachabilityEvent>(message =>
+            {
+                switch (message)
+                {
+                    case ClusterEvent.UnreachableMember msg:
+                        log.Info($"Member detected as unreachable: {msg.Member}");
+                        break;
+                    case ClusterEvent.ReachableMember msg:
+                        log.Info($"Member is now reachable: {msg.Member}");
+                        break;
+                    default:
+                        Unhandled(message);
+                        break;
+                }
+            });
+
+            Receive<ClusterEvent.MemberStatusChange>(message =>
+            {
+                switch (message)
+                {
+                    case ClusterEvent.MemberUp msg:
+                        log.Info($"Member is now Up: {msg.Member.Address}");
+                        break;
+                    case ClusterEvent.MemberRemoved msg:
+                        log.Info($"Member is removed: {msg.Member.Address} after {msg.PreviousStatus}");
+                        break;
+                    default:
+                        Unhandled(message);
+                        break;
+                }
+            });
+        }
+    }
+}

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/Dockerfile
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/Dockerfile
@@ -1,0 +1,36 @@
+﻿FROM mcr.microsoft.com/dotnet/sdk:3.1 AS base
+WORKDIR /app
+
+# should be a comma-delimited list
+ENV CLUSTER_SEEDS "[]"
+ENV CLUSTER_IP ""
+ENV CLUSTER_PORT "4053"
+
+# 9110 - Petabridge.Cmd
+# 4055 - Akka.Remote
+# 8558 - Akka.Management
+EXPOSE 9110 4053 8558
+
+# Install Petabridge.Cmd client so it can be invoked remotely via
+# Docker or K8s 'exec` commands
+RUN dotnet tool install --global pbm 
+
+# RUN pbm help
+
+COPY ./bin/Release/netcoreapp3.1/publish/ /app
+
+FROM mcr.microsoft.com/dotnet/runtime:3.1 AS app
+WORKDIR /app
+
+COPY --from=base /app /app
+
+# copy .NET Core global tool
+COPY --from=base /root/.dotnet /root/.dotnet/
+
+# Needed because https://stackoverflow.com/questions/51977474/install-dotnet-core-tool-dockerfile
+ENV PATH="${PATH}:/root/.dotnet/tools"
+
+# Add DNS utils
+RUN apt update && apt install dnsutils -y
+
+ENTRYPOINT ["dotnet", "KubernetesCluster.dll"]

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/KubernetesCluster.csproj
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/KubernetesCluster.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="app.conf">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Akka.Cluster.Tools" Version="$(AkkaVersion)" />
+        <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
+        <PackageReference Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
+        <PackageReference Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
+        <PackageReference Include="Akka.Bootstrap.Docker" Version="0.5.3" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.17" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.17" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.17" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.17" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\..\..\..\discovery\kubernetes\Akka.Discovery.KubernetesApi\Akka.Discovery.KubernetesApi.csproj" />
+      <ProjectReference Include="..\..\..\..\..\Akka.Management.Cluster.Bootstrap\Akka.Management.Cluster.Bootstrap.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/Program.cs
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/Program.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace KubernetesCluster
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var host = new HostBuilder()
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddLogging();
+                    services.AddHostedService<AkkaService>(); // runs Akka.NET
+ 
+                })
+                .ConfigureLogging((hostContext, configLogging) =>
+                {
+                    configLogging.AddConsole();
+ 
+                })
+                .UseConsoleLifetime()
+                .Build();
+
+            await host.RunAsync();
+        }
+    }
+}

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/README.md
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/README.md
@@ -1,0 +1,19 @@
+# Akka.ClusterBootstrap
+This project is meant to serve as a demonstration of how Akka.Management.Cluster.Bootstrap bootstraps a 3 node cluster from a list of resolved IP addresses provided by a discovery service.
+
+## Running ClusterBootstrap
+This benchmark is run using Docker and `docker-compose`.
+
+First, build all of the benchmark images by running the following command at the root of the repository directory:
+
+```
+PS> ./build.cmd docker
+```
+
+In the [`/src/ClusterBootstrap/docker`](docker/) folder you can deploy the sample by running the following command:
+
+```
+PS> docker-compose up
+```
+
+This will launch a size 3-node cluster.

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/app.conf
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/app.conf
@@ -1,0 +1,88 @@
+# See petabridge.cmd configuration options here: https://cmd.petabridge.com/articles/install/host-configuration.html
+petabridge.cmd{
+	# default IP address used to listen for incoming petabridge.cmd client connections
+	# should be a safe default as it listens on "all network interfaces".
+	host = "0.0.0.0"
+
+	# default port number used to listen for incoming petabridge.cmd client connections
+	port = 9110
+}
+
+akka {
+    loglevel = INFO
+    # trigger autostart by loading the extension through config
+    extensions = ["Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management.Cluster.Bootstrap"]
+
+    actor.provider = cluster
+  
+    remote {
+        dot-netty.tcp {
+            transport-class = "Akka.Remote.Transport.DotNetty.TcpTransport, Akka.Remote"
+            applied-adapters = []
+            transport-protocol = tcp
+            hostname = "" # Overriden by docker bootstrap
+            port = 4053
+        }
+    }            
+
+    cluster {
+        roles = [cluster]
+        
+      downing-provider-class = "Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster"
+      split-brain-resolver {
+        active-strategy = keep-majority
+      }
+    }
+    
+    management {
+        http.port = 8558
+        http.hostname = ""
+        cluster.bootstrap {
+            contact-point-discovery {
+                discovery-method = akka.discovery
+                service-name = clusterbootstrap
+                port-name = management
+                required-contact-point-nr = 2
+                stable-margin = 5s
+                contact-with-all-contact-points = true
+            }
+        }
+    }
+    
+    discovery {
+        method = kubernetes-api
+        
+        kubernetes-api {
+            class = "Akka.Discovery.KubernetesApi.KubernetesApiServiceDiscovery, Akka.Discovery.KubernetesApi"
+
+            # API server, cert and token information. Currently these are present on K8s versions: 1.6, 1.7, 1.8, and perhaps more
+            api-ca-path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            api-token-path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+            api-service-host-env-name = "KUBERNETES_SERVICE_HOST"
+            api-service-port-env-name = "KUBERNETES_SERVICE_PORT"
+
+            # Namespace discovery path
+            #
+            # If this path doesn't exist, the namespace will default to "default".
+            pod-namespace-path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+            # Namespace to query for pods.
+            #
+            # Set this value to a specific string to override discovering the namespace using pod-namespace-path.
+            pod-namespace = "<pod-namespace>"
+
+            # Domain of the k8s cluster
+            pod-domain = "cluster.local"
+
+            # Selector value to query pod API with.
+            # `{0}` will be replaced with the configured effective name, which defaults to the actor system name
+            pod-label-selector = "app={0}"
+
+            # Enables the usage of the raw IP instead of the composed value for the resolved target host
+            use-raw-ip = false
+
+            # When set, validate the container is not in 'waiting' state
+            container-name = ""
+        }
+    }
+}


### PR DESCRIPTION
- Cache k8s client instead of re-instantiating it on every Lookup call
- Catch exceptions and transforms them into sensible warning logs and exception messages