### PR TITLE
[Coordination.Kubernetes] Change hosting extension to use options instead of setup

### DIFF
--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/Program.cs
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/Program.cs
@@ -49,7 +49,7 @@ namespace KubernetesCluster
                                 Roles = new[] { "cluster" }, 
                                 SplitBrainResolver = new LeaseMajorityOption
                                 {
-                                    LeaseImplementation = KubernetesLeaseOption.Instance
+                                    LeaseImplementation = new KubernetesLeaseOption()
                                 }
                             });
                         

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/AkkaHostingSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/AkkaHostingSpec.cs
@@ -13,6 +13,7 @@ using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Hosting;
 using FluentAssertions;
+using Humanizer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
@@ -30,51 +31,107 @@ namespace Akka.Coordination.KubernetesApi.Tests
             builder.WithKubernetesLease();
             
             builder.Configuration.HasValue.Should().BeTrue();
-            builder.Configuration.Value.GetConfig("akka.coordination.lease.kubernetes")
-                .Should().NotBeNull();
+            var config = builder.Configuration.Value.GetConfig(KubernetesLease.ConfigPath);
+            config.Should().NotBeNull();
+            config = config.WithFallback(builder.Configuration.Value.GetConfig("akka.coordination.lease"));
+            
+            var settings = KubernetesSettings.Create(config);
+            settings.ApiCaPath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt");
+            settings.ApiTokenPath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/token");
+            settings.ApiServiceHostEnvName.Should().Be("KUBERNETES_SERVICE_HOST");
+            settings.ApiServicePortEnvName.Should().Be("KUBERNETES_SERVICE_PORT");
+            settings.Namespace.Should().BeNull(); 
+            settings.NamespacePath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); 
+            settings.ApiServiceRequestTimeout.Should().Be(2.Seconds());
+            settings.Secure.Should().BeTrue(); 
+            settings.BodyReadTimeout.Should().Be(1.Seconds()); 
+
+            var timeSettings = TimeoutSettings.Create(config);
+            timeSettings.HeartbeatInterval.Should().Be(12.Seconds());
+            timeSettings.HeartbeatTimeout.Should().Be(120.Seconds());
+            timeSettings.OperationTimeout.Should().Be(5.Seconds());
         }
         
-        [Fact(DisplayName = "Hosting Action<Setup> extension should add Setup class and default hocon settings")]
+        [Fact(DisplayName = "Hosting Action<KubernetesLeaseOption> extension should override hocon settings")]
         public void HostingExtension2Test()
         {
             var builder = new AkkaConfigurationBuilder(new ServiceCollection(), "test");
             
             builder.WithKubernetesLease(lease =>
             {
-                lease.Namespace = "underTest";
+                lease.ApiCaPath = "a";
+                lease.ApiTokenPath = "b";
+                lease.ApiServiceHostEnvName = "c";
+                lease.ApiServicePortEnvName = "d";
+                lease.Namespace = "e";
+                lease.NamespacePath = "f";
+                lease.ApiServiceRequestTimeout = 3.Seconds();
+                lease.SecureApiServer = false;
+                lease.HeartbeatInterval = 4.Seconds();
+                lease.HeartbeatTimeout = 10.Seconds();
+                lease.LeaseOperationTimeout = 4.Seconds();
             });
                         
             builder.Configuration.HasValue.Should().BeTrue();
-            builder.Configuration.Value.GetConfig("akka.coordination.lease.kubernetes")
-                .Should().NotBeNull();
-            var setup = ExtractSetup(builder);
-            setup.Should().NotBeNull();
-            // !: null check above
-            setup!.Namespace.Should().Be("underTest");
+            var config = builder.Configuration.Value.GetConfig(KubernetesLease.ConfigPath);
+            config.Should().NotBeNull();
+            config = config.WithFallback(builder.Configuration.Value.GetConfig("akka.coordination.lease"));
+            
+            var settings = KubernetesSettings.Create(config);
+            settings.ApiCaPath.Should().Be("a");
+            settings.ApiTokenPath.Should().Be("b");
+            settings.ApiServiceHostEnvName.Should().Be("c");
+            settings.ApiServicePortEnvName.Should().Be("d");
+            settings.Namespace.Should().Be("e"); 
+            settings.NamespacePath.Should().Be("f"); 
+            settings.ApiServiceRequestTimeout.Should().Be(3.Seconds());
+            settings.Secure.Should().BeFalse(); 
+            settings.BodyReadTimeout.Should().Be(1.5.Seconds());
+
+            var timeSettings = TimeoutSettings.Create(config);
+            timeSettings.HeartbeatInterval.Should().Be(4.Seconds());
+            timeSettings.HeartbeatTimeout.Should().Be(10.Seconds());
+            timeSettings.OperationTimeout.Should().Be(4.Seconds());
         }
         
