### PR TITLE
[Discovery.KubernetesApi] add option to query pods in all namespaces

### DIFF
--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/KubernetesDiscoverySettingsSpec.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/KubernetesDiscoverySettingsSpec.cs
@@ -28,6 +28,7 @@ namespace Akka.Discovery.KubernetesApi.Tests
             settings.ApiServicePortEnvName.Should().Be("KUBERNETES_SERVICE_PORT");
             settings.PodNamespacePath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/namespace");
             settings.PodNamespace.Should().BeNull();
+            settings.AllNamespaces.Should().BeFalse();
             settings.PodDomain.Should().Be("cluster.local");
             settings.PodLabelSelector("a").Should().Be("app=a");
             settings.RawIp.Should().BeTrue();
@@ -47,6 +48,7 @@ namespace Akka.Discovery.KubernetesApi.Tests
             empty.ApiServicePortEnvName.Should().Be(settings.ApiServicePortEnvName);
             empty.PodNamespacePath.Should().Be(settings.PodNamespacePath);
             empty.PodNamespace.Should().Be(settings.PodNamespace);
+            empty.AllNamespaces.Should().Be(settings.AllNamespaces);
             empty.PodDomain.Should().Be(settings.PodDomain);
             empty.PodLabelSelector("a").Should().Be(settings.PodLabelSelector("a"));
             empty.RawIp.Should().Be(settings.RawIp);
@@ -63,6 +65,7 @@ namespace Akka.Discovery.KubernetesApi.Tests
                 .WithApiServicePortEnvName("d")
                 .WithPodNamespacePath("e")
                 .WithPodNamespace("f")
+                .WithAllNamespaces(true)
                 .WithPodDomain("g")
                 .WithPodLabelSelector("h={0}")
                 .WithRawIp(false)
@@ -74,6 +77,7 @@ namespace Akka.Discovery.KubernetesApi.Tests
             settings.ApiServicePortEnvName.Should().Be("d");
             settings.PodNamespacePath.Should().Be("e");
             settings.PodNamespace.Should().Be("f");
+            settings.AllNamespaces.Should().BeTrue();
             settings.PodDomain.Should().Be("g");
             settings.PodLabelSelector("a").Should().Be("h=a");
             settings.RawIp.Should().BeFalse();
@@ -91,6 +95,7 @@ namespace Akka.Discovery.KubernetesApi.Tests
                 ApiServicePortEnvName  = "d",
                 PodNamespacePath  = "e",
                 PodNamespace  = "f",
+                AllNamespaces = true,
                 PodDomain  = "g",
                 PodLabelSelector  = "h={0}",
                 RawIp  = false,
@@ -104,6 +109,7 @@ namespace Akka.Discovery.KubernetesApi.Tests
             settings.ApiServicePortEnvName.Should().Be("d");
             settings.PodNamespacePath.Should().Be("e");
             settings.PodNamespace.Should().Be("f");
+            settings.AllNamespaces.Should().BeTrue();
             settings.PodDomain.Should().Be("g");
             settings.PodLabelSelector("a").Should().Be("h=a");
             settings.RawIp.Should().BeFalse();
@@ -122,6 +128,7 @@ namespace Akka.Discovery.KubernetesApi.Tests
                     ApiServicePortEnvName = "d",
                     PodNamespacePath = "e",
                     PodNamespace = "f",
+                    AllNamespaces = true,
                     PodDomain = "g",
                     PodLabelSelector = "h={0}",
                     RawIp = false,
@@ -138,6 +145,7 @@ namespace Akka.Discovery.KubernetesApi.Tests
                 settings.ApiServicePortEnvName.Should().Be("d");
                 settings.PodNamespacePath.Should().Be("e");
                 settings.PodNamespace.Should().Be("f");
+                settings.AllNamespaces.Should().BeTrue();
                 settings.PodDomain.Should().Be("g");
                 settings.PodLabelSelector("a").Should().Be("h=a");
                 settings.RawIp.Should().BeFalse();

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesApiServiceDiscovery.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesApiServiceDiscovery.cs
@@ -96,20 +96,10 @@ namespace Akka.Discovery.KubernetesApi
             V1PodList podList;
             try
             {
-#if !NET6_0_OR_GREATER
-                var result = await _client.ListNamespacedPodWithHttpMessagesAsync(
-                        namespaceParameter: PodNamespace,
-                        labelSelector: labelSelector,
-                        cancellationToken: cts.Token)
-                    .ConfigureAwait(false);
-                podList = result.Body;
-#else
-                var result = await _client.ListNamespacedPodAsync(
-                    namespaceParameter: PodNamespace,
-                    labelSelector: labelSelector,
-                    cancellationToken: cts.Token);
-                podList = result;
-#endif
+                if(_settings.AllNamespaces)
+                    podList = await ListPodForAllNamespaces(labelSelector, cts);
+                else
+                    podList = await ListNamespacedPod(labelSelector, cts);
             }
             catch (SerializationException e)
             {
@@ -177,7 +167,45 @@ namespace Akka.Discovery.KubernetesApi
 
             return new Resolved(serviceName: lookup.ServiceName, addresses: addresses);
         }
