### PR TITLE
Change Azure lease hosting extensions to use options class instead of setup

### DIFF
--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/AkkaHostingSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/AkkaHostingSpec.cs
@@ -50,7 +50,7 @@ namespace Akka.Coordination.Azure.Tests
         {
             var builder = new AkkaConfigurationBuilder(new ServiceCollection(), "test");
             
-            builder.WithAzureLease(new AzureLeaseSetup
+            builder.WithAzureLease(new AzureLeaseOption
             {
                 ContainerName = "underTest"
             });

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureLeaseSettingsSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureLeaseSettingsSpec.cs
@@ -101,14 +101,13 @@ namespace Akka.Coordination.Azure.Tests
                 .WithConnectionString("a")
                 .WithContainerName("b")
                 .WithApiServiceRequestTimeout(11.Seconds())
-                .WithBodyReadTimeout(12.Seconds())
                 .WithAzureCredential(cred, uri)
                 .WithBlobClientOption(opt);
             
             settings.ConnectionString.Should().Be("a");
             settings.ContainerName.Should().Be("b");
             settings.ApiServiceRequestTimeout.Should().Be(11.Seconds());
-            settings.BodyReadTimeout.Should().Be(12.Seconds()); 
+            settings.BodyReadTimeout.Should().Be(5.5.Seconds()); 
             settings.ServiceEndpoint.Should().Be(uri);
             settings.AzureCredential.Should().Be(cred); 
             settings.BlobClientOptions.Should().Be(opt);
@@ -126,17 +125,16 @@ namespace Akka.Coordination.Azure.Tests
                 ConnectionString = "a",
                 ContainerName = "b",
                 ApiServiceRequestTimeout = 11.Seconds(),
-                BodyReadTimeout = 12.Seconds(),
                 ServiceEndpoint = uri,
                 AzureCredential = cred,
                 BlobClientOptions = opt
             };
             
-            var settings = setup.Apply(AzureLeaseSettings.Empty, null);
+            var settings = setup.Apply(AzureLeaseSettings.Empty, null!);
             settings.ConnectionString.Should().Be("a");
             settings.ContainerName.Should().Be("b");
             settings.ApiServiceRequestTimeout.Should().Be(11.Seconds());
-            settings.BodyReadTimeout.Should().Be(12.Seconds()); 
+            settings.BodyReadTimeout.Should().Be(5.5.Seconds()); 
             settings.ServiceEndpoint.Should().Be(uri);
             settings.AzureCredential.Should().Be(cred); 
             settings.BlobClientOptions.Should().Be(opt);

--- a/src/coordination/azure/Akka.Coordination.Azure/AkkaHostingExtensions.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/AkkaHostingExtensions.cs
@@ -27,7 +27,7 @@ namespace Akka.Coordination.Azure
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
         public static AkkaConfigurationBuilder WithAzureLease(this AkkaConfigurationBuilder builder, string connectionString)
-            => WithAzureLease(builder, new AzureLeaseSetup{ ConnectionString = connectionString });
+            => WithAzureLease(builder, new AzureLeaseOption{ ConnectionString = connectionString });
         
         /// <summary>
         ///     Adds Akka.Coordination.Azure <see cref="Lease"/> support to the <see cref="ActorSystem"/>.
@@ -46,12 +46,12 @@ namespace Akka.Coordination.Azure
         /// </returns>
         public static AkkaConfigurationBuilder WithAzureLease(
             this AkkaConfigurationBuilder builder,
-            Action<AzureLeaseSetup> configure)
+            Action<AzureLeaseOption> configure)
         {
             if (configure == null)
                 throw new ArgumentNullException(nameof(configure));
             
-            var setup = new AzureLeaseSetup();
+            var setup = new AzureLeaseOption();
             configure(setup);
             return WithAzureLease(builder, setup);
         }
