### PR TITLE
[Discovery.Azure] Fix nullable warnings, fix message handling bugs in actors

### DIFF
--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/ActorSpec.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/ActorSpec.cs
@@ -81,9 +81,10 @@ akka.remote.dot-netty.tcp.port = 0
             await WithinAsync(3.Seconds(), async () =>
             {
                 await EventFilter.Debug(contains: "LastUpdate successfully updated from")
-                    .ExpectOneAsync(async () =>
+                    .ExpectOneAsync(() =>
                     {
                         actor.Tell("heartbeat", actor); // Fake a timer message
+                        return Task.CompletedTask;
                     });
             });
 

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/XUnitLogger.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/XUnitLogger.cs
@@ -30,7 +30,7 @@ namespace Akka.Discovery.Azure.Tests
             WriteLogEntry(logLevel, eventId, formattedMessage, exception);
         }
 
-        private void WriteLogEntry(LogLevel logLevel, EventId eventId, string message, Exception exception)
+        private void WriteLogEntry(LogLevel logLevel, EventId eventId, string? message, Exception? exception)
         {
             var level = logLevel switch
             {
@@ -67,7 +67,7 @@ namespace Akka.Discovery.Azure.Tests
             TState state,
             Exception exception,
             Func<TState, Exception, string> formatter,
-            out string result)
+            out string? result)
         {
             formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
             

--- a/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
@@ -56,8 +56,8 @@ namespace Akka.Discovery.Azure
         public static AkkaConfigurationBuilder WithAzureDiscovery(
             this AkkaConfigurationBuilder builder,
             string connectionString,
-            string serviceName = null,
-            string publicHostname = null,
+            string? serviceName = null,
+            string? publicHostname = null,
             int? publicPort = null)
         {
             var setup = new AzureDiscoverySetup
@@ -120,9 +120,9 @@ namespace Akka.Discovery.Azure
             this AkkaConfigurationBuilder builder,
             Uri azureTableEndpoint,
             TokenCredential azureCredential,
-            TableClientOptions tableClientOptions = null,
-            string serviceName = null,
-            string publicHostname = null,
+            TableClientOptions? tableClientOptions = null,
+            string? serviceName = null,
+            string? publicHostname = null,
             int? publicPort = null)
         {
             if (azureCredential == null) throw new ArgumentNullException(nameof(azureCredential));

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySettings.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySettings.cs
@@ -9,7 +9,6 @@ using System.Net;
 using Akka.Actor;
 using Azure.Core;
 using Azure.Data.Tables;
-using Azure.Identity;
 
 namespace Akka.Discovery.Azure
 {
@@ -74,9 +73,9 @@ namespace Akka.Discovery.Azure
             TimeSpan operationTimeout,
             TimeSpan retryBackoff,
             TimeSpan maximumRetryBackoff,
-            Uri azureTableEndpoint,
-            TokenCredential azureCredential,
-            TableClientOptions tableClientOptions)
+            Uri? azureTableEndpoint,
+            TokenCredential? azureCredential,
+            TableClientOptions? tableClientOptions)
         {
             if (ttlHeartbeatInterval <= TimeSpan.Zero)
                 throw new ArgumentException("Must be greater than zero", nameof(ttlHeartbeatInterval));
@@ -135,9 +134,9 @@ namespace Akka.Discovery.Azure
         public TimeSpan OperationTimeout { get; }
         public TimeSpan RetryBackoff { get; }
         public TimeSpan MaximumRetryBackoff { get; }
-        public Uri AzureTableEndpoint { get; }
-        public TokenCredential AzureAzureCredential { get; }
-        public TableClientOptions TableClientOptions { get; }
+        public Uri? AzureTableEndpoint { get; }
+        public TokenCredential? AzureAzureCredential { get; }
+        public TableClientOptions? TableClientOptions { get; }
 
         public override string ToString()
             => "[AzureDiscoverySettings](" +
@@ -189,28 +188,28 @@ namespace Akka.Discovery.Azure
         public AzureDiscoverySettings WithAzureCredential(
             Uri azureTableEndpoint,
             TokenCredential credential,
-            TableClientOptions tableClientOptions = null)
+            TableClientOptions? tableClientOptions = null)
             => Copy(
                 azureTableEndpoint: azureTableEndpoint,
                 credential: credential,
                 tableClientOptions: tableClientOptions);
         
         private AzureDiscoverySettings Copy(
-            string serviceName = null,
-            string host = null,
+            string? serviceName = null,
+            string? host = null,
             int? port = null,
-            string connectionString = null,
-            string tableName = null,
+            string? connectionString = null,
+            string? tableName = null,
             TimeSpan? pruneInterval = null,
             TimeSpan? staleTtlThreshold = null,
             TimeSpan? ttlHeartbeatInterval = null,
             TimeSpan? operationTimeout = null,
             TimeSpan? retryBackoff = null,
             TimeSpan? maximumRetryBackoff = null,
-            Uri azureTableEndpoint = null,
-            TokenCredential credential = null,
-            TableClientOptions tableClientOptions = null)
-            => new AzureDiscoverySettings(
+            Uri? azureTableEndpoint = null,
+            TokenCredential? credential = null,
+            TableClientOptions? tableClientOptions = null)
+            => new (
                 serviceName: serviceName ?? ServiceName,
                 hostName: host ?? HostName,
                 port: port ?? Port,

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySetup.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySetup.cs
@@ -15,20 +15,20 @@ namespace Akka.Discovery.Azure
 {
     public sealed class AzureDiscoverySetup: Setup
     {
-        public string ServiceName { get; set; }
-        public string HostName { get; set; }
+        public string? ServiceName { get; set; }
+        public string? HostName { get; set; }
         public int? Port { get; set; }
-        public string ConnectionString { get; set; }
-        public string TableName { get; set; }
+        public string? ConnectionString { get; set; }
+        public string? TableName { get; set; }
         public TimeSpan? TtlHeartbeatInterval { get; set; }
         public TimeSpan? StaleTtlThreshold { get; set; }
         public TimeSpan? PruneInterval { get; set; }
         public TimeSpan? OperationTimeout { get; set; }
         public TimeSpan? RetryBackoff { get; set; }
         public TimeSpan? MaximumRetryBackoff { get; set; }
-        public Uri AzureTableEndpoint { get; set; }
-        public TokenCredential AzureCredential { get; set; }
-        public TableClientOptions TableClientOptions { get; set; }
+        public Uri? AzureTableEndpoint { get; set; }
+        public TokenCredential? AzureCredential { get; set; }
+        public TableClientOptions? TableClientOptions { get; set; }
         public AzureDiscoverySetup WithServiceName(string serviceName)
         {
             ServiceName = serviceName;
@@ -93,7 +93,7 @@ namespace Akka.Discovery.Azure
         public AzureDiscoverySetup WithAzureCredential(
             Uri azureTableEndpoint,
             TokenCredential credential,
-            TableClientOptions tableClientOptions = null)
+            TableClientOptions? tableClientOptions = null)
         {
             AzureTableEndpoint = azureTableEndpoint;
             AzureCredential = credential;

--- a/src/discovery/azure/Akka.Discovery.Azure/Exceptions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/Exceptions.cs
@@ -1,0 +1,92 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Exceptions.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Akka.Actor;
+
+namespace Akka.Discovery.Azure;
+
+/// <summary>
+/// Thrown when a prune operation failed
+/// </summary>
+public sealed class PruneOperationException: AkkaException
+{
+    public PruneOperationException(List<string> reasons)
+    {
+        Reasons = reasons;
+    }
+
+    public PruneOperationException(string message, List<string> reasons, Exception? cause = null) : base(message, cause)
+    {
+        Reasons = reasons;
+    }
+
+    public PruneOperationException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+        Reasons = new List<string>();
+    }
+    
+    public List<string> Reasons { get; }
+
+    public override string Message => $"{base.Message}. Reasons:\n\t-{string.Join("\n\t-", Reasons)}";
+}
+
+/// <summary>
+/// Thrown when <see cref="ClusterMemberTableClient"/> failed to connect to Azure Table
+/// </summary>
+public sealed class InitializationException : AkkaException
+{
+    public InitializationException()
+    {
+    }
+
+    public InitializationException(string message, Exception? cause = null) : base(message, cause)
+    {
+    }
+
+    public InitializationException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}
+
+/// <summary>
+/// Thrown when the client failed to update the node entity
+/// </summary>
+public sealed class UpdateOperationException : AkkaException
+{
+    public UpdateOperationException()
+    {
+    }
+
+    public UpdateOperationException(string message, Exception? cause = null) : base(message, cause)
+    {
+    }
+
+    public UpdateOperationException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}
+
+/// <summary>
+/// Thrown when the client failed to create an entity entry
+/// </summary>
+public sealed class CreateEntityFailedException : AkkaException
+{
+    public CreateEntityFailedException()
+    {
+    }
+
+    public CreateEntityFailedException(string message, Exception cause = null) : base(message, cause)
+    {
+    }
+
+    public CreateEntityFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/src/discovery/azure/Akka.Discovery.Azure/Model/ClusterMember.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/Model/ClusterMember.cs
@@ -35,7 +35,7 @@ namespace Akka.Discovery.Azure.Model
 
             Raw = entity;
             Proto = ClusterMemberProto.Parser.ParseFrom(entity.GetBinary(PayloadName));
-            LastUpdate = new DateTime(entity.GetInt64(LastUpdateName).Value);
+            LastUpdate = new DateTime(entity.GetInt64(LastUpdateName)!.Value);
         }
         
         #region Required fields
@@ -93,8 +93,7 @@ namespace Akka.Discovery.Azure.Model
             };
         }
 
-        public static ClusterMember FromEntity(TableEntity entity)
-            => new ClusterMember(entity);
+        public static ClusterMember FromEntity(TableEntity entity) => new(entity);
         
         internal static string CreateRowKey(string? host, IPAddress? address, int port)
             => $"{host}-{address?.MapToIPv4()}-{port}";


### PR DESCRIPTION
This is a fairly large PR, there was some logic error with actor message handling.

All client methods now either succeeds or throws an error, it is the actor responsibility to interpret the failures or success of a method call by using `PipeTo` and schedule a retry if one is deemed nescessary