### PR TITLE
Harden Management and ClusterBootstrap interaction

### DIFF
--- a/src/cluster.bootstrap/Akka.Management.Cluster.Bootstrap.Tests/HostingSpecs.cs
+++ b/src/cluster.bootstrap/Akka.Management.Cluster.Bootstrap.Tests/HostingSpecs.cs
@@ -89,17 +89,11 @@ namespace Akka.Management.Cluster.Bootstrap.Tests
             {
                 builder =>
                 {
-                    // need to cheat a little because the default is 2, which would never work
-                    builder.AddHocon(
-                        "akka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr = 1");
-                    builder.WithClusterBootstrap("testService", autoStart: true);
+                    builder.WithClusterBootstrap("testService", requiredContactPoints: 1, autoStart: true);
                 },
                 builder =>
                 {
-                    // need to cheat a little because the default is 2, which would never work
-                    builder.AddHocon(
-                        "akka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr = 1");
-                    builder.WithClusterBootstrap("testService", autoStart: false);
+                    builder.WithClusterBootstrap("testService", requiredContactPoints: 1, autoStart: false);
                     builder.AddStartup(async (system, registry) =>
                     {
                         await AkkaManagement.Get(system).Start();
@@ -127,6 +121,32 @@ namespace Akka.Management.Cluster.Bootstrap.Tests
                         await AkkaManagement.Get(system).Start();
                         await ClusterBootstrap.Get(system).Start();
                     });
+                },
+                
+                // Should start normally when both Akka.Management and ClusterBootstrap is auto-started
+                builder =>
+                {
+                    builder.WithExtensions(typeof(AkkaManagementProvider));
+                    builder.WithClusterBootstrap("testService", requiredContactPoints: 1, autoStart: true);
+                },
+                builder =>
+                {
+                    builder.WithExtensions(
+                        typeof(AkkaManagementProvider),
+                        typeof(ClusterBootstrapProvider));
+                    builder.WithClusterBootstrap("testService", requiredContactPoints: 1, autoStart: false);
+                },
+                builder =>
+                {
+                    builder.WithClusterBootstrap("testService", requiredContactPoints: 1, autoStart: true);
+                    builder.WithExtensions(typeof(AkkaManagementProvider));
+                },
+                builder =>
+                {
+                    builder.WithClusterBootstrap("testService", requiredContactPoints: 1, autoStart: false);
+                    builder.WithExtensions(
+                        typeof(AkkaManagementProvider),
+                        typeof(ClusterBootstrapProvider));
                 },
             };
             

--- a/src/cluster.bootstrap/Akka.Management.Cluster.Bootstrap/AkkaHostingExtensions.cs
+++ b/src/cluster.bootstrap/Akka.Management.Cluster.Bootstrap/AkkaHostingExtensions.cs
@@ -5,9 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Linq;
 using Akka.Actor;
-using Akka.Configuration;
 using Akka.Hosting;
 
 namespace Akka.Management.Cluster.Bootstrap
@@ -54,6 +52,7 @@ namespace Akka.Management.Cluster.Bootstrap
             string serviceName = null,
             string serviceNamespace = null,
             string portName = null,
+            int? requiredContactPoints = null,
             bool? newClusterEnabled = null,
             bool autoStart = true)
             => builder.WithClusterBootstrap(new ClusterBootstrapSetup
@@ -63,7 +62,8 @@ namespace Akka.Management.Cluster.Bootstrap
                 {
                     ServiceName = serviceName,
                     ServiceNamespace = serviceNamespace,
-                    PortName = portName
+                    PortName = portName,
+                    RequiredContactPointsNr = requiredContactPoints
                 }
             }, autoStart);
         
@@ -123,29 +123,14 @@ namespace Akka.Management.Cluster.Bootstrap
             if (autoStart)
             {
                 // Inject ClusterBootstrapProvider into akka.extensions
-                if (builder.Configuration.IsEmpty)
-                {
-                    var config = (Config)$"akka.extensions=[\"{typeof(ClusterBootstrapProvider).AssemblyQualifiedName}\"]";
-                    builder.AddHocon(config, HoconAddMode.Prepend);
-                }
-                else
-                {
-                    var extensions = builder.Configuration.Value.GetStringList("akka.extensions").ToList();
-                    if (extensions.All(s => !s.Contains(nameof(ClusterBootstrapProvider))))
-                    {
-                        extensions.Add(typeof(ClusterBootstrapProvider).AssemblyQualifiedName);
-                        var config = (Config)$"akka.extensions=[{string.Join(",", extensions.Select(s => $"\"{s}\""))}]";
-                        builder.AddHocon(config, HoconAddMode.Prepend);
-                    }
-                }
-            }
-            else
-            {
-                builder.AddHocon(
-                    "akka.management.http.routes.cluster-bootstrap = \"Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management.Cluster.Bootstrap\"", 
-                    HoconAddMode.Prepend);
+                builder.WithExtensions(typeof(ClusterBootstrapProvider));
             }
         
+            // Cluster bootstrap routes needs to be added for it to work with Akka.Management
+            builder.AddHocon(
+                $"akka.management.http.routes.cluster-bootstrap = \"{typeof(ClusterBootstrapProvider).AssemblyQualifiedName}\"", 
+                HoconAddMode.Prepend);
+            
             builder.AddSetup(setup);
             return builder;
         }

--- a/src/cluster.bootstrap/Akka.Management.Cluster.Bootstrap/ClusterBootstrap.cs
+++ b/src/cluster.bootstrap/Akka.Management.Cluster.Bootstrap/ClusterBootstrap.cs
@@ -103,7 +103,7 @@ namespace Akka.Management.Cluster.Bootstrap
             _joinDecider = (IJoinDecider)Activator.CreateInstance(joinDeciderType, system, Settings);
             
             var autoStart = system.Settings.Config.GetStringList("akka.extensions")
-                .Any(s => s.Contains(typeof(ClusterBootstrap).Name));
+                .Any(s => s.Contains(typeof(ClusterBootstrapProvider).Name));
             if (autoStart)
             {
                 _log.Info("ClusterBootstrap loaded through 'akka.extensions' auto starting bootstrap.");

--- a/src/management/Akka.Management/AkkaHostingExtensions.cs
+++ b/src/management/Akka.Management/AkkaHostingExtensions.cs
@@ -116,10 +116,7 @@ namespace Akka.Management
             builder.AddSetup(setup);
             if (autoStart)
             {
-                builder.AddStartup(async (system, _) =>
-                {
-                    await AkkaManagement.Get(system).Start();
-                });
+                builder.WithExtensions(typeof(AkkaManagementProvider));
             }
 
             return builder;


### PR DESCRIPTION
## Changes
* AkkaManagement.Start() should be idempotent, it should start only once and returns the same Task on multiple invocation
* AkkaManagement should start automatically when added in `akka.extensions`, this behaviour should be consistent with other modules in Akka ecosystem
* AkkaManagement and ClusterBootstrap should co-exist when both are auto-started from Akka.Hosting in any combination

## Still a problem
* Without Akka.Hosting, ClusterBootstrap HTTP routes would not be registered if AkkaManagement starts *before* ClusterBootstrap starts, because ClusterBootstrap injects its routes manually when it starts. User would need to remember to add `.WithFallback(ClusterBootstrap.DefaultConfiguration())` to their HOCON configuration for this to work.