@@ -72,12 +72,10 @@ namespace Akka.Coordination.Azure
         /// </returns>
         public static AkkaConfigurationBuilder WithAzureLease(
             this AkkaConfigurationBuilder builder,
-            AzureLeaseSetup setup)
+            AzureLeaseOption setup)
         {
+            setup.Apply(builder);
             builder.AddHocon(AzureLease.DefaultConfiguration, HoconAddMode.Append);
-            if (setup != null)
-                builder.AddSetup(setup);
-            
             return builder;
         }
         

--- a/src/coordination/azure/Akka.Coordination.Azure/AzureLeaseOption.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/AzureLeaseOption.cs
@@ -6,27 +6,68 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Text;
 using Akka.Actor.Setup;
 using Akka.Cluster.Hosting.SBR;
+using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Hosting.Coordination;
+using Azure.Core;
+using Azure.Storage.Blobs;
 
 namespace Akka.Coordination.Azure
 {
     public class AzureLeaseOption: LeaseOptionBase
     {
-        public static readonly AzureLeaseOption Instance = new ();
+        public string? ConnectionString { get; set; }
+        public string? ContainerName { get; set; }
+        public TimeSpan? ApiServiceRequestTimeout { get; set; }
+        public Uri? ServiceEndpoint { get; set; }
+        public TokenCredential? AzureCredential { get; set; }
+        public BlobClientOptions? BlobClientOptions { get; set; }
+        public TimeSpan? HeartbeatInterval { get; set; }
+        public TimeSpan? HeartbeatTimeout { get; set; }
+        public TimeSpan? LeaseOperationTimeout { get; set; }
 
-        private AzureLeaseOption()
-        {
-        }
-        
         public override string ConfigPath { get; } = "akka.coordination.lease.azure";
         public override Type Class { get; } = typeof(AzureLease);
         
-        public override void Apply(AkkaConfigurationBuilder builder, Setup? setup = null)
+        public override void Apply(AkkaConfigurationBuilder builder, Setup? s = null)
         {
-            throw new NotImplementedException("Not intended to be applied, use the `WithAzureLease()` Akka.Hosting extension method instead.");
+            var sb = new StringBuilder();
+            sb.AppendLine($"{ConfigPath} {{");
+            sb.AppendLine($"lease-class = {Class.AssemblyQualifiedName!.ToHocon()}");
+            if (ConnectionString is { })
+                sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
+            if (ContainerName is { })
+                sb.AppendLine($"container-name = {ContainerName.ToHocon()}");
+            if (ApiServiceRequestTimeout is { })
+                sb.AppendLine($"api-service-request-timeout = {ApiServiceRequestTimeout.ToHocon()}");
+            if (HeartbeatInterval is { })
+                sb.AppendLine($"heartbeat-interval = {HeartbeatInterval.ToHocon()}");
+            if (HeartbeatTimeout is { })
+                sb.AppendLine($"heartbeat-timeout = {HeartbeatTimeout.ToHocon()}");
+            if (LeaseOperationTimeout is { })
+                sb.AppendLine($"lease-operation-timeout = {LeaseOperationTimeout.ToHocon()}");
+            sb.AppendLine("}");
+
+            if ((ServiceEndpoint is { } && AzureCredential is null) ||
+                (ServiceEndpoint is null && AzureCredential is { }))
+                throw new ConfigurationException("To use AzureCredential, both AzureCredential and ServiceEndpoint need to be populated.");
+
+            builder.AddHocon(sb.ToString(), HoconAddMode.Prepend);
+
+            var setup = new AzureLeaseSetup
+            {
+                AzureCredential = AzureCredential,
+                ServiceEndpoint = ServiceEndpoint,
+                BlobClientOptions = BlobClientOptions,
+                ApiServiceRequestTimeout = ApiServiceRequestTimeout,
+                ConnectionString = ConnectionString,
+                ContainerName = ContainerName
+            };
+
+            builder.AddSetup(setup);
         }
     }
 }

