### PR TITLE
[Discovery.AwsApi] Add Akka.Hosting extension methods

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -18,9 +18,9 @@ jobs:
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true
       - task: UseDotNet@2
-        displayName: 'Use .NET 5 SDK 5.0'
+        displayName: 'Use .NET 6 SDK 6.0'
         inputs:
-          version: 5.0.x
+          version: 6.0.x
       - task: UseDotNet@2
         displayName: 'Use .NET Core SDK 3.1'
         inputs:

--- a/build.fsx
+++ b/build.fsx
@@ -49,7 +49,7 @@ let outputNuGet = output @@ "nuget"
 // Configuration values for tests
 let testNetFrameworkVersion = "net471"
 let testNetCoreVersion = "netcoreapp3.1"
-let testNetVersion = "net5.0"
+let testNetVersion = "net6.0"
 
 Target "Clean" (fun _ ->
     ActivateFinalTarget "KillCreatedProcesses"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,9 +29,9 @@ Update all AWSSDK versions</PackageReleaseNotes>
   <PropertyGroup>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency;service discovery;cluster;clustering;</AkkaPackageTags>
     <LibraryFramework>netstandard2.0</LibraryFramework>
-    <NetFramework>net5.0</NetFramework>
+    <NetFramework>net6.0</NetFramework>
     <TestsNetCoreFramework>netcoreapp3.1</TestsNetCoreFramework>
-    <TestsNet>net5.0</TestsNet>
+    <TestsNet>net6.0</TestsNet>
     <XunitVersion>2.4.2</XunitVersion>
     <XUnitRunnerVersion>2.4.3</XUnitRunnerVersion>
     <CoverletVersion>3.1.2</CoverletVersion>

--- a/src/discovery/aws/Akka.Discovery.AwsApi/Akka.Discovery.AwsApi.csproj
+++ b/src/discovery/aws/Akka.Discovery.AwsApi/Akka.Discovery.AwsApi.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="Akka.Discovery" Version="$(AkkaVersion)" />
+      <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
       <PackageReference Include="AWSSDK.EC2" Version="3.7.83.5" />
       <PackageReference Include="AWSSDK.ECS" Version="3.7.5.71" />
     </ItemGroup>

--- a/src/discovery/aws/Akka.Discovery.AwsApi/Ec2/AkkaHostingExtensions.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi/Ec2/AkkaHostingExtensions.cs
@@ -1,0 +1,131 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="AkkaHostingExtensions.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Hosting;
+
+namespace Akka.Discovery.AwsApi.Ec2
+{
+    public static class AkkaHostingExtensions
+    {
+        /// <summary>
+        ///     Adds Akka.Discovery.AwsApi.Ec2 support to the <see cref="ActorSystem"/>.
+        ///     Note that this only adds the discovery plugin, you will still need to add ClusterBootstrap for
+        ///     a complete solution.
+        /// </summary>
+        /// <param name="builder">
+        ///     The builder instance being configured.
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        /// <example>
+        ///   <code>
+        ///     services.AddAkka("mySystem", builder => {
+        ///         builder
+        ///             .WithClustering()
+        ///             .WithClusterBootstrap(setup =>
+        ///             {
+        ///                 setup.ContactPointDiscovery.ServiceName = "testService";
+        ///                 setup.ContactPointDiscovery.RequiredContactPointsNr = 1;
+        ///             }, autoStart: true)
+        ///             .WithAwsEc2Discovery();
+        ///     }
+        ///   </code>
+        /// </example>
+        public static AkkaConfigurationBuilder WithAwsEc2Discovery(this AkkaConfigurationBuilder builder)
+            => builder.WithAwsEc2Discovery(new Ec2ServiceDiscoverySetup());
+
+        /// <summary>
+        ///     Adds Akka.Discovery.AwsApi.Ec2 support to the <see cref="ActorSystem"/>.
+        ///     Note that this only adds the discovery plugin, you will still need to add ClusterBootstrap for
+        ///     a complete solution.
+        /// </summary>
+        /// <param name="builder">
+        ///     The builder instance being configured.
+        /// </param>
+        /// <param name="configure">
+        ///     An action that modifies an <see cref="Ec2ServiceDiscoverySetup"/> instance, used
+        ///     to configure Akka.Discovery.AwsApi.Ec2.
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        /// <example>
+        ///   <code>
+        ///     services.AddAkka("mySystem", builder => {
+        ///         builder
+        ///             .WithClustering()
+        ///             .WithClusterBootstrap(setup =>
+        ///             {
+        ///                 setup.ContactPointDiscovery.ServiceName = "testService";
+        ///                 setup.ContactPointDiscovery.RequiredContactPointsNr = 1;
+        ///             }, autoStart: true)
+        ///             .WithAwsEc2Discovery(setup => {
+        ///                 setup.WithCredentialProvider&lt;AnonymousEc2CredentialProvider&gt;();
+        ///                 setup.TagKey = "myTag";
+        ///             });
+        ///     }
+        ///   </code>
+        /// </example>
+        public static AkkaConfigurationBuilder WithAwsEc2Discovery(
+            this AkkaConfigurationBuilder builder,
+            Action<Ec2ServiceDiscoverySetup> configure)
+        {
+            var setup = new Ec2ServiceDiscoverySetup();
+            configure(setup);
+            return builder.WithAwsEc2Discovery(setup);
+        }
+
+        /// <summary>
+        ///     Adds Akka.Discovery.AwsApi.Ec2 support to the <see cref="ActorSystem"/>.
+        ///     Note that this only adds the discovery plugin, you will still need to add ClusterBootstrap for
+        ///     a complete solution.
+        /// </summary>
+        /// <param name="builder">
+        ///     The builder instance being configured.
+        /// </param>
+        /// <param name="setup">
+        ///     The <see cref="Ec2ServiceDiscoverySetup"/> instance used to configure Akka.Discovery.Azure.
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        /// <example>
+        ///   <code>
+        ///     services.AddAkka("mySystem", builder => {
+        ///         builder
+        ///             .WithClustering()
+        ///             .WithClusterBootstrap(setup =>
+        ///             {
+        ///                 setup.ContactPointDiscovery.ServiceName = "testService";
+        ///                 setup.ContactPointDiscovery.RequiredContactPointsNr = 1;
+        ///             }, autoStart: true)
+        ///             .WithAwsEc2Discovery(setup => {
+        ///                 setup.WithCredentialProvider&lt;AnonymousEc2CredentialProvider&gt;();
+        ///                 setup.TagKey = "myTag";
+        ///             });
+        ///     }
+        ///   </code>
+        /// </example>
+        public static AkkaConfigurationBuilder WithAwsEc2Discovery(
+            this AkkaConfigurationBuilder builder,
+            Ec2ServiceDiscoverySetup setup)
+        {
+            builder.AddHocon("akka.discovery.method = aws-api-ec2-tag-based", HoconAddMode.Prepend);
+            builder.AddSetup(setup);
+            
+            // force start the module
+            builder.AddStartup((system, registry) =>
+            {
+                AwsEc2Discovery.Get(system);
+            });
+            return builder;
+        }
+    }
+}

--- a/src/discovery/aws/Akka.Discovery.AwsApi/Ec2/Ec2ServiceDiscoverySetup.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi/Ec2/Ec2ServiceDiscoverySetup.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Akka.Actor.Setup;
+using Akka.Configuration;
 using Amazon.EC2;
 using Amazon.EC2.Model;
 
@@ -17,10 +18,30 @@ namespace Akka.Discovery.AwsApi.Ec2
     public sealed class Ec2ServiceDiscoverySetup : Setup
     {
         private Type _clientConfig;
-        public Type ClientConfig => _clientConfig;
+
+        public Type ClientConfig
+        {
+            get => _clientConfig;
+            set
+            {
+                if (value != null && !typeof(AmazonEC2Config).IsAssignableFrom(value))
+                    throw new ConfigurationException($"{nameof(ClientConfig)} Type value need to extend {nameof(AmazonEC2Config)}. Was: {value.Name}");
+                _clientConfig = value;
+            }
+        } 
 
         private Type _credProvider;
-        public Type CredentialsProvider => _credProvider;
+        public Type CredentialsProvider
+        {
+            get => _credProvider;
+            set
+            {
+                if (value != null && !typeof(Ec2CredentialProvider).IsAssignableFrom(value))
+                    throw new ConfigurationException($"{nameof(CredentialsProvider)} Type value need to extend {nameof(Ec2CredentialProvider)}. Was: {value.Name}");
+                _credProvider = value;
+            }
+        } 
+
         public string TagKey { get; set; }
         public List<Filter> Filters { get; set; }
         public List<int> Ports { get; set; }
@@ -29,13 +50,13 @@ namespace Akka.Discovery.AwsApi.Ec2
 
         public Ec2ServiceDiscoverySetup WithClientConfig<T>() where T: AmazonEC2Config
         {
-            _clientConfig = typeof(T);
+            ClientConfig = typeof(T);
             return this;
         }
 
         public Ec2ServiceDiscoverySetup WithCredentialProvider<T>() where T : Ec2CredentialProvider
         {
-            _credProvider = typeof(T);
+            CredentialsProvider = typeof(T);
             return this;
         }
         

--- a/src/discovery/aws/Akka.Discovery.AwsApi/Ecs/AkkaHostingExtensions.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi/Ecs/AkkaHostingExtensions.cs
@@ -1,0 +1,153 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="AkkaHostingExtensions.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Hosting;
+using Amazon.ECS.Model;
+
+namespace Akka.Discovery.AwsApi.Ecs
+{
+    public static class AkkaHostingExtensions
+    {
+        /// <summary>
+        ///     Adds Akka.Discovery.AwsApi.Ecs support to the <see cref="ActorSystem"/>.
+        ///     Note that this only adds the discovery plugin, you will still need to add ClusterBootstrap for
+        ///     a complete solution.
+        /// </summary>
+        /// <param name="builder">
+        ///     The builder instance being configured.
+        /// </param>
+        /// <param name="clusterName">
+        ///     <para>
+        ///         Optional. The name of the AWS ECS cluster.
+        ///     </para>
+        ///     <b>Default</b>: "default"
+        /// </param>
+        /// <param name="tags">
+        ///     <para>
+        ///     Optional. A list of <see cref="Tag"/> used to filter the ECS cluster tasks.
+        ///     The task must have the same exact list of tags to be considered as potential contact point by the
+        ///     discovery module.
+        ///     </para>
+        ///     <b>Default</b>: empty list.
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        /// <example>
+        ///   <code>
+        ///     services.AddAkka("mySystem", builder => {
+        ///         builder
+        ///             .WithClustering()
+        ///             .WithClusterBootstrap(setup =>
+        ///             {
+        ///                 setup.ContactPointDiscovery.ServiceName = "testService";
+        ///                 setup.ContactPointDiscovery.RequiredContactPointsNr = 1;
+        ///             }, autoStart: true)
+        ///             .WithAwsEcsDiscovery();
+        ///     }
+        ///   </code>
+        /// </example>
+        public static AkkaConfigurationBuilder WithAwsEcsDiscovery(
+            this AkkaConfigurationBuilder builder,
+            string clusterName = null,
+            IEnumerable<Tag> tags = null)
+            => builder.WithAwsEcsDiscovery(new EcsServiceDiscoverySetup
+            {
+                Cluster = clusterName,
+                Tags = tags
+            });
+
+        /// <summary>
+        ///     Adds Akka.Discovery.AwsApi.Ec2 support to the <see cref="ActorSystem"/>.
+        ///     Note that this only adds the discovery plugin, you will still need to add ClusterBootstrap for
+        ///     a complete solution.
+        /// </summary>
+        /// <param name="builder">
+        ///     The builder instance being configured.
+        /// </param>
+        /// <param name="configure">
+        ///     An action that modifies an <see cref="EcsServiceDiscoverySetup"/> instance, used
+        ///     to configure Akka.Discovery.AwsApi.Ec2.
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        /// <example>
+        ///   <code>
+        ///     services.AddAkka("mySystem", builder => {
+        ///         builder
+        ///             .WithClustering()
+        ///             .WithClusterBootstrap(setup =>
+        ///             {
+        ///                 setup.ContactPointDiscovery.ServiceName = "testService";
+        ///                 setup.ContactPointDiscovery.RequiredContactPointsNr = 1;
+        ///             }, autoStart: true)
+        ///             .WithAwsEcsDiscovery(setup => {
+        ///                 setup.Cluster = "my-ecs-cluster-name";
+        ///             });
+        ///     }
+        ///   </code>
+        /// </example>
+        public static AkkaConfigurationBuilder WithAwsEcsDiscovery(
+            this AkkaConfigurationBuilder builder,
+            Action<EcsServiceDiscoverySetup> configure)
+        {
+            var setup = new EcsServiceDiscoverySetup();
+            configure(setup);
+            return builder.WithAwsEcsDiscovery(setup);
+        }
+
+        /// <summary>
+        ///     Adds Akka.Discovery.AwsApi.Ec2 support to the <see cref="ActorSystem"/>.
+        ///     Note that this only adds the discovery plugin, you will still need to add ClusterBootstrap for
+        ///     a complete solution.
+        /// </summary>
+        /// <param name="builder">
+        ///     The builder instance being configured.
+        /// </param>
+        /// <param name="setup">
+        ///     The <see cref="EcsServiceDiscoverySetup"/> instance used to configure Akka.Discovery.Azure.
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        /// <example>
+        ///   <code>
+        ///     services.AddAkka("mySystem", builder => {
+        ///         builder
+        ///             .WithClustering()
+        ///             .WithClusterBootstrap(setup =>
+        ///             {
+        ///                 setup.ContactPointDiscovery.ServiceName = "testService";
+        ///                 setup.ContactPointDiscovery.RequiredContactPointsNr = 1;
+        ///             }, autoStart: true)
+        ///             .WithAwsEcsDiscovery(new EcsServiceDiscoverySetup {
+        ///                 Cluster = "my-ecs-cluster-name"
+        ///             });
+        ///     }
+        ///   </code>
+        /// </example>
+        public static AkkaConfigurationBuilder WithAwsEcsDiscovery(
+            this AkkaConfigurationBuilder builder,
+            EcsServiceDiscoverySetup setup)
+        {
+            builder.AddHocon("akka.discovery.method = aws-api-ecs", HoconAddMode.Prepend);
+            builder.AddSetup(setup);
+            
+            // force start the module
+            builder.AddStartup((system, registry) =>
+            {
+                AwsEcsDiscovery.Get(system);
+            });
+            return builder;
+        }
+
+    }
+}

--- a/src/discovery/aws/Akka.Discovery.AwsApi/Ecs/AwsEcsDiscovery.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi/Ecs/AwsEcsDiscovery.cs
@@ -14,7 +14,7 @@ using Akka.Util;
 
 namespace Akka.Discovery.AwsApi.Ecs
 {
-    public class EcsDiscovery: IExtension
+    public class AwsEcsDiscovery: IExtension
     {
         public static Either<string, IPAddress> GetContainerAddress()
         {
@@ -29,14 +29,14 @@ namespace Akka.Discovery.AwsApi.Ecs
         }
         
         public static Configuration.Config DefaultConfiguration()
-            => ConfigurationFactory.FromResource<EcsDiscovery>("Akka.Discovery.AwsApi.reference.conf");
+            => ConfigurationFactory.FromResource<AwsEcsDiscovery>("Akka.Discovery.AwsApi.reference.conf");
         
-        public static EcsDiscovery Get(ActorSystem system)
-            => system.WithExtension<EcsDiscovery, EcsDiscoveryProvider>();
+        public static AwsEcsDiscovery Get(ActorSystem system)
+            => system.WithExtension<AwsEcsDiscovery, EcsDiscoveryProvider>();
 
         public readonly EcsServiceDiscoverySettings Settings;
 
-        public EcsDiscovery(ExtendedActorSystem system)
+        public AwsEcsDiscovery(ExtendedActorSystem system)
         {
             system.Settings.InjectTopLevelFallback(DefaultConfiguration());
             Settings = EcsServiceDiscoverySettings.Create(system);
@@ -48,10 +48,10 @@ namespace Akka.Discovery.AwsApi.Ecs
 
     }
     
-    public class EcsDiscoveryProvider : ExtensionIdProvider<EcsDiscovery>
+    public class EcsDiscoveryProvider : ExtensionIdProvider<AwsEcsDiscovery>
     {
-        public override EcsDiscovery CreateExtension(ExtendedActorSystem system)
-            => new EcsDiscovery(system);
+        public override AwsEcsDiscovery CreateExtension(ExtendedActorSystem system)
+            => new AwsEcsDiscovery(system);
     }
     
 }

--- a/src/discovery/aws/Akka.Discovery.AwsApi/Ecs/EcsServiceDiscovery.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi/Ecs/EcsServiceDiscovery.cs
@@ -43,7 +43,7 @@ namespace Akka.Discovery.AwsApi.Ecs
         
         public EcsServiceDiscovery(ActorSystem system)
         {
-            _settings = EcsDiscovery.Get(system).Settings;
+            _settings = AwsEcsDiscovery.Get(system).Settings;
         }
         
         public override async Task<Resolved> Lookup(Lookup lookup, TimeSpan resolveTimeout)

--- a/src/discovery/aws/Akka.Discovery.AwsApi/reference.conf
+++ b/src/discovery/aws/Akka.Discovery.AwsApi/reference.conf
@@ -57,15 +57,5 @@ akka.discovery {
     # Filter out any tasks that contains any of these tags
     # Example: [{ key = "deployment-side", value = "blue" }, ...]
     tags = []
-
-    # client may use specified endpoint for example ec2.us-west-1.amazonaws.com
-    # region is automatically extrapolated from the endpoint URL
-    # endpoint = ""
-    
-    # client may use specified region for example us-west-1
-    # endpoints are automatically generated.
-    # NOTE: You can only set either an endpoint OR a region, not both.
-    #       Region will always win if both are declared.
-    # region = ""
-    
+  }   
 }

--- a/src/discovery/examples/Aws.Ecs/Aws.Ecs.csproj
+++ b/src/discovery/examples/Aws.Ecs/Aws.Ecs.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
 

--- a/src/discovery/examples/Aws.Ecs/Dockerfile
+++ b/src/discovery/examples/Aws.Ecs/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/sdk:3.1 AS base
+﻿FROM mcr.microsoft.com/dotnet/sdk:6.0 AS base
 WORKDIR /app
 
 # should be a comma-delimited list
@@ -17,9 +17,9 @@ RUN dotnet tool install --global pbm
 
 # RUN pbm help
 
-COPY ./bin/Release/netcoreapp3.1/publish/ /app
+COPY ./bin/Release/net6.0/publish/ /app
 
-FROM mcr.microsoft.com/dotnet/runtime:3.1 AS app
+FROM mcr.microsoft.com/dotnet/runtime:6.0 AS app
 WORKDIR /app
 
 COPY --from=base /app /app
@@ -30,7 +30,8 @@ COPY --from=base /root/.dotnet /root/.dotnet/
 # Needed because https://stackoverflow.com/questions/51977474/install-dotnet-core-tool-dockerfile
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
-# Add DNS utils
-RUN apt update && apt install dnsutils -y
+# Needed because https://github.com/aws/amazon-ecs-agent/issues/3299
+# Fix was https://github.com/dotnet/coreclr/pull/16141
+ENV COMPlus_EnableDiagnostics=0
 
 ENTRYPOINT ["dotnet", "Aws.Ecs.dll"]


### PR DESCRIPTION
## Changes
- Add Akka.Hosting extension methods to Akka.Discovery.AwsApi.Ec2
- Change EcsDiscovery class name to AwsEcsDiscovery to make it consistent with the Ec2 counterpart
- Add Akka.Hosting extension methods to Akka.Discovery.AwsApi.Ecs
- Fix the AWS ECS sample Dockerfile
- Update the AWS ECS sample project to use the Akka.Hosting extension methods.