### PR TITLE
Fixes for Discovery.Azure

### DIFF
--- a/src/discovery/azure/Akka.Discovery.Azure/AzureServiceDiscovery.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureServiceDiscovery.cs
@@ -59,12 +59,20 @@ namespace Akka.Discovery.Azure
         {
             if(_log.IsDebugEnabled)
                 _log.Debug("Starting lookup for service {0}", lookup.ServiceName);
-            
-            var members = await _guardianActor.Ask<ImmutableList<ClusterMember>>(lookup, resolveTimeout);
 
-            return new Resolved(
-                lookup.ServiceName,
-                members.Select(m => new ResolvedTarget(m.Host, m.Port, m.Address)).ToImmutableList());
+            try
+            {
+                var members = await _guardianActor.Ask<ImmutableList<ClusterMember>>(lookup, resolveTimeout);
+
+                return new Resolved(
+                    lookup.ServiceName,
+                    members.Select(m => new ResolvedTarget(m.Host, m.Port, m.Address)).ToImmutableList());
+            }
+            catch (Exception e)
+            {
+                _log.Warning(e, "Failed to perform contact point lookup");
+                return new Resolved(lookup.ServiceName);
+            }
         }
     }
 }

--- a/src/discovery/azure/Akka.Discovery.Azure/ClusterMemberTableClient.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/ClusterMemberTableClient.cs
@@ -96,7 +96,7 @@ namespace Akka.Discovery.Azure
                 return null;
 
             var query = _client
-                .QueryAsync<TableEntity>($"PartitionKey eq '{_serviceName}' and {ClusterMember.LastUpdateName} ge {lastUpdate}")
+                .QueryAsync<TableEntity>($"PartitionKey eq '{_serviceName}' and {ClusterMember.LastUpdateName} ge {lastUpdate}L")
                 .WithCancellation(token);
 
             var list = ImmutableList.CreateBuilder<ClusterMember>();
@@ -148,7 +148,7 @@ namespace Akka.Discovery.Azure
                 return false;
 
             var query = _client
-                .QueryAsync<TableEntity>($"PartitionKey eq '{_serviceName}' and {ClusterMember.LastUpdateName} lt {lastUpdate}")
+                .QueryAsync<TableEntity>($"PartitionKey eq '{_serviceName}' and {ClusterMember.LastUpdateName} lt {lastUpdate}L")
                 .WithCancellation(token);
 
             var batch = new List<TableTransactionAction>();


### PR DESCRIPTION
## Changes
- Update the OData query, missing "L" qualifier to mark that the numbers are to be read as an Int64, Azure would default to reading any numbers as an Int32 and throws an overflow parse error.
- Fix discovery `Lookup` method, it should not throw when the `Ask` operation timed out.