### PR TITLE
Add missing Http.Shim package

### DIFF
--- a/src/management/Akka.Http.Shim/Akka.Http.Shim.csproj
+++ b/src/management/Akka.Http.Shim/Akka.Http.Shim.csproj
@@ -5,7 +5,6 @@
     <PackageTags>$(AkkaPackageTags)</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Akka.Http</RootNamespace>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Readding Akka.Http.Shim as a nuget package.
It turns out the dll from a non packable package does not get added automatically to other packages that depends on it. 