### PR TITLE
Feature/migrate to tokencredential

### DIFF
--- a/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
@@ -10,6 +10,7 @@ using Akka.Actor;
 using Akka.Hosting;
 using Azure.Data.Tables;
 using Azure.Identity;
+using Azure.Core;
 
 namespace Akka.Discovery.Azure
 {
@@ -81,7 +82,7 @@ namespace Akka.Discovery.Azure
         ///     The <see cref="Uri"/> to the azure table endpoint, this is usually in the form of "https://{yourAccountName}.table.core.windows.net/"
         /// </param>
         /// <param name="azureCredential">
-        ///     The <see cref="DefaultAzureCredential"/> instance that will be used to authorize the table client with Azure Table Storage service.
+        ///     The <see cref="TokenCredential"/> instance that will be used to authorize the table client with Azure Table Storage service.
         /// </param>
         /// <param name="tableClientOptions">
         ///     Optional <see cref="TableClientOptions"/> instance to configure requests to the Azure Table Storage service.
@@ -118,7 +119,7 @@ namespace Akka.Discovery.Azure
         public static AkkaConfigurationBuilder WithAzureDiscovery(
             this AkkaConfigurationBuilder builder,
             Uri azureTableEndpoint,
-            DefaultAzureCredential azureCredential,
+            TokenCredential azureCredential,
             TableClientOptions tableClientOptions = null,
             string serviceName = null,
             string publicHostname = null,

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySettings.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySettings.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Net;
 using Akka.Actor;
+using Azure.Core;
 using Azure.Data.Tables;
 using Azure.Identity;
 
@@ -74,7 +75,7 @@ namespace Akka.Discovery.Azure
             TimeSpan retryBackoff,
             TimeSpan maximumRetryBackoff,
             Uri azureTableEndpoint,
-            DefaultAzureCredential azureCredential,
+            TokenCredential azureCredential,
             TableClientOptions tableClientOptions)
         {
             if (ttlHeartbeatInterval <= TimeSpan.Zero)
@@ -135,7 +136,7 @@ namespace Akka.Discovery.Azure
         public TimeSpan RetryBackoff { get; }
         public TimeSpan MaximumRetryBackoff { get; }
         public Uri AzureTableEndpoint { get; }
-        public DefaultAzureCredential AzureAzureCredential { get; }
+        public TokenCredential AzureAzureCredential { get; }
         public TableClientOptions TableClientOptions { get; }
 
         public override string ToString()
@@ -187,7 +188,7 @@ namespace Akka.Discovery.Azure
 
         public AzureDiscoverySettings WithAzureCredential(
             Uri azureTableEndpoint,
-            DefaultAzureCredential credential,
+            TokenCredential credential,
             TableClientOptions tableClientOptions = null)
             => Copy(
                 azureTableEndpoint: azureTableEndpoint,
@@ -207,7 +208,7 @@ namespace Akka.Discovery.Azure
             TimeSpan? retryBackoff = null,
             TimeSpan? maximumRetryBackoff = null,
             Uri azureTableEndpoint = null,
-            DefaultAzureCredential credential = null,
+            TokenCredential credential = null,
             TableClientOptions tableClientOptions = null)
             => new AzureDiscoverySettings(
                 serviceName: serviceName ?? ServiceName,

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySetup.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySetup.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using Akka.Actor.Setup;
+using Azure.Core;
 using Azure.Data.Tables;
 using Azure.Identity;
 
@@ -26,7 +27,7 @@ namespace Akka.Discovery.Azure
         public TimeSpan? RetryBackoff { get; set; }
         public TimeSpan? MaximumRetryBackoff { get; set; }
         public Uri AzureTableEndpoint { get; set; }
-        public DefaultAzureCredential AzureCredential { get; set; }
+        public TokenCredential AzureCredential { get; set; }
         public TableClientOptions TableClientOptions { get; set; }
         public AzureDiscoverySetup WithServiceName(string serviceName)
         {

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySetup.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySetup.cs
@@ -92,7 +92,7 @@ namespace Akka.Discovery.Azure
 
         public AzureDiscoverySetup WithAzureCredential(
             Uri azureTableEndpoint,
-            DefaultAzureCredential credential,
+            TokenCredential credential,
             TableClientOptions tableClientOptions = null)
         {
             AzureTableEndpoint = azureTableEndpoint;


### PR DESCRIPTION
Fixes #860

## Changes

DefaultAzureCredentials parameters have been changed to TokenCredential

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
