### PR TITLE
[Coordination.Azure] Fix lease update and prune bug

### DIFF
--- a/src/discovery/azure/Akka.Discovery.Azure/Actors/HeartbeatActor.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/Actors/HeartbeatActor.cs
@@ -74,7 +74,7 @@ namespace Akka.Discovery.Azure.Actors
                     if(_log.IsDebugEnabled)
                         _log.Debug("Updating cluster member entry TTL");
 
-                    ExecuteUpdateOpWithRetry().PipeTo(Self);
+                    ExecuteUpdateOpWithRetry().PipeTo(Self, success: () => Status.Success.Instance);
                     break;
                 
                 case Status.Success _:
@@ -89,7 +89,7 @@ namespace Akka.Discovery.Azure.Actors
                     }
                     
                     _log.Warning(f.Cause, "Failed to update TTL heartbeat, retrying");
-                    ExecuteUpdateOpWithRetry().PipeTo(Self);
+                    ExecuteUpdateOpWithRetry().PipeTo(Self, success: () => Status.Success.Instance);
                     break;
                 
                 default:

--- a/src/discovery/azure/Akka.Discovery.Azure/Actors/HeartbeatActor.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/Actors/HeartbeatActor.cs
@@ -74,7 +74,7 @@ namespace Akka.Discovery.Azure.Actors
                     if(_log.IsDebugEnabled)
                         _log.Debug("Updating cluster member entry TTL");
 
-                    ExecuteUpdateOpWithRetry().PipeTo(Self, success: () => Status.Success.Instance);
+                    ExecuteUpdateOpWithRetry().PipeTo(Self);
                     break;
                 
                 case Status.Success _:
@@ -89,7 +89,7 @@ namespace Akka.Discovery.Azure.Actors
                     }
                     
                     _log.Warning(f.Cause, "Failed to update TTL heartbeat, retrying");
-                    ExecuteUpdateOpWithRetry().PipeTo(Self, success: () => Status.Success.Instance);
+                    ExecuteUpdateOpWithRetry().PipeTo(Self);
                     break;
                 
                 default:
@@ -99,7 +99,7 @@ namespace Akka.Discovery.Azure.Actors
         }
 
         // Always call this method using PipeTo, we'll be waiting for Status.Success or Status.Failure asynchronously
-        private async Task ExecuteUpdateOpWithRetry()
+        private async Task<Status> ExecuteUpdateOpWithRetry()
         {
             // Calculate backoff
             var backoff = new TimeSpan(_backoff.Ticks * _retryCount++);
@@ -115,6 +115,8 @@ namespace Akka.Discovery.Azure.Actors
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
             cts.CancelAfter(_timeout);
             await _client.UpdateAsync(cts.Token);
+
+            return Status.Success.Instance;
         }
 
         public ITimerScheduler? Timers { get; set; }

--- a/src/discovery/azure/Akka.Discovery.Azure/Actors/PruneActor.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/Actors/PruneActor.cs
@@ -106,7 +106,7 @@ namespace Akka.Discovery.Azure.Actors
                     if (_log.IsDebugEnabled)
                         _log.Debug("Pruning stale cluster member entries");
 
-                    ExecutePruneOpWithRetry().PipeTo(Self);
+                    ExecutePruneOpWithRetry().PipeTo(Self, success: () => Status.Success.Instance);
                     return true;
                 
                 case ClusterEvent.LeaderChanged evt:
@@ -128,7 +128,7 @@ namespace Akka.Discovery.Azure.Actors
                     }
                     
                     _log.Warning(f.Cause, "Failed to prune stale cluster member entries, retrying");
-                    ExecutePruneOpWithRetry().PipeTo(Self);
+                    ExecutePruneOpWithRetry().PipeTo(Self, success: () => Status.Success.Instance);
                     return true;
                 
                 case Status.Success :


### PR DESCRIPTION
Fixes #1251

## Changes

* Force "void" `PipeTo` to return `Status.Success` on successful invocation.