### PR TITLE
fix NET Core App 3.1 HTTP error

### DIFF
--- a/src/cluster.bootstrap/Akka.Management.Cluster.Bootstrap.Tests/ContactPoint/HttpContactPointRoutesSpec.cs
+++ b/src/cluster.bootstrap/Akka.Management.Cluster.Bootstrap.Tests/ContactPoint/HttpContactPointRoutesSpec.cs
@@ -49,7 +49,7 @@ namespace Akka.Management.Cluster.Bootstrap.Tests.ContactPoint
             context.Request.Method = HttpMethods.Get;
             context.Request.Path = ClusterBootstrapRequests.BootstrapSeedNodes("").ToString();
             
-            var requestContext = new RequestContext(HttpRequest.Create(context.Request), Sys);
+            var requestContext = new RequestContext(await HttpRequest.CreateAsync(context.Request), Sys);
             var response = (RouteResult.Complete) await _httpBootstrap.Routes.Concat()(requestContext);
             response.Response.Entity.DataBytes.ToString().Should().Contain("\"Nodes\":[]");
         }
@@ -75,7 +75,7 @@ namespace Akka.Management.Cluster.Bootstrap.Tests.ContactPoint
             context.Request.Method = HttpMethods.Get;
             context.Request.Path = ClusterBootstrapRequests.BootstrapSeedNodes("");
             
-            var requestContext = new RequestContext(HttpRequest.Create(context.Request), Sys);
+            var requestContext = new RequestContext(await HttpRequest.CreateAsync(context.Request), Sys);
             var response = (RouteResult.Complete) await _httpBootstrap.Routes.Concat()(requestContext);
 
             var responseString = response.Response.Entity.DataBytes.ToString();

--- a/src/management/Akka.Http.Shim/AkkaRoutingMiddleware.cs
+++ b/src/management/Akka.Http.Shim/AkkaRoutingMiddleware.cs
@@ -47,7 +47,7 @@ namespace Akka.Http
                 throw new ArgumentNullException(nameof(context));
             }
             
-            var requestContext = new RequestContext(Dsl.Model.HttpRequest.Create(context.Request), _system);
+            var requestContext = new RequestContext(await Dsl.Model.HttpRequest.CreateAsync(context.Request), _system);
                         
             var response = await _routes(requestContext);
             switch (response)

--- a/src/management/Akka.Management.Tests/HealthCheckRoutesSpec.cs
+++ b/src/management/Akka.Management.Tests/HealthCheckRoutesSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Management.Tests
         public async Task HealthCheckReadyReturn200ForRight()
         {
             var result = (RouteResult.Complete)
-                await TestRoutes().Concat()(Get("/ready"));
+                await TestRoutes().Concat()(await Get("/ready"));
             result.Response.Status.Should().Be((int) HttpStatusCode.OK);
         }
         
@@ -47,7 +47,7 @@ namespace Akka.Management.Tests
         {
             var result = (RouteResult.Complete)
                 await TestRoutes(
-                    readyResultValue: Task.FromResult((Either<string, Done>)new Left<string, Done>("com.someclass.MyCheck"))).Concat()(Get("/ready"));
+                    readyResultValue: Task.FromResult((Either<string, Done>)new Left<string, Done>("com.someclass.MyCheck"))).Concat()(await Get("/ready"));
             result.Response.Status.Should().Be((int) HttpStatusCode.InternalServerError);
             result.Response.Entity.DataBytes.ToString().Should().Be("Not Healthy: com.someclass.MyCheck");
         }
@@ -57,7 +57,7 @@ namespace Akka.Management.Tests
         {
             var result = (RouteResult.Complete)
                 await TestRoutes(
-                    readyResultValue: Task.FromException<Either<string, Done>>(new Exception("darn it"))).Concat()(Get("/ready"));
+                    readyResultValue: Task.FromException<Either<string, Done>>(new Exception("darn it"))).Concat()(await Get("/ready"));
             result.Response.Status.Should().Be((int) HttpStatusCode.InternalServerError);
             result.Response.Entity.DataBytes.ToString().Should().Be("Health Check Failed: darn it");
         }
@@ -66,7 +66,7 @@ namespace Akka.Management.Tests
         public async Task HealthCheckAliveReturn200ForRight()
         {
             var result = (RouteResult.Complete)
-                await TestRoutes().Concat()(Get("/alive"));
+                await TestRoutes().Concat()(await Get("/alive"));
             result.Response.Status.Should().Be((int) HttpStatusCode.OK);
         }
         
@@ -76,7 +76,7 @@ namespace Akka.Management.Tests
             var result = (RouteResult.Complete)
                 await TestRoutes(
                     aliveResultValue: Task.FromResult(
-                        (Either<string, Done>) new Left<string, Done>("com.someclass.MyCheck"))).Concat()(Get("/alive"));
+                        (Either<string, Done>) new Left<string, Done>("com.someclass.MyCheck"))).Concat()(await Get("/alive"));
             result.Response.Status.Should().Be((int) HttpStatusCode.InternalServerError);
             result.Response.Entity.DataBytes.ToString().Should().Be("Not Healthy: com.someclass.MyCheck");
         }
@@ -86,12 +86,12 @@ namespace Akka.Management.Tests
         {
             var result = (RouteResult.Complete)
                 await TestRoutes(aliveResultValue: Task.FromException<Either<string, Done>>(new Exception("darn it"))).Concat()
-                    (Get("/alive"));
+                    (await Get("/alive"));
             result.Response.Status.Should().Be((int) HttpStatusCode.InternalServerError);
             result.Response.Entity.DataBytes.ToString().Should().Be("Health Check Failed: darn it");
         }
 
-        private RequestContext Get(string route)
+        private async Task<RequestContext> Get(string route)
         {
             var context = new DefaultHttpContext();
             context.Request.Method = HttpMethods.Get;
@@ -99,7 +99,7 @@ namespace Akka.Management.Tests
             context.Request.Body = new MemoryStream();
             context.Request.Protocol = "HTTP/1.1";
 
-            var request = HttpRequest.Create(context.Request);
+            var request = await HttpRequest.CreateAsync(context.Request);
             
             return new RequestContext(request, Sys);
         }


### PR DESCRIPTION
close #562

## Changes

Rewrote the `HttpRequest` API to no longer call / block on `async` methods in the constructor - instead the static `Create` method has been renamed to `CreateAsync` and it `await`s the underlying ASP.NET API properly.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #562
