### PR TITLE
Fix CVE-2018-8292

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,7 +33,7 @@ Update all AWSSDK versions</PackageReleaseNotes>
         
         <AkkaVersion>1.5.24</AkkaVersion>
         <AkkaHostingVersion>1.5.24</AkkaHostingVersion>
-        <PbmVersion>1.4.1</PbmVersion>
+        <PbmVersion>1.4.2</PbmVersion>
         
         <KubernetesClientVersionNetStandard>4.0.26</KubernetesClientVersionNetStandard>
         <KubernetesClientVersionNet>13.0.26</KubernetesClientVersionNet>


### PR DESCRIPTION
Solution is now clean of all CVEs

```
PS D:\git\akkadotnet\Akka.Management> dotnet list package --vulnerable --include-transitive

The following sources were used:
   https://api.nuget.org/v3/index.json

The given project `Akka.Management` has no vulnerable packages given the current sources.
The given project `Akka.Management.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Http.Shim` has no vulnerable packages given the current sources.
The given project `Akka.Discovery.AwsApi` has no vulnerable packages given the current sources.
The given project `Akka.Http.Shim.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Discovery.AwsApi.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Discovery.AwsApi.Integration.Tests` has no vulnerable packages given the current sources.
The given project `StressTest` has no vulnerable packages given the current sources.
The given project `Akka.Discovery.KubernetesApi` has no vulnerable packages given the current sources.
The given project `Akka.Discovery.KubernetesApi.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Coordination.KubernetesApi` has no vulnerable packages given the current sources.
The given project `Akka.Coordination.KubernetesApi.Tests` has no vulnerable packages given the current sources.
The given project `KubernetesCluster` has no vulnerable packages given the current sources.
The given project `Kubernetes.StressTest` has no vulnerable packages given the current sources.
The given project `Akka.Discovery.Azure` has no vulnerable packages given the current sources.
The given project `Akka.Discovery.Azure.Tests` has no vulnerable packages given the current sources.
The given project `AzureCluster` has no vulnerable packages given the current sources.
The given project `Aws.Ecs` has no vulnerable packages given the current sources.
The given project `Akka.Coordination.Azure` has no vulnerable packages given the current sources.
The given project `Akka.Coordination.Azure.Tests` has no vulnerable packages given the current sources.
The given project `Azure.StressTest` has no vulnerable packages given the current sources.
```

## Changes

* Bump PbmVersion to 1.4.2