-        [Fact(DisplayName = "Hosting Setup extension should add Setup class and default hocon settings")]
+        [Fact(DisplayName = "Hosting Setup extension should override hocon settings")]
         public void HostingExtension3Test()
         {
             var builder = new AkkaConfigurationBuilder(new ServiceCollection(), "test");
             
-            builder.WithKubernetesLease(new KubernetesLeaseSetup
+            builder.WithKubernetesLease(new KubernetesLeaseOption
             {
-                Namespace = "underTest"
+                ApiCaPath = "a",
+                ApiTokenPath = "b",
+                ApiServiceHostEnvName = "c",
+                ApiServicePortEnvName = "d",
+                Namespace = "e",
+                NamespacePath = "f",
+                ApiServiceRequestTimeout = 3.Seconds(),
+                SecureApiServer = false,
+                HeartbeatInterval = 4.Seconds(),
+                HeartbeatTimeout = 10.Seconds(),
+                LeaseOperationTimeout = 4.Seconds()
             });
                         
             builder.Configuration.HasValue.Should().BeTrue();
-            builder.Configuration.Value.GetConfig("akka.coordination.lease.kubernetes")
-                .Should().NotBeNull();
-            var setup = ExtractSetup(builder);
-            setup.Should().NotBeNull();
-            // !: null check above
-            setup!.Namespace.Should().Be("underTest");
-        }
+            var config = builder.Configuration.Value.GetConfig(KubernetesLease.ConfigPath);
+            config.Should().NotBeNull();
+            var settings = KubernetesSettings.Create(config);
+            settings.ApiCaPath.Should().Be("a");
+            settings.ApiTokenPath.Should().Be("b");
+            settings.ApiServiceHostEnvName.Should().Be("c");
+            settings.ApiServicePortEnvName.Should().Be("d");
+            settings.Namespace.Should().Be("e"); 
+            settings.NamespacePath.Should().Be("f"); 
+            settings.ApiServiceRequestTimeout.Should().Be(3.Seconds());
+            settings.Secure.Should().BeFalse(); 
+            settings.BodyReadTimeout.Should().Be(1.5.Seconds());
 
-        private KubernetesLeaseSetup? ExtractSetup(AkkaConfigurationBuilder builder)
-        {
-            return builder.Setups.FirstOrDefault(s => s is KubernetesLeaseSetup) as KubernetesLeaseSetup;
+            var timeSettings = TimeoutSettings.Create(config);
+            timeSettings.HeartbeatInterval.Should().Be(4.Seconds());
+            timeSettings.HeartbeatTimeout.Should().Be(10.Seconds());
+            timeSettings.OperationTimeout.Should().Be(4.Seconds());
         }
     }
 }

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/KubernetesSettingsSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/KubernetesSettingsSpec.cs
@@ -24,7 +24,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     .WithFallback(LeaseProvider.DefaultConfig())
                 : KubernetesLease.DefaultConfiguration
                     .WithFallback(LeaseProvider.DefaultConfig());
-            return KubernetesSettings.Create(config.GetConfig(KubernetesLease.ConfigPath), TimeoutSettings.Create(config.GetConfig("akka.coordination.lease")));
+            return KubernetesSettings.Create(config.GetConfig(KubernetesLease.ConfigPath).WithFallback(config.GetConfig("akka.coordination.lease")));
         }
         
         [Fact(DisplayName = "default request-timeout should be 2/5 of the lease-operation-timeout")]
@@ -51,7 +51,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
         }
 
         [Fact(DisplayName =
-            "Kubernetes settings should not allow server request timeout greater than operation timeout")]
+            "Kubernetes settings should not allow service request timeout greater than operation timeout")]
         public void InvalidServerRequestTimeout()
         {
             Assert.Throws<ConfigurationException>(() =>
@@ -59,7 +59,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 Conf(@"
                     akka.coordination.lease.lease-operation-timeout=5s
                     akka.coordination.lease.kubernetes.api-service-request-timeout=6s");
-            }).Message.Should().Be("'api-service-request-timeout can not be less than 'lease-operation-timeout'");
+            }).Message.Should().Be("'api-service-request-timeout can not be greater than 'lease-operation-timeout'");
         }
 
         [Fact(DisplayName = "KubernetesSettings should contain default values")]

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/AkkaHostingExtensions.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/AkkaHostingExtensions.cs
@@ -21,22 +21,8 @@ namespace Akka.Coordination.KubernetesApi
         /// <param name="builder">
         ///     The builder instance being configured.
         /// </param>
