### PR TITLE
Fix Coordination.Kubernetes settings

### DIFF
--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/KubernetesSettingsSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/KubernetesSettingsSpec.cs
@@ -24,7 +24,15 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     .WithFallback(LeaseProvider.DefaultConfig())
                 : KubernetesLease.DefaultConfiguration
                     .WithFallback(LeaseProvider.DefaultConfig());
-            return KubernetesSettings.Create(config.GetConfig(KubernetesLease.ConfigPath).WithFallback(config.GetConfig("akka.coordination.lease")));
+            
+            // NOTE: this is how LeaseSettings is created in Akka.Coordination
+            // https://github.com/akkadotnet/akka.net/blob/f75886921174746cf80244ec18c4e61923725a2d/src/core/Akka.Coordination/LeaseProvider.cs#L127-L131
+            var leaseConfig = config
+                .GetConfig(KubernetesLease.ConfigPath)
+                .WithFallback(config.GetConfig("akka.coordination.lease"));
+
+            var leaseSettings =  LeaseSettings.Create(leaseConfig, "lease-name", "owner-name");
+            return KubernetesSettings.Create(leaseSettings);
         }
         
         [Fact(DisplayName = "default request-timeout should be 2/5 of the lease-operation-timeout")]

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLease.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLease.cs
@@ -57,7 +57,7 @@ namespace Akka.Coordination.KubernetesApi
             _settings = settings;
             
             _log = Logging.GetLogger(system, GetType());
-            var kubernetesSettings = KubernetesSettings.Create(system);
+            var kubernetesSettings = KubernetesSettings.Create(settings);
 
             var setup = system.Settings.Setup.Get<KubernetesLeaseSetup>();
             if (setup.HasValue)

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesSettings.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesSettings.cs
@@ -47,12 +47,10 @@ namespace Akka.Coordination.KubernetesApi
             BodyReadTimeout = bodyReadTimeout ?? TimeSpan.FromSeconds(1);
         }
 
-        public static KubernetesSettings Create(ActorSystem system)
-            => Create(system.Settings.Config.GetConfig(KubernetesLease.ConfigPath));
-        
-        public static KubernetesSettings Create(Config config)
+        public static KubernetesSettings Create(LeaseSettings settings)
         {
-            var leaseTimeoutSettings = TimeoutSettings.Create(config);
+            var config = settings.LeaseConfig;
+            var leaseTimeoutSettings = settings.TimeoutSettings;
             var requestTimeoutValue = config.GetStringIfDefined("api-service-request-timeout");
             var apiServerRequestTimeout = !string.IsNullOrWhiteSpace(requestTimeoutValue)
                 ? config.GetTimeSpan("api-service-request-timeout")


### PR DESCRIPTION
Coordination settings is handled like persistence config where the actual config is composed by the plugin provider and it is a merged config of the actual config and a default config.

`KubernetesSettings` shouldn't base its config on `ActorSystem.Settings`, it should base its config on the `LeaseSettings.LeaseConfig` which is the actual composed config for the lease.