### PR TITLE
Fix racy timeout tests

### DIFF
--- a/src/cluster.bootstrap/Akka.Management.Cluster.Bootstrap.Tests/ContactPoint/ClusterBootstrapAutostartIntegrationSpec.cs
+++ b/src/cluster.bootstrap/Akka.Management.Cluster.Bootstrap.Tests/ContactPoint/ClusterBootstrapAutostartIntegrationSpec.cs
@@ -181,7 +181,7 @@ namespace Akka.Management.Cluster.Bootstrap.Tests.ContactPoint
             {
                 cluster.State.Members.Count.Should().Be(ClusterSize);
                 cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(ClusterSize);
-            }, RemainingOrDefault * ClusterSize);
+            }, RemainingOrDefault * ClusterSize * 2);
             
             // cluster bootstrap coordinator should stop after joining
             foreach (var tuple in probeList)


### PR DESCRIPTION
## Changes
- bumped the timeout value for ClusterBootstrapAutostartIntegrationSpec, timed out while it is still forming the cluster
- use `AwaitAssertAsync` around HTTP probing to make sure that the problem was not caused by Ceen slow socket setup