+
+        private async Task<V1PodList> ListNamespacedPod(string labelSelector, CancellationTokenSource cts)
+        {
+            V1PodList podList;
+#if !NET6_0_OR_GREATER
+            var result = await _client.ListNamespacedPodWithHttpMessagesAsync(
+                namespaceParameter: PodNamespace,
+                labelSelector: labelSelector,
+                cancellationToken: cts.Token)
+                .ConfigureAwait(false);
+            podList = result.Body;
+#else
+            var result = await _client.ListNamespacedPodAsync(
+                namespaceParameter: PodNamespace,
+                labelSelector: labelSelector,
+                cancellationToken: cts.Token);
+            podList = result;
+#endif
+            return podList;
+        }
         
+        private async Task<V1PodList> ListPodForAllNamespaces(string labelSelector, CancellationTokenSource cts)
+        {
+            V1PodList podList;
+#if !NET6_0_OR_GREATER
+            var result = await _client.ListPodForAllNamespacesWithHttpMessagesAsync(
+                labelSelector: labelSelector,
+                cancellationToken: cts.Token)
+                .ConfigureAwait(false);
+            podList = result.Body;
+#else
+            var result = await _client.ListPodForAllNamespacesAsync(
+                labelSelector: labelSelector,
+                cancellationToken: cts.Token);
+            podList = result;
+#endif
+            return podList;
+        }
+
         // This uses blocking IO, and so should only be used to read configuration at startup.
         private string? ReadConfigVarFromFileSystem(string path, string name)
         {

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesApiServiceDiscovery.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesApiServiceDiscovery.cs
@@ -89,8 +89,8 @@ namespace Akka.Discovery.KubernetesApi
             var labelSelector = _settings.PodLabelSelector(lookup.ServiceName);
             
             if(_log.IsInfoEnabled)
-                _log.Info("Querying for pods with label selector: [{0}]. Namespace: [{1}]. Port: [{2}]",
-                    labelSelector, PodNamespace, lookup.PortName);
+                _log.Info("Querying for pods with label selector: [{0}]. Namespace: [{1}]. AllNamespaces: [{2}]. Port: [{3}]",
+                    labelSelector, PodNamespace, _settings.AllNamespaces, lookup.PortName);
 
             var cts = new CancellationTokenSource(resolveTimeout);
             V1PodList podList;

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesDiscoveryOptions.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesDiscoveryOptions.cs
@@ -26,6 +26,7 @@ public class KubernetesDiscoveryOptions: IHoconOption
     public string? ApiServicePortEnvName { get; set; }
     public string? PodNamespacePath { get; set; }
     public string? PodNamespace { get; set; }
+    public bool? AllNamespaces { get; set; }
     public string? PodDomain { get; set; }
     public string? PodLabelSelector { get; set; }
     public bool? RawIp { get; set; }
@@ -49,6 +50,8 @@ public class KubernetesDiscoveryOptions: IHoconOption
             sb.AppendLine($"pod-namespace-path = {PodNamespacePath.ToHocon()}");
         if (PodNamespace is { })
             sb.AppendLine($"pod-namespace = {PodNamespace.ToHocon()}");
+        if (AllNamespaces is { })
+            sb.AppendLine($"all-namespaces = {AllNamespaces.ToHocon()}");
         if (PodDomain is { })
             sb.AppendLine($"pod-domain = {PodDomain.ToHocon()}");
         if (PodLabelSelector is { })

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesDiscoverySettings.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesDiscoverySettings.cs
@@ -25,6 +25,7 @@ namespace Akka.Discovery.KubernetesApi
                 config.GetString("api-service-port-env-name"),
                 config.GetString("pod-namespace-path"),
                 config.GetStringIfDefined("pod-namespace"),
+                config.GetBoolean("all-namespaces"),
                 config.GetString("pod-domain"),
                 config.GetString("pod-label-selector"),
                 config.GetBoolean("use-raw-ip"),
@@ -40,6 +41,7 @@ namespace Akka.Discovery.KubernetesApi
             string apiServicePortEnvName,
             string podNamespacePath,
             string? podNamespace,
+            bool allNamespaces,
             string podDomain,
             string podLabelSelector,
             bool rawIp,
@@ -51,6 +53,7 @@ namespace Akka.Discovery.KubernetesApi
             ApiServicePortEnvName = apiServicePortEnvName;
             PodNamespacePath = podNamespacePath;
             PodNamespace = podNamespace;
+            AllNamespaces = allNamespaces;
             PodDomain = podDomain;
             _podLabelSelector = podLabelSelector;
             RawIp = rawIp;
@@ -63,6 +66,7 @@ namespace Akka.Discovery.KubernetesApi
         public string ApiServicePortEnvName { get; }
         public string PodNamespacePath { get; }
         public string? PodNamespace { get; }
+        public bool AllNamespaces { get; }
         public string PodDomain { get; }
         public string PodLabelSelector(string name)
             => string.Format(_podLabelSelector, name);
@@ -81,6 +85,8 @@ namespace Akka.Discovery.KubernetesApi
             => Copy(podNamespacePath: podNamespacePath);
         public KubernetesDiscoverySettings WithPodNamespace(string podNamespace)
             => Copy(podNamespace: podNamespace);
+        public KubernetesDiscoverySettings WithAllNamespaces(bool allNamespaces)
+            => Copy(allNamespaces: allNamespaces);
         public KubernetesDiscoverySettings WithPodDomain(string podDomain)
             => Copy(podDomain: podDomain);
         public KubernetesDiscoverySettings WithPodLabelSelector(string podLabelSelector)
@@ -97,6 +103,7 @@ namespace Akka.Discovery.KubernetesApi
             string? apiServicePortEnvName = null,
             string? podNamespacePath = null,
             string? podNamespace = null,
+            bool? allNamespaces = null,
             string? podDomain = null,
             string? podLabelSelector = null,
             bool? rawIp = null,
@@ -108,6 +115,7 @@ namespace Akka.Discovery.KubernetesApi
                 apiServicePortEnvName: apiServicePortEnvName ?? ApiServicePortEnvName,
                 podNamespacePath: podNamespacePath ?? PodNamespacePath,
                 podNamespace: podNamespace ?? PodNamespace,
+                allNamespaces: allNamespaces ?? AllNamespaces,
                 podDomain: podDomain ?? PodDomain,
                 podLabelSelector: podLabelSelector ?? _podLabelSelector,
                 rawIp: rawIp ?? RawIp,

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesDiscoverySetup.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesDiscoverySetup.cs
@@ -18,6 +18,7 @@ namespace Akka.Discovery.KubernetesApi
         public string? ApiServicePortEnvName { get; set; }
         public string? PodNamespacePath { get; set; }
         public string? PodNamespace { get; set; }
+        public bool? AllNamespaces { get; set; }
         public string? PodDomain { get; set; }
         public string? PodLabelSelector { get; set; }
         public bool? RawIp { get; set; }
@@ -31,6 +32,7 @@ namespace Akka.Discovery.KubernetesApi
                 apiServicePortEnvName: ApiServicePortEnvName,
                 podNamespacePath: PodNamespacePath,
                 podNamespace: PodNamespace,
+                allNamespaces: AllNamespaces,
                 podDomain: PodDomain,
                 podLabelSelector: PodLabelSelector,
                 rawIp: RawIp,

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/README.md
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/README.md
@@ -62,6 +62,11 @@ akka.discovery.kubernetes-api {
     # Set this value to a specific string to override discovering the namespace using pod-namespace-path.
     pod-namespace = "<pod-namespace>"
 
+    # Enable to query pods in all namespaces
+    #
+    # If this is set to true, the pod-namespace configuration is ignored.
+    all-namespaces = true
+
     # Domain of the k8s cluster
     pod-domain = "cluster.local"
 

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/reference.conf
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/reference.conf
@@ -24,7 +24,12 @@ akka.discovery {
     #
     # Set this value to a specific string to override discovering the namespace using pod-namespace-path.
     pod-namespace = "<pod-namespace>"
-
+    
+    # Enable to query pods in all namespaces
+    #
+    # If this is set to true, the pod-namespace configuration is ignored.
+    all-namespaces = false
+    
     # Domain of the k8s cluster
     pod-domain = "cluster.local"
 


### PR DESCRIPTION
## Changes

Adds a new option to query K8s Pods in all namespaces instead of querying in a specific namespace. It still supports to filter by `podSelector`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
* [x] I have added website (README) documentation for this feature.
