### PR TITLE
Make AzureLeaseSetup more strict

### DIFF
--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureLeaseSettingsSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureLeaseSettingsSpec.cs
@@ -102,8 +102,7 @@ namespace Akka.Coordination.Azure.Tests
                 .WithContainerName("b")
                 .WithApiServiceRequestTimeout(11.Seconds())
                 .WithBodyReadTimeout(12.Seconds())
-                .WithServiceEndpoint(uri)
-                .WithAzureCredential(cred)
+                .WithAzureCredential(cred, uri)
                 .WithBlobClientOption(opt);
             
             settings.ConnectionString.Should().Be("a");
@@ -133,7 +132,7 @@ namespace Akka.Coordination.Azure.Tests
                 BlobClientOptions = opt
             };
             
-            var settings = setup.Apply(AzureLeaseSettings.Empty);
+            var settings = setup.Apply(AzureLeaseSettings.Empty, null);
             settings.ConnectionString.Should().Be("a");
             settings.ContainerName.Should().Be("b");
             settings.ApiServiceRequestTimeout.Should().Be(11.Seconds());

--- a/src/coordination/azure/Akka.Coordination.Azure/AzureLease.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/AzureLease.cs
@@ -61,7 +61,7 @@ namespace Akka.Coordination.Azure
 
             var setup = system.Settings.Setup.Get<AzureLeaseSetup>();
             if (setup.HasValue)
-                azureLeaseSettings = setup.Value.Apply(azureLeaseSettings);
+                azureLeaseSettings = setup.Value.Apply(azureLeaseSettings, system);
             
             _timeout = _settings.TimeoutSettings.OperationTimeout;
             _leaseName = MakeDns1039Compatible(settings.LeaseName);

--- a/src/coordination/azure/Akka.Coordination.Azure/AzureLeaseSettings.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/AzureLeaseSettings.cs
@@ -85,10 +85,16 @@ namespace Akka.Coordination.Azure
             => Copy(apiServiceRequestTimeout: apiServiceRequestTimeout);
         public AzureLeaseSettings WithBodyReadTimeout(TimeSpan bodyReadTimeout)
             => Copy(bodyReadTimeout: bodyReadTimeout);
-        public AzureLeaseSettings WithServiceEndpoint(Uri serviceEndpoint)
-            => Copy(serviceEndpoint: serviceEndpoint);
-        public AzureLeaseSettings WithAzureCredential(TokenCredential azureCredential)
-            => Copy(azureCredential: azureCredential);
+        public AzureLeaseSettings WithAzureCredential(TokenCredential azureCredential, Uri serviceEndpoint)
+        {
+            if (azureCredential is null)
+                throw new ArgumentNullException(nameof(azureCredential), "TokenCredential must not be null");
+            if(serviceEndpoint is null)
+                throw new ArgumentNullException(nameof(serviceEndpoint), "Service URI must not be null");
+            
+            return Copy(azureCredential: azureCredential, serviceEndpoint: serviceEndpoint);
+        }
+        
         public AzureLeaseSettings WithBlobClientOption(BlobClientOptions blobClientOptions)
             => Copy(blobClientOptions: blobClientOptions);
         


### PR DESCRIPTION
Fixes #961

## Changes

* Make `AzureLeaseSetup` check that both `AzureCredential` and `ServiceEndpoint` is defined when being applied to settings.