### PR TITLE
[Discovery.Azure] Cleanup self member entry during ActorSystem shutdown

### DIFF
--- a/src/discovery/azure/Akka.Discovery.Azure/ClusterMemberTableClient.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/ClusterMemberTableClient.cs
@@ -189,6 +189,11 @@ namespace Akka.Discovery.Azure
             return !errored;
         }
 
+        public async Task RemoveSelf(CancellationToken token = default)
+        {
+            await _client.DeleteEntityAsync(_entity.PartitionKey, _entity.RowKey, ETag.All, token);
+        }
+
         #region Helper methods
 
         /// <summary>


### PR DESCRIPTION
Add cleanup code during system shutdown, this lessen the amount of junk accumulating inside the Azure ClusterMember table, making cluster restart and scaling faster.