### PR TITLE
Fix CVE-2024-21319 and CVE-2022-26907

### DIFF
--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
@@ -24,6 +24,13 @@
         -->
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.7.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
+
+        <!--
+          These reference is added to resolve CVE-2022-26907 because KubernetesClient 4.0.26 references the bad version
+          of this package. This can be removed if KubernetesClient ever release a clean version in the future (not 
+          likely) or if we drop .NET Standard 2.0 support
+        -->
+        <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFramework)' ">

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
@@ -16,6 +16,14 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == '$(LibraryFramework)' ">
         <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNetStandard)" />
+
+        <!--
+          These reference is added to resolve CVE-2024-21319 because KubernetesClient 4.0.26 references the bad version
+          of this package. This can be removed if KubernetesClient ever release a clean version in the future (not 
+          likely) or if we drop .NET Standard 2.0 support
+        -->
+        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.7.0" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFramework)' ">

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
@@ -15,6 +15,15 @@
     
     <ItemGroup Condition=" '$(TargetFramework)' == '$(LibraryFramework)' ">
         <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNetStandard)" />
+
+        <!--
+          These reference is added to resolve CVE-2024-21319 because KubernetesClient 4.0.26 references the bad version
+          of this package. This can be removed if KubernetesClient ever release a clean version in the future (not 
+          likely) or if we drop .NET Standard 2.0 support
+        -->
+        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.7.0" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
+        <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFramework)' ">

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
@@ -23,7 +23,6 @@
         -->
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.7.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
-        <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFramework)' ">

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
@@ -23,6 +23,13 @@
         -->
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.7.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
+
+        <!--
+          These reference is added to resolve CVE-2022-26907 because KubernetesClient 4.0.26 references the bad version
+          of this package. This can be removed if KubernetesClient ever release a clean version in the future (not 
+          likely) or if we drop .NET Standard 2.0 support
+        -->
+        <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFramework)' ">


### PR DESCRIPTION
CVE-2024-21319 and CVE-2022-26907 only applies to all `KubernetesClient` related projects that targets .NET Standard 2.0. It is very unlikely that there will be any update for this version.

## Changes

Reference clean version of `Microsoft.IdentityModel.JsonWebTokens` and `System.IdentityModel.Tokens.Jwt` directly, only if the project targets netstandard2.0