### PR TITLE
[K8S LEASE] Fix settings and settings spec, add Setup support

### DIFF
--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/KubernetesSettingsSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/KubernetesSettingsSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using Akka.Configuration;
 using FluentAssertions;
+using Humanizer;
 using Xunit;
 
 #nullable enable
@@ -15,32 +16,38 @@ namespace Akka.Coordination.KubernetesApi.Tests
 {
     public class KubernetesSettingsSpec
     {
-        private KubernetesSettings Conf(string overrides)
+        private static KubernetesSettings Conf(string? overrides)
         {
-            var config = ConfigurationFactory.ParseString(overrides)
-                .WithFallback(KubernetesLease.DefaultConfiguration)
-                .WithFallback(LeaseProvider.DefaultConfig());
-            return KubernetesSettings.Create(config, TimeoutSettings.Create(config.GetConfig("akka.coordination.lease")));
+            var config = !string.IsNullOrEmpty(overrides) 
+                ? ConfigurationFactory.ParseString(overrides)
+                    .WithFallback(KubernetesLease.DefaultConfiguration)
+                    .WithFallback(LeaseProvider.DefaultConfig())
+                : KubernetesLease.DefaultConfiguration
+                    .WithFallback(LeaseProvider.DefaultConfig());
+            return KubernetesSettings.Create(config.GetConfig(KubernetesLease.ConfigPath), TimeoutSettings.Create(config.GetConfig("akka.coordination.lease")));
         }
         
         [Fact(DisplayName = "default request-timeout should be 2/5 of the lease-operation-timeout")]
         public void RequestTimeoutIsTwoFifthOfLeaseOperationTimeout()
         {
-            Conf("lease-operation-timeout=5s").ApiServiceRequestTimeout.Should().Be(TimeSpan.FromSeconds(2));
+            Conf("akka.coordination.lease.lease-operation-timeout=10s")
+                .ApiServiceRequestTimeout.Should().Be(TimeSpan.FromSeconds(4));
         }
 
         [Fact(DisplayName = "default body-read timeout should be 1/2 of api request timeout")]
         public void BodyReadTimeoutIsHalfOfApiRequestTimeout()
         {
-            Conf("lease-operation-timeout=5s").BodyReadTimeout.Should().Be(TimeSpan.FromSeconds(1));
+            Conf("akka.coordination.lease.lease-operation-timeout=10s")
+                .BodyReadTimeout.Should().Be(TimeSpan.FromSeconds(2));
         }
 
         [Fact(DisplayName = "Kubernetes settings should allow api server request timeout override")]
         public void ShouldAllowServerRequestTimeoutOverride()
         {
             Conf(@"
-            lease-operation-timeout=5s
-            api-service-request-timeout=4s").ApiServiceRequestTimeout.Should().Be(TimeSpan.FromSeconds(4));
+            akka.coordination.lease.lease-operation-timeout=5s
+            akka.coordination.lease.kubernetes.api-service-request-timeout=4s").ApiServiceRequestTimeout
+                .Should().Be(TimeSpan.FromSeconds(4));
         }
 
         [Fact(DisplayName =
@@ -50,10 +57,93 @@ namespace Akka.Coordination.KubernetesApi.Tests
             Assert.Throws<ConfigurationException>(() =>
             {
                 Conf(@"
-                    lease-operation-timeout=5s
-                    api-service-request-timeout=6s");
+                    akka.coordination.lease.lease-operation-timeout=5s
+                    akka.coordination.lease.kubernetes.api-service-request-timeout=6s");
             }).Message.Should().Be("'api-service-request-timeout can not be less than 'lease-operation-timeout'");
+        }
 
+        [Fact(DisplayName = "KubernetesSettings should contain default values")]
+        public void DefaultKubernetesSettingsTest()
+        {
+            var settings = Conf(null);
+            settings.ApiCaPath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt");
+            settings.ApiTokenPath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/token");
+            settings.ApiServiceHostEnvName.Should().Be("KUBERNETES_SERVICE_HOST");
+            settings.ApiServicePortEnvName.Should().Be("KUBERNETES_SERVICE_PORT");
+            settings.Namespace.Should().BeNull(); 
+            settings.NamespacePath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); 
+            settings.ApiServiceRequestTimeout.Should().Be(2.Seconds());
+            settings.Secure.Should().BeTrue(); 
+            settings.BodyReadTimeout.Should().Be(1.Seconds()); 
+        }
+
+        [Fact(DisplayName = "Empty KubernetesSettings should contain default values")]
+        public void EmptyKubernetesSettingsTest()
+        {
+            var settings = Conf(null);
+            var empty = KubernetesSettings.Empty;
+            empty.ApiCaPath.Should().Be(settings.ApiCaPath);
+            empty.ApiTokenPath.Should().Be(settings.ApiTokenPath);
+            empty.ApiServiceHostEnvName.Should().Be(settings.ApiServiceHostEnvName);
+            empty.ApiServicePortEnvName.Should().Be(settings.ApiServicePortEnvName);
+            empty.Namespace.Should().Be(settings.Namespace);
+            empty.NamespacePath.Should().Be(settings.NamespacePath); 
+            empty.ApiServiceRequestTimeout.Should().Be(settings.ApiServiceRequestTimeout);
+            empty.Secure.Should().Be(settings.Secure); 
+            empty.BodyReadTimeout.Should().Be(settings.BodyReadTimeout); 
+        }
+
+        [Fact(DisplayName = "KubernetesSettings overrides should work")]
+        public void KubernetesSettingsOverrideTest()
+        {
+            var settings = KubernetesSettings.Empty
+                .WithApiCaPath("a")
+                .WithApiTokenPath("b")
+                .WithApiServiceHostEnvName("c")
+                .WithApiServicePortEnvName("d")
+                .WithNamespace("e")
+                .WithNamespacePath("f")
+                .WithApiServiceRequestTimeout(11.Seconds())
+                .WithSecure(false)
+                .WithBodyReadTimeout(12.Seconds());
+            
+            settings.ApiCaPath.Should().Be("a");
+            settings.ApiTokenPath.Should().Be("b");
+            settings.ApiServiceHostEnvName.Should().Be("c");
+            settings.ApiServicePortEnvName.Should().Be("d");
+            settings.Namespace.Should().Be("e"); 
+            settings.NamespacePath.Should().Be("f"); 
+            settings.ApiServiceRequestTimeout.Should().Be(11.Seconds());
+            settings.Secure.Should().BeFalse(); 
+            settings.BodyReadTimeout.Should().Be(12.Seconds()); 
+        }
+        
+        [Fact(DisplayName = "KubernetesLeaseSetup overrides should work")]
+        public void KubernetesLeaseSetupOverrideTest()
+        {
+            var setup = new KubernetesLeaseSetup
+            {
+                ApiCaPath = "a",
+                ApiTokenPath = "b",
+                ApiServiceHostEnvName = "c",
+                ApiServicePortEnvName = "d",
+                Namespace = "e",
+                NamespacePath = "f",
+                ApiServiceRequestTimeout = 11.Seconds(),
+                Secure = false,
+                BodyReadTimeout = 12.Seconds()
+            };
+            
+            var settings = setup.Apply(KubernetesSettings.Empty);
+            settings.ApiCaPath.Should().Be("a");
+            settings.ApiTokenPath.Should().Be("b");
+            settings.ApiServiceHostEnvName.Should().Be("c");
+            settings.ApiServicePortEnvName.Should().Be("d");
+            settings.Namespace.Should().Be("e"); 
+            settings.NamespacePath.Should().Be("f"); 
+            settings.ApiServiceRequestTimeout.Should().Be(11.Seconds());
+            settings.Secure.Should().BeFalse(); 
+            settings.BodyReadTimeout.Should().Be(12.Seconds()); 
         }
     }
 }

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLease.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLease.cs
@@ -58,6 +58,11 @@ namespace Akka.Coordination.KubernetesApi
             
             _log = Logging.GetLogger(system, GetType());
             var kubernetesSettings = KubernetesSettings.Create(system, settings.TimeoutSettings);
+
+            var setup = system.Settings.Setup.Get<KubernetesLeaseSetup>();
+            if (setup.HasValue)
+                kubernetesSettings = setup.Value.Apply(kubernetesSettings);
+            
             var client = new KubernetesApiImpl(system, kubernetesSettings);
             _timeout = _settings.TimeoutSettings.OperationTimeout;
             _leaseName = MakeDns1039Compatible(settings.LeaseName);

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLeaseSetup.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLeaseSetup.cs
@@ -1,0 +1,49 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="KubernetesLeaseSetup.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Actor.Setup;
+
+namespace Akka.Coordination.KubernetesApi
+{
+    public class KubernetesLeaseSetup: Setup
+    {
+        public string ApiCaPath { get; set; }
+        public string ApiTokenPath { get; set; }
+        public string ApiServiceHostEnvName { get; set; }
+        public string ApiServicePortEnvName { get; set; }
+        public string Namespace { get; set; }
+        public string NamespacePath { get; set; }
+        public TimeSpan? ApiServiceRequestTimeout { get; set; }
+        public bool? Secure { get; set; }
+        public TimeSpan? BodyReadTimeout { get; set; }
+
+        internal KubernetesSettings Apply(KubernetesSettings settings)
+        {
+            if (ApiCaPath != null)
+                settings = settings.WithApiCaPath(ApiCaPath);
+            if (ApiTokenPath != null)
+                settings = settings.WithApiTokenPath(ApiTokenPath);
+            if (ApiServiceHostEnvName != null)
+                settings = settings.WithApiServiceHostEnvName(ApiServiceHostEnvName);
+            if (ApiServicePortEnvName != null)
+                settings = settings.WithApiServicePortEnvName(ApiServicePortEnvName);
+            if (Namespace != null)
+                settings = settings.WithNamespace(Namespace);
+            if (NamespacePath != null)
+                settings = settings.WithNamespacePath(NamespacePath);
+            if (ApiServiceRequestTimeout != null)
+                settings = settings.WithApiServiceRequestTimeout(ApiServiceRequestTimeout.Value);
+            if (Secure != null)
+                settings = settings.WithSecure(Secure.Value);
+            if (BodyReadTimeout != null)
+                settings = settings.WithBodyReadTimeout(BodyReadTimeout.Value);
+            return settings;
+        }
+        
+    }
+}

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesSettings.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesSettings.cs
@@ -14,6 +14,17 @@ namespace Akka.Coordination.KubernetesApi
 {
     public class KubernetesSettings
     {
+        public static readonly KubernetesSettings Empty = new KubernetesSettings(
+            apiCaPath: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+            apiTokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+            apiServiceHostEnvName: "KUBERNETES_SERVICE_HOST",
+            apiServicePortEnvName: "KUBERNETES_SERVICE_PORT",
+            ns: null,
+            namespacePath: "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+            apiServiceRequestTimeout: TimeSpan.FromSeconds(2),
+            secure: true,
+            bodyReadTimeout: TimeSpan.FromSeconds(1)); 
+        
         public KubernetesSettings(
             string apiCaPath,
             string apiTokenPath,
@@ -76,5 +87,44 @@ namespace Akka.Coordination.KubernetesApi
         public bool Secure { get; }
         public TimeSpan BodyReadTimeout { get; }
  
+        public KubernetesSettings WithApiCaPath(string apiCaPath)
+            => Copy(apiCaPath: apiCaPath);
+        public KubernetesSettings WithApiTokenPath(string apiTokenPath)
+            => Copy(apiTokenPath: apiTokenPath);
+        public KubernetesSettings WithApiServiceHostEnvName(string apiServiceHostEnvName)
+            => Copy(apiServiceHostEnvName: apiServiceHostEnvName);
+        public KubernetesSettings WithApiServicePortEnvName(string apiServicePortEnvName)
+            => Copy(apiServicePortEnvName: apiServicePortEnvName);
+        public KubernetesSettings WithNamespace(string ns)
+            => Copy(ns: ns);
+        public KubernetesSettings WithNamespacePath(string namespacePath)
+            => Copy(namespacePath: namespacePath);
+        public KubernetesSettings WithApiServiceRequestTimeout(TimeSpan apiServiceRequestTimeout)
+            => Copy(apiServiceRequestTimeout: apiServiceRequestTimeout);
+        public KubernetesSettings WithSecure(bool secure)
+            => Copy(secure: secure);
+        public KubernetesSettings WithBodyReadTimeout(TimeSpan bodyReadTimeout)
+            => Copy(bodyReadTimeout: bodyReadTimeout);
+        
+        private KubernetesSettings Copy(
+            string? apiCaPath = null,
+            string? apiTokenPath = null,
+            string? apiServiceHostEnvName = null,
+            string? apiServicePortEnvName = null,
+            string? ns = null,
+            string? namespacePath = null,
+            TimeSpan? apiServiceRequestTimeout = null,
+            bool? secure = null,
+            TimeSpan? bodyReadTimeout = null)
+            => new KubernetesSettings(
+                apiCaPath: apiCaPath ?? ApiCaPath,
+                apiTokenPath: apiTokenPath ?? ApiTokenPath,
+                apiServiceHostEnvName: apiServiceHostEnvName ?? ApiServiceHostEnvName,
+                apiServicePortEnvName: apiServicePortEnvName ?? ApiServicePortEnvName,
+                ns: ns ?? Namespace,
+                namespacePath: namespacePath ?? NamespacePath,
+                apiServiceRequestTimeout: apiServiceRequestTimeout ?? ApiServiceRequestTimeout,
+                secure: secure ?? Secure,
+                bodyReadTimeout: bodyReadTimeout ?? BodyReadTimeout);
     }
 }

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/reference.conf
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/reference.conf
@@ -39,5 +39,7 @@ akka.coordination.lease.kubernetes {
     # The amount of time to wait for a lease to be aquired or released. This includes all requests to the API
     # server that are required. If this timeout is hit then the lease *may* be taken due to the response being lost
     # on the way back from the API server but will be reported as not taken and can be safely retried.
-    lease-operation-timeout = 5s
+    
+    # CURRENTLY BEING IGNORED. Use 'akka.coordination.lease.lease-operation-timeout' instead.
+    # lease-operation-timeout = 5s
 }


### PR DESCRIPTION
- Fix KubernetesSettings, `lease-operation-timeout` was not being used in code and the spec was not testing it correctly.
- Add Setup support for Akka.Hosting integration