### PR TITLE
Update KubernetesClient to 13.0.26 for net6.0 target

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,7 +35,8 @@ Update all AWSSDK versions</PackageReleaseNotes>
         <AkkaHostingVersion>1.5.17.1</AkkaHostingVersion>
         <PbmVersion>1.4.0</PbmVersion>
         
-        <KubernetesClientVersion>4.0.26</KubernetesClientVersion>
+        <KubernetesClientVersionNetStandard>4.0.26</KubernetesClientVersionNetStandard>
+        <KubernetesClientVersionNet>13.0.26</KubernetesClientVersionNet>
         <MicrosoftExtensionsVersion>[6.0.*,)</MicrosoftExtensionsVersion>
         <AzureIdentityVersion>1.10.4</AzureIdentityVersion>
         <ProtobufVersion>3.25.3</ProtobufVersion>

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/Akka.Coordination.KubernetesApi.Tests.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/Akka.Coordination.KubernetesApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>$(TestsNet)</TargetFramework>
+        <TargetFrameworks>$(TestsNetCoreFramework);$(TestsNet)</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>$(LibraryFramework)</TargetFramework>
+        <TargetFrameworks>$(LibraryFramework);$(NetFramework)</TargetFrameworks>
         <Description>Akka.NET coordination module for Kubernetes</Description>
         <PackageTags>$(AkkaPackageTags);Kubernetes;</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -12,7 +12,14 @@
         <PackageReference Include="Akka.Coordination" Version="$(AkkaVersion)" />
         <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
         <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == '$(LibraryFramework)' ">
+        <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNetStandard)" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFramework)' ">
+        <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNet)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/Akka.Discovery.KubernetesApi.Tests.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/Akka.Discovery.KubernetesApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>$(TestsNet)</TargetFramework>
+        <TargetFrameworks>$(TestsNetCoreFramework);$(TestsNet)</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/KubernetesApiServiceDiscoverySpec.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/KubernetesApiServiceDiscoverySpec.cs
@@ -9,14 +9,17 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Akka.Actor;
 using FluentAssertions;
 using k8s.Models;
-using Microsoft.Rest.Serialization;
 using Xunit;
+
+#if !NET6_0_OR_GREATER
+using Microsoft.Rest.Serialization;
+#else
+using k8s;
+#endif
 
 namespace Akka.Discovery.KubernetesApi.Tests
 {
@@ -246,7 +249,11 @@ namespace Akka.Discovery.KubernetesApi.Tests
         public void IgnoreRunningPodsWhereContainerIsWaiting()
         {
             var json = LoadResource("Akka.Discovery.KubernetesApi.Tests.multi-container-pod.json");
+#if !NET6_0_OR_GREATER
             var podList = SafeJsonConvert.DeserializeObject<V1PodList>(json);
+#else
+            var podList = KubernetesJson.Deserialize<V1PodList>(json);
+#endif
 
             KubernetesApiServiceDiscovery.Targets(
                 podList, 

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>$(LibraryFramework)</TargetFramework>
+        <TargetFrameworks>$(LibraryFramework);$(NetFramework)</TargetFrameworks>
         <Description>Akka.NET discovery module for Kubernetes</Description>
         <PackageTags>$(AkkaPackageTags);Kubernetes;</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,7 +11,14 @@
     <ItemGroup>
         <PackageReference Include="Akka.Discovery" Version="$(AkkaVersion)" />
         <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
+    </ItemGroup>
+    
+    <ItemGroup Condition=" '$(TargetFramework)' == '$(LibraryFramework)' ">
+        <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNetStandard)" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFramework)' ">
+        <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNet)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesApiServiceDiscovery.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesApiServiceDiscovery.cs
@@ -17,8 +17,15 @@ using Akka.Event;
 using k8s;
 using k8s.Authentication;
 using k8s.Models;
-using Microsoft.Rest;
 using Newtonsoft.Json;
+
+#if !NET6_0_OR_GREATER
+using Microsoft.Rest;
+#else
+using System.Runtime.Serialization;
+using k8s.Autorest;
+#endif
+
 
 namespace Akka.Discovery.KubernetesApi
 {
@@ -89,12 +96,20 @@ namespace Akka.Discovery.KubernetesApi
             V1PodList podList;
             try
             {
+#if !NET6_0_OR_GREATER
                 var result = await _client.ListNamespacedPodWithHttpMessagesAsync(
                         namespaceParameter: PodNamespace,
                         labelSelector: labelSelector,
                         cancellationToken: cts.Token)
                     .ConfigureAwait(false);
                 podList = result.Body;
+#else
+                var result = await _client.ListNamespacedPodAsync(
+                    namespaceParameter: PodNamespace,
+                    labelSelector: labelSelector,
+                    cancellationToken: cts.Token);
+                podList = result;
+#endif
             }
             catch (SerializationException e)
             {


### PR DESCRIPTION
Fixes #2349

## Changes

* Dual targetting for netstandard2.0 and net6.0
* Use compiler directives to implement version migration to KubernetesClient net6.0