-        /// <returns>
-        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
-        /// </returns>
-        public static AkkaConfigurationBuilder WithKubernetesLease(this AkkaConfigurationBuilder builder)
-            => builder.WithKubernetesLease(null as KubernetesLeaseSetup);
-        
-        /// <summary>
-        ///     Adds Akka.Coordination.KubernetesApi <see cref="Lease"/> support to the <see cref="ActorSystem"/>.
-        ///     Note that this only adds the lease plugin, you will still need to add the services that depends on
-        ///     <see cref="Lease"/> to use this.
-        /// </summary>
-        /// <param name="builder">
-        ///     The builder instance being configured.
-        /// </param>
         /// <param name="configure">
-        ///     An action that modifies an <see cref="KubernetesLeaseSetup"/> instance, used
+        ///     An action that modifies an <see cref="KubernetesLeaseOption"/> instance, used
         ///     to configure Akka.Coordination.KubernetesApi.
         /// </param>
         /// <returns>
@@ -44,12 +30,12 @@ namespace Akka.Coordination.KubernetesApi
         /// </returns>
         public static AkkaConfigurationBuilder WithKubernetesLease(
             this AkkaConfigurationBuilder builder,
-            Action<KubernetesLeaseSetup> configure)
+            Action<KubernetesLeaseOption> configure)
         {
             if (configure == null)
                 throw new ArgumentNullException(nameof(configure));
             
-            var setup = new KubernetesLeaseSetup();
+            var setup = new KubernetesLeaseOption();
             configure(setup);
             return WithKubernetesLease(builder, setup);
         }
@@ -62,20 +48,19 @@ namespace Akka.Coordination.KubernetesApi
         /// <param name="builder">
         ///     The builder instance being configured.
         /// </param>
-        /// <param name="setup">
-        ///     The <see cref="KubernetesLeaseSetup"/> instance used to configure Akka.Discovery.Azure.
+        /// <param name="options">
+        ///     The <see cref="KubernetesLeaseOption"/> instance used to configure Akka.Discovery.Azure.
         /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
         public static AkkaConfigurationBuilder WithKubernetesLease(
             this AkkaConfigurationBuilder builder,
-            KubernetesLeaseSetup? setup)
+            KubernetesLeaseOption? options = null)
         {
+            options?.Apply(builder);
             builder.AddHocon(KubernetesLease.DefaultConfiguration, HoconAddMode.Append);
-            if (setup != null)
-                builder.AddSetup(setup);
-            
+            builder.AddHocon(LeaseProvider.DefaultConfig(), HoconAddMode.Append);
             return builder;
         }
         

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLease.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLease.cs
@@ -29,8 +29,8 @@ namespace Akka.Coordination.KubernetesApi
 
         private static string TruncateTo63Characters(string name) => name.Length > 63 ? name.Substring(0, 63) : name;
 