--- a/src/coordination/azure/Akka.Coordination.Azure/AzureLeaseSettings.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/AzureLeaseSettings.cs
@@ -50,19 +50,19 @@ namespace Akka.Coordination.Azure
             var config = rootConfig.GetConfig(AzureLease.ConfigPath);
             
             var requestTimeoutValue = config.GetStringIfDefined("api-service-request-timeout");
-            var apiServerRequestTimeout = !string.IsNullOrWhiteSpace(requestTimeoutValue)
+            var apiServiceRequestTimeout = !string.IsNullOrWhiteSpace(requestTimeoutValue)
                 ? config.GetTimeSpan("api-service-request-timeout")
                 : new TimeSpan(leaseTimeoutSettings.OperationTimeout.Ticks * 2 / 5);  // 2/5 gives two API operations + a buffer
 
-            if (apiServerRequestTimeout >= leaseTimeoutSettings.OperationTimeout)
+            if (apiServiceRequestTimeout >= leaseTimeoutSettings.OperationTimeout)
                 throw new ConfigurationException(
                     "'api-service-request-timeout can not be less than 'akka.coordination.lease.lease-operation-timeout'");
             
             return new AzureLeaseSettings(
                 connectionString: config.GetStringIfDefined("connection-string"),
                 containerName: config.GetStringIfDefined("container-name"),
-                apiServiceRequestTimeout: apiServerRequestTimeout,
-                bodyReadTimeout: new TimeSpan(apiServerRequestTimeout.Ticks / 2),
+                apiServiceRequestTimeout: apiServiceRequestTimeout,
+                bodyReadTimeout: new TimeSpan(apiServiceRequestTimeout.Ticks / 2),
                 serviceEndpoint: null,
                 azureCredential: null,
                 blobClientOptions: null
@@ -82,9 +82,9 @@ namespace Akka.Coordination.Azure
         public AzureLeaseSettings WithContainerName(string containerName)
             => Copy(containerName: containerName);
         public AzureLeaseSettings WithApiServiceRequestTimeout(TimeSpan apiServiceRequestTimeout)
-            => Copy(apiServiceRequestTimeout: apiServiceRequestTimeout);
-        public AzureLeaseSettings WithBodyReadTimeout(TimeSpan bodyReadTimeout)
-            => Copy(bodyReadTimeout: bodyReadTimeout);
+            => Copy(
+                apiServiceRequestTimeout: apiServiceRequestTimeout,
+                bodyReadTimeout: new TimeSpan(apiServiceRequestTimeout.Ticks / 2));
         public AzureLeaseSettings WithAzureCredential(TokenCredential azureCredential, Uri serviceEndpoint)
         {
             if (azureCredential is null)

--- a/src/coordination/azure/Akka.Coordination.Azure/AzureLeaseSetup.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/AzureLeaseSetup.cs
@@ -20,12 +20,11 @@ namespace Akka.Coordination.Azure
         public string? ConnectionString { get; set; }
         public string? ContainerName { get; set; }
         public TimeSpan? ApiServiceRequestTimeout { get; set; }
-        public TimeSpan? BodyReadTimeout { get; set; }
         public Uri? ServiceEndpoint { get; set; }
         public TokenCredential? AzureCredential { get; set; }
         public BlobClientOptions? BlobClientOptions { get; set; }
 
-        internal AzureLeaseSettings Apply(AzureLeaseSettings settings, ActorSystem? system)
+        internal AzureLeaseSettings Apply(AzureLeaseSettings settings, ActorSystem system)
         {
             if (ConnectionString is { })
                 settings = settings.WithConnectionString(ConnectionString);
@@ -36,19 +35,13 @@ namespace Akka.Coordination.Azure
             if (ApiServiceRequestTimeout is { })
                 settings = settings.WithApiServiceRequestTimeout(ApiServiceRequestTimeout.Value);
 
-            if (BodyReadTimeout is { })
-                settings = settings.WithBodyReadTimeout(BodyReadTimeout.Value);
-
             if (AzureCredential is { })
             {
                 if(ServiceEndpoint is null)
                 {
-                    if (system is { })
-                    {
-                        var log = Logging.GetLogger(system, this);
-                        log.Error(
-                            "Skipping AzureCredential setup. Both AzureCredential and ServiceEndpoint must be defined.");
-                    }
+                    var log = Logging.GetLogger(system, this);
+                    log.Error(
+                        "Skipping AzureCredential setup. Both AzureCredential and ServiceEndpoint must be defined.");
                 }
                 else
                     settings = settings.WithAzureCredential(AzureCredential, ServiceEndpoint);

--- a/src/coordination/azure/Akka.Coordination.Azure/HoconExtensions.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/HoconExtensions.cs
@@ -1,0 +1,33 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="HoconExtensions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+
+namespace Akka.Coordination.Azure;
+
+// TODO: Remove this extension class when Akka.Hosting version greater than 1.0.0 has been released 
+public static class HoconExtensions
+{
+    private static readonly Regex EscapeRegex = new ("[][$\"\\\\{}:=,#`^?!@*&]{1}", RegexOptions.Compiled);
+        
+    public static string ToHocon(this string? text)
+    {
+        // nullable literal value support
+        if (text is null)
+            return "null";
+
+        // triple double quote multi line support
+        if (text.Contains("\n") && !text.StartsWith("\"\"\"") && !text.EndsWith("\"\"\""))
+            return $"\"\"\"{text}\"\"\"";
+
+        // Not going to bother to check quote validity
+        if (text.Length > 1 && text.StartsWith("\"") && text.EndsWith("\""))
+            return text;
+            
+        // double quote support
+        return text == string.Empty || EscapeRegex.IsMatch(text) ? $"\"{text}\"" : text;
+    }
+}

--- a/src/coordination/examples/azure/Azure.StressTest/Program.cs
+++ b/src/coordination/examples/azure/Azure.StressTest/Program.cs
@@ -10,77 +10,83 @@ namespace Azure.StressTest;
 
 public static class Program
 {
-    public static async Task Main(params string[] args)
+public static async Task Main(params string[] args)
+{
+using var host = new HostBuilder()
+    .ConfigureServices((hostContext, services) =>
     {
-        using var host = new HostBuilder()
-            .ConfigureServices((hostContext, services) =>
-            {
-                services.AddLogging();
-                
-                var systemName = Environment.GetEnvironmentVariable("ACTORSYSTEM")?.Trim() ?? "AkkaService";
-                var ip = Environment.GetEnvironmentVariable("CLUSTER_IP")?.Trim() ?? Dns.GetHostName();
-                services.AddAkka(systemName, (builder, provider) =>
-                {
-                    // Add HOCON configuration from Docker
-                    builder.AddHocon(
-                        ((Config)@"
+        services.AddLogging();
+        
+        var systemName = Environment.GetEnvironmentVariable("ACTORSYSTEM")?.Trim() ?? "AkkaService";
+        var ip = Environment.GetEnvironmentVariable("CLUSTER_IP")?.Trim() ?? Dns.GetHostName();
+
+        var leaseOptions = new AzureLeaseOption
+        {
+            ConnectionString = ConnectionString()
+        };
+        
+        services.AddAkka(systemName, (builder, provider) =>
+        {
+            // Add HOCON configuration from Docker
+            builder.AddHocon(
+                ((Config)@"
 # don't shutdown gracefully if SIGTERM is received
 coordinated-shutdown.run-by-clr-shutdown-hook = off
 coordinated-shutdown.run-by-actor-system-terminate = off")
-                            .BootstrapFromDocker(), 
-                        HoconAddMode.Prepend);
+                    .BootstrapFromDocker(), 
+                HoconAddMode.Prepend);
 
-                    // Add Akka.Remote support.
-                    builder.WithRemoting(hostname: ip, port: 4053);
-                    
-                    // Add Akka.Cluster support
-                    builder.WithClustering(new ClusterOptions
-                        {
-                            Roles = new[] { "cluster" }, 
-                            SplitBrainResolver = new LeaseMajorityOption
-                            {
-                                LeaseImplementation = AzureLeaseOption.Instance
-                            }
-                        });
-
-                    // Add Akka.Management support
-                    builder.WithAkkaManagement(setup =>
+            // Add Akka.Remote support.
+            builder.WithRemoting(hostname: ip, port: 4053);
+            
+            // Add Akka.Coordination.Azure lease support
+            builder.WithAzureLease(setup => { setup.ConnectionString = ConnectionString(); });
+            
+            // Add Akka.Cluster support
+            builder.WithClustering(new ClusterOptions
+                {
+                    Roles = new[] { "cluster" }, 
+                    SplitBrainResolver = new LeaseMajorityOption
                     {
-                        setup.Http.HostName = ip;
-                    });
-                    
-                    // Add Akka.Management.Cluster.Bootstrap support
-                    builder.WithClusterBootstrap(setup =>
-                    {
-                        setup.ContactPointDiscovery.ServiceName = "clusterbootstrap";
-                        setup.ContactPointDiscovery.PortName = "management";
-                    }, autoStart: true);
-
-                    // Add Akka.Discovery.Azure support
-                    builder.WithAzureDiscovery(
-                        connectionString: ConnectionString(),
-                        serviceName: "clusterbootstrap", 
-                        publicHostname: ip);
-                    
-                    // Add Akka.Coordination.Azure lease support
-                    builder.WithAzureLease(setup => { setup.ConnectionString = ConnectionString(); });
-                    
-                    // Add https://cmd.petabridge.com/ for diagnostics
-                    builder.WithPetabridgeCmd("0.0.0.0", 9110, ClusterCommands.Instance, new RemoteCommands(), new TestCommands());
-
-                    // Add start-up code
-                    builder.AddTestActors();
+                        LeaseImplementation = new AzureLeaseOption()
+                    }
                 });
-            })
-            .ConfigureLogging((hostContext, configLogging) =>
-            {
-                configLogging.AddConsole();
-            })
-            .UseConsoleLifetime()
-            .Build();
 
-        await host.RunAsync();
-    }
+            // Add Akka.Management support
+            builder.WithAkkaManagement(setup =>
+            {
+                setup.Http.HostName = ip;
+            });
+            
+            // Add Akka.Management.Cluster.Bootstrap support
+            builder.WithClusterBootstrap(setup =>
+            {
+                setup.ContactPointDiscovery.ServiceName = "clusterbootstrap";
+                setup.ContactPointDiscovery.PortName = "management";
+            }, autoStart: true);
+
+            // Add Akka.Discovery.Azure support
+            builder.WithAzureDiscovery(
+                connectionString: ConnectionString(),
+                serviceName: "clusterbootstrap", 
+                publicHostname: ip);
+            
+            // Add https://cmd.petabridge.com/ for diagnostics
+            builder.WithPetabridgeCmd("0.0.0.0", 9110, ClusterCommands.Instance, new RemoteCommands(), new TestCommands());
+
+            // Add start-up code
+            builder.AddTestActors();
+        });
+    })
+    .ConfigureLogging((hostContext, configLogging) =>
+    {
+        configLogging.AddConsole();
+    })
+    .UseConsoleLifetime()
+    .Build();
+
+await host.RunAsync();
+}
     
     private const string AzuriteConnectionString = 
         "DefaultEndpointsProtocol=http;" +


### PR DESCRIPTION
## Changes

Change `WithAzureLease()` to accept `AzureLeaseOption` instead of `AzureLeaseSetup` to make it consistent with other `Akka.Hosting` extension methods in the ecosystem