### PR TITLE
Standardize csproj files using Directory.Build.props

### DIFF
--- a/Akka.Management.sln
+++ b/Akka.Management.sln
@@ -81,6 +81,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE = LICENSE
 		README.md = README.md
 		RELEASE_NOTES.md = RELEASE_NOTES.md
+		src\Directory.Build.props = src\Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{64BED000-5004-4873-98A9-948FBF772EF4}"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,58 +1,58 @@
 <Project>
-  <PropertyGroup>
-    <Copyright>Copyright © 2013-2021 Akka.NET Team</Copyright>
-    <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>0.2.2</VersionPrefix>
-    <PackageReleaseNotes>Update to [Akka.NET v1.4.26](https://github.com/akkadotnet/akka.net/releases/tag/1.4.26)
+    <PropertyGroup>
+        <Copyright>Copyright © 2013-2021 Akka.NET Team</Copyright>
+        <Authors>Akka.NET Team</Authors>
+        <VersionPrefix>0.2.2</VersionPrefix>
+        <PackageReleaseNotes>Update to [Akka.NET v1.4.26](https://github.com/akkadotnet/akka.net/releases/tag/1.4.26)
 [Added Akka.Discovery.KubernetesApi package](https://github.com/akkadotnet/Akka.Management/pull/145) - as the name implies, it uses the Kubernetes API to query for available pods to act as seed nodes.
 Update all AWSSDK versions</PackageReleaseNotes>
-    <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/akkadotnet/Akka.Management</PackageProjectUrl>
-    <License>        
-      Copyright (c) .NET Foundation and Contributors
-      All Rights Reserved
+        <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
+        <PackageProjectUrl>https://github.com/akkadotnet/Akka.Management</PackageProjectUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
+    </PropertyGroup>
 
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
+    <PropertyGroup>
+        <LangVersion>10.0</LangVersion>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
 
-          http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-    </License>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AkkaPackageTags>akka;actors;actor model;Akka;concurrency;service discovery;cluster;clustering;</AkkaPackageTags>
-    <LibraryFramework>netstandard2.0</LibraryFramework>
-    <NetFramework>net6.0</NetFramework>
-    <TestsNetCoreFramework>netcoreapp3.1</TestsNetCoreFramework>
-    <TestsNet>net6.0</TestsNet>
-    <XunitVersion>2.4.2</XunitVersion>
-    <XUnitRunnerVersion>2.4.3</XUnitRunnerVersion>
-    <CoverletVersion>3.2.0</CoverletVersion>
-    <FluentAssertionVersion>6.8.0</FluentAssertionVersion>
-    <TestSdkVersion>17.4.0</TestSdkVersion>
-    <AkkaVersion>1.4.46</AkkaVersion>
-    <AkkaHostingVersion>0.5.2-beta1</AkkaHostingVersion>
-    <KubernetesClientVersion>4.0.26</KubernetesClientVersion>
-    <MicrosoftExtensionsVersion>7.0.0</MicrosoftExtensionsVersion>
-    <PbmVersion>1.1.3</PbmVersion>
-  </PropertyGroup>
-  <!-- SourceLink support for all Akka.NET projects -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-  <PropertyGroup>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AkkaPackageTags>akka;actors;actor model;Akka;concurrency;service discovery;cluster;clustering;</AkkaPackageTags>
+        <LibraryFramework>netstandard2.0</LibraryFramework>
+        <NetFramework>net6.0</NetFramework>
+        
+        <TestsNetCoreFramework>netcoreapp3.1</TestsNetCoreFramework>
+        <TestsNet>net6.0</TestsNet>
+        <XunitVersion>2.4.2</XunitVersion>
+        <XUnitRunnerVersion>2.4.3</XUnitRunnerVersion>
+        <CoverletVersion>3.2.0</CoverletVersion>
+        <FluentAssertionVersion>6.8.0</FluentAssertionVersion>
+        <TestSdkVersion>17.4.0</TestSdkVersion>
+        <WireMockVersion>1.5.11</WireMockVersion>
+        
+        <AkkaVersion>1.4.46</AkkaVersion>
+        <AkkaHostingVersion>0.5.2-beta1</AkkaHostingVersion>
+        <PbmVersion>1.1.3</PbmVersion>
+        <BootstrapDockerVersion>0.5.3</BootstrapDockerVersion>
+        
+        <KubernetesClientVersion>4.0.26</KubernetesClientVersion>
+        <MicrosoftExtensionsVersion>7.0.0</MicrosoftExtensionsVersion>
+        <AzureIdentityVersion>1.8.0</AzureIdentityVersion>
+        <ProtobufVersion>3.21.9</ProtobufVersion>
+        <GrpcToolsVersion>2.50.0</GrpcToolsVersion>
+    </PropertyGroup>
+    
+    <!-- SourceLink support for all Akka.NET projects -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    </ItemGroup>
+    <PropertyGroup>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
 </Project>

--- a/src/cluster.bootstrap/examples/discovery/azure/AzureCluster/AzureCluster.csproj
+++ b/src/cluster.bootstrap/examples/discovery/azure/AzureCluster/AzureCluster.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Nullable>enable</Nullable>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
@@ -14,7 +13,7 @@
         <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
         <PackageReference Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
         <PackageReference Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
-        <PackageReference Include="Akka.Bootstrap.Docker" Version="0.5.3" />
+        <PackageReference Include="Akka.Bootstrap.Docker" Version="$(BootstrapDockerVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/KubernetesCluster.csproj
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/KubernetesCluster.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
@@ -12,7 +13,7 @@
         <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
         <PackageReference Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
         <PackageReference Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
-        <PackageReference Include="Akka.Bootstrap.Docker" Version="0.5.3" />
+        <PackageReference Include="Akka.Bootstrap.Docker" Version="$(BootstrapDockerVersion)" />
         <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/Akka.Coordination.Azure.Tests.csproj
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/Akka.Coordination.Azure.Tests.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
         <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="WireMock.Net" Version="1.5.11" />
+        <PackageReference Include="WireMock.Net" Version="$(WireMockVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
+++ b/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
@@ -5,7 +5,6 @@
 		<Description>Akka.NET coordination module for Microsoft Azure</Description>
 		<PackageTags>$(AkkaPackageTags);Azure;</PackageTags>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -17,10 +16,10 @@
 		<PackageReference Include="Akka.Cluster" Version="$(AkkaVersion)" />
 		<PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
 		<PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-		<PackageReference Include="Azure.Identity" Version="1.8.0" />
+		<PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
-		<PackageReference Include="Google.Protobuf" Version="3.21.9" />
-		<PackageReference Include="Grpc.Tools" Version="2.50.0">
+		<PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
+		<PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/coordination/examples/azure/Azure.StressTest/Azure.StressTest.csproj
+++ b/src/coordination/examples/azure/Azure.StressTest/Azure.StressTest.csproj
@@ -4,8 +4,8 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,7 +14,7 @@
         <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
         <PackageReference Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
         <PackageReference Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
-        <PackageReference Include="Akka.Bootstrap.Docker" Version="0.5.3" />
+        <PackageReference Include="Akka.Bootstrap.Docker" Version="$(BootstrapDockerVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />

--- a/src/coordination/examples/kubernetes/Kubernetes.StressTest/Kubernetes.StressTest.csproj
+++ b/src/coordination/examples/kubernetes/Kubernetes.StressTest/Kubernetes.StressTest.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,7 +18,7 @@
         <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
         <PackageReference Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
         <PackageReference Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
-        <PackageReference Include="Akka.Bootstrap.Docker" Version="0.5.3" />
+        <PackageReference Include="Akka.Bootstrap.Docker" Version="$(BootstrapDockerVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/Akka.Coordination.KubernetesApi.Tests.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/Akka.Coordination.KubernetesApi.Tests.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
         <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="WireMock.Net" Version="1.5.11" />
+        <PackageReference Include="WireMock.Net" Version="$(WireMockVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
@@ -5,7 +5,6 @@
         <Description>Akka.NET coordination module for Kubernetes</Description>
         <PackageTags>$(AkkaPackageTags);Kubernetes;</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Akka.Discovery.AwsApi.Tests.csproj
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Akka.Discovery.AwsApi.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>$(TestsNetFramework);$(TestsNetCoreFramework);$(TestsNet)</TargetFrameworks>
-      <IsPackable>false</IsPackable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/discovery/azure/Akka.Discovery.Azure/Akka.Discovery.Azure.csproj
+++ b/src/discovery/azure/Akka.Discovery.Azure/Akka.Discovery.Azure.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,9 +13,9 @@
       <PackageReference Include="Akka.Cluster" Version="$(AkkaVersion)" />
       <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
       <PackageReference Include="Azure.Data.Tables" Version="12.7.1" />
-      <PackageReference Include="Azure.Identity" Version="1.8.0" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.9" />
-      <PackageReference Include="Grpc.Tools" Version="2.50.0">
+      <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
+      <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
+      <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>

--- a/src/discovery/examples/Aws.Ecs/Aws.Ecs.csproj
+++ b/src/discovery/examples/Aws.Ecs/Aws.Ecs.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
@@ -12,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Akka.Bootstrap.Docker" Version="0.5.3" />
-      <PackageReference Include="Akka.Cluster.Hosting" Version="0.5.1" />
+      <PackageReference Include="Akka.Bootstrap.Docker" Version="$(BootstrapDockerVersion)" />
+      <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
     </ItemGroup>
 
 </Project>

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
@@ -5,7 +5,6 @@
         <Description>Akka.NET discovery module for Kubernetes</Description>
         <PackageTags>$(AkkaPackageTags);Kubernetes;</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/management/Akka.Http.Shim/Akka.Http.Shim.csproj
+++ b/src/management/Akka.Http.Shim/Akka.Http.Shim.csproj
@@ -5,7 +5,6 @@
     <PackageTags>$(AkkaPackageTags)</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Akka.Http</RootNamespace>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/management/Akka.Management/Akka.Management.csproj
+++ b/src/management/Akka.Management/Akka.Management.csproj
@@ -4,7 +4,6 @@
     <Description>Akka cluster management module for Akka.NET</Description>
     <PackageTags>$(AkkaPackageTags)</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Standardize csproj:
- LangVersion to 10.0
- Nullable to enable
- License to use PackageLicenseExpression that links directly to Apache-2.0.
- Complete version tags

The new PackageLicenseExpression tag translates to these nuspec tags:
```xml
<license type="expression">Apache-2.0</license>
<licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
```