-        private static readonly Regex Rx1 = new Regex("[_.]");
-        private static readonly Regex Rx2 = new Regex("[^-a-z0-9]");
+        private static readonly Regex Rx1 = new ("[_.]", RegexOptions.Compiled);
+        private static readonly Regex Rx2 = new ("[^-a-z0-9]", RegexOptions.Compiled);
         private static string MakeDns1039Compatible(string name)
         {
             var normalized = name.Normalize(NormalizationForm.FormKD).ToLowerInvariant();
@@ -57,7 +57,7 @@ namespace Akka.Coordination.KubernetesApi
             _settings = settings;
             
             _log = Logging.GetLogger(system, GetType());
-            var kubernetesSettings = KubernetesSettings.Create(system, settings.TimeoutSettings);
+            var kubernetesSettings = KubernetesSettings.Create(system);
 
             var setup = system.Settings.Setup.Get<KubernetesLeaseSetup>();
             if (setup.HasValue)

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLeaseOption.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLeaseOption.cs
@@ -5,8 +5,9 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Text;
 using Akka.Actor.Setup;
-using Akka.Cluster.Hosting.SBR;
+using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Hosting.Coordination;
 
@@ -15,18 +16,54 @@ namespace Akka.Coordination.KubernetesApi
 {
     public class KubernetesLeaseOption: LeaseOptionBase
     {
-        public static readonly KubernetesLeaseOption Instance = new ();
-
-        private KubernetesLeaseOption()
-        {
-        }
+        public string? ApiCaPath { get; set; }
+        public string? ApiTokenPath { get; set; }
+        public string? ApiServiceHostEnvName { get; set; }
+        public string? ApiServicePortEnvName { get; set; }
+        public string? Namespace { get; set; }
+        public string? NamespacePath { get; set; }
+        public TimeSpan? ApiServiceRequestTimeout { get; set; }
+        public bool? SecureApiServer { get; set; }
+        public TimeSpan? HeartbeatInterval { get; set; }
+        public TimeSpan? HeartbeatTimeout { get; set; }
+        public TimeSpan? LeaseOperationTimeout { get; set; }
         
         public override string ConfigPath => KubernetesLease.ConfigPath;
         public override Type Class { get; } = typeof(KubernetesLease);
         
-        public override void Apply(AkkaConfigurationBuilder builder, Setup? setup = null)
+        public override void Apply(AkkaConfigurationBuilder builder, Setup? inputSetup = null)
         {
-            throw new NotImplementedException("Not intended to be applied, use the `WithKubernetesLease()` Akka.Hosting extension method instead.");
+            var sb = new StringBuilder();
+            sb.AppendLine($"{ConfigPath} {{");
+            sb.AppendLine($"lease-class = {Class.AssemblyQualifiedName!.ToHocon()}");
+            if (ApiCaPath is { })
+                sb.AppendLine($"api-ca-path = {ApiCaPath.ToHocon()}");
+            if (ApiTokenPath is { })
+                sb.AppendLine($"api-token-path = {ApiTokenPath.ToHocon()}");
+            if (ApiServiceHostEnvName is { })
+                sb.AppendLine($"api-service-host-env-name = {ApiServiceHostEnvName.ToHocon()}");
+            if (ApiServicePortEnvName is { })
+                sb.AppendLine($"api-service-port-env-name = {ApiServicePortEnvName.ToHocon()}");
+            if (NamespacePath is { })
+                sb.AppendLine($"namespace-path = {NamespacePath.ToHocon()}");
+            if (Namespace is { })
+                sb.AppendLine($"namespace = {Namespace.ToHocon()}");
+            if (ApiServiceRequestTimeout is { })
+                sb.AppendLine($"api-service-request-timeout = {ApiServiceRequestTimeout.ToHocon()}");
+            if (SecureApiServer is { })
+                sb.AppendLine($"secure-api-server = {SecureApiServer.ToHocon()}");
+            if (HeartbeatInterval is { })
+                sb.AppendLine($"heartbeat-interval = {HeartbeatInterval.ToHocon()}");
+            if (HeartbeatTimeout is { })
+                sb.AppendLine($"heartbeat-timeout = {HeartbeatTimeout.ToHocon()}");
+            if (LeaseOperationTimeout is { })
+                sb.AppendLine($"lease-operation-timeout = {LeaseOperationTimeout.ToHocon()}");
+            sb.AppendLine("}");
+
+            //var config = ConfigurationFactory.ParseString(sb.ToString())
+            //    .WithFallback(LeaseProvider.DefaultConfig().GetConfig("akka.coordination.lease"));
+
+            builder.AddHocon(sb.ToString(), HoconAddMode.Prepend);
         }
     }
 }

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/reference.conf
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/reference.conf
@@ -18,15 +18,19 @@ akka.coordination.lease.kubernetes {
     namespace = "<namespace>"
 
     # How often to write time into CRD so that if the holder crashes
-    # another node can take the lease after a given timeout. If left blank then the default is
-    # max(5s, heartbeat-timeout / 10) which will be 12s with the default heartbeat-timeout
-    heartbeat-interval = ""
+    # another node can take the lease after a given timeout. Will never be smaller than 5 seconds.
+    # A good value to use is between 5 seconds and (heartbeat-timeout / 10) seconds.
+    # If uncommented, will override the default global value `akka.coordination.lease.heartbeat-interval`
+    #
+    # heartbeat-interval = 12s
 
     # How long a lease must not be updated before another node can assume
     # the holder has crashed.
     # If the lease holder hasn't crashed its next heart beat will fail due to the version
     # having been updated
-    heartbeat-timeout = 120s
+    # If uncommented, will override the default global value `akka.coordination.lease.heartbeat-timeout`
+    #
+    # heartbeat-timeout = 120s
 
     # The individual timeout for each HTTP request. Defaults to 2/5 of the lease-operation-timeout
     # Can't be greater than then lease-operation-timeout
@@ -39,7 +43,7 @@ akka.coordination.lease.kubernetes {
     # The amount of time to wait for a lease to be aquired or released. This includes all requests to the API
     # server that are required. If this timeout is hit then the lease *may* be taken due to the response being lost
     # on the way back from the API server but will be reported as not taken and can be safely retried.
-    
-    # CURRENTLY BEING IGNORED. Use 'akka.coordination.lease.lease-operation-timeout' instead.
+    # If uncommented, will override the default global value `akka.coordination.lease.lease-operation-timeout`
+    #
     # lease-operation-timeout = 5s
 }


### PR DESCRIPTION
## Changes
- Hosting extension accepts KubernetesLeaseOption instead of KubernetesLeaseSetup
- Settings are applied via injected HOCON settings instead of being injected via setup
- Add a more comprehensive setting unit tests
- Hocon settings fixes