### PR TITLE
Update RELEASE_NOTES.md for 1.5.15 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+#### 1.5.15 January 11 2024 ####
+
+* Update to [Akka.NET v1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.15)
+* Update dependency NuGet package versions to latest versions
+  * [Bump Akka.Hosting to 1.5.15](https://github.com/akkadotnet/Akka.Management/pull/2271)
+  * [Bump AWSSDK.S3 to 3.7.305.9](https://github.com/akkadotnet/Akka.Management/pull/2274)
+  * [Bump AWSSDK.ECS to 3.7.304](https://github.com/akkadotnet/Akka.Management/pull/2275)
+  * [Bump AWSSDK.CludFormation to 3.7.302.21](https://github.com/akkadotnet/Akka.Management/pull/2277)
+  * [Bump AWSSDK.EC2 to 3.7.311](https://github.com/akkadotnet/Akka.Management/pull/2257)
+  * [Bump Google.Protobuf to 3.25.2](https://github.com/akkadotnet/Akka.Management/pull/2264)
+  * [Bump Azure.Storage.Blobs to 12.19.1](https://github.com/akkadotnet/Akka.Management/pull/2171)
+  * [Bump Azure.Identity to 1.10.4](https://github.com/akkadotnet/Akka.Management/pull/2262)
+  * [Bump Azure.Data.Tables to 12.8.2](https://github.com/akkadotnet/Akka.Management/pull/2250)
+
 #### 1.5.7 May 23 2023 ####
 
 * Update to [Akka.NET v1.5.7](https://github.com/akkadotnet/akka.net/releases/tag/1.5.7)
@@ -7,7 +21,7 @@
   * [Bump AWSSDK.S3 to 3.7.104.11](https://github.com/akkadotnet/Akka.Management/pull/1734)
   * [Bump AWSSDK.EC2 to 3.7.135.1](https://github.com/akkadotnet/Akka.Management/pull/1769)
   * [Bump AWSSDK.CludFormation to 3.7.105.25](https://github.com/akkadotnet/Akka.Management/pull/1767)
-  * [Bump AWSSDK.ECS to 5.7.108.7](https://github.com/akkadotnet/Akka.Management/pull/1768)
+  * [Bump AWSSDK.ECS to 3.7.108.7](https://github.com/akkadotnet/Akka.Management/pull/1768)
   * [Bump Google.Protobuf to 3.23.1](https://github.com/akkadotnet/Akka.Management/pull/1755)
   * [Bump Azure.Storage.Blobs to 12.16.0](https://github.com/akkadotnet/Akka.Management/pull/1594)
 


### PR DESCRIPTION
## 1.5.15 January 11 2024

* Update to [Akka.NET v1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.15)
* Update dependency NuGet package versions to latest versions
  * [Bump Akka.Hosting to 1.5.15](https://github.com/akkadotnet/Akka.Management/pull/2271)
  * [Bump AWSSDK.S3 to 3.7.305.9](https://github.com/akkadotnet/Akka.Management/pull/2274)
  * [Bump AWSSDK.ECS to 3.7.304](https://github.com/akkadotnet/Akka.Management/pull/2275)
  * [Bump AWSSDK.CludFormation to 3.7.302.21](https://github.com/akkadotnet/Akka.Management/pull/2277)
  * [Bump AWSSDK.EC2 to 3.7.311](https://github.com/akkadotnet/Akka.Management/pull/2257)
  * [Bump Google.Protobuf to 3.25.2](https://github.com/akkadotnet/Akka.Management/pull/2264)
  * [Bump Azure.Storage.Blobs to 12.19.1](https://github.com/akkadotnet/Akka.Management/pull/2171)
  * [Bump Azure.Identity to 1.10.4](https://github.com/akkadotnet/Akka.Management/pull/2262)
  * [Bump Azure.Data.Tables to 12.8.2](https://github.com/akkadotnet/Akka.Management/pull/2250)