### PR TITLE
Update Discovery.Azure to support multi-config

### DIFF
--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/AzureDiscoverySettingsSpecs.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/AzureDiscoverySettingsSpecs.cs
@@ -25,7 +25,8 @@ namespace Akka.Discovery.Azure.Tests
             var assemblyName = typeof(AzureServiceDiscovery).Assembly.FullName!.Split(',')[0].Trim();
             var config = AzureServiceDiscovery.DefaultConfig.GetConfig("akka.discovery.azure");
             config.GetString("class").Should().Be($"{typeof(AzureServiceDiscovery).Namespace}.{nameof(AzureServiceDiscovery)}, {assemblyName}");
-            
+
+            settings.ReadOnly.Should().BeFalse();
             settings.ServiceName.Should().Be("default");
             settings.HostName.Should().Be(Dns.GetHostName());
             settings.Port.Should().Be(8558);
@@ -46,6 +47,7 @@ namespace Akka.Discovery.Azure.Tests
             var settings = AzureDiscoverySettings.Create(AzureServiceDiscovery.DefaultConfig);
             var empty = AzureDiscoverySettings.Empty;
 
+            empty.ReadOnly.Should().Be(settings.ReadOnly);
             empty.ServiceName.Should().Be(settings.ServiceName);
             empty.HostName.Should().Be(settings.HostName);
             empty.Port.Should().Be(settings.Port);
@@ -66,6 +68,7 @@ namespace Akka.Discovery.Azure.Tests
             var uri = new Uri("https://whatever.com");
             var credential = new DefaultAzureCredential();
             var settings = AzureDiscoverySettings.Empty
+                .WithReadOnlyMode(true)
                 .WithServiceName("a")
                 .WithPublicHostName("host")
                 .WithPublicPort(1234)
@@ -76,7 +79,8 @@ namespace Akka.Discovery.Azure.Tests
                 .WithPruneInterval(3.Seconds())
                 .WithOperationTimeout(4.Seconds())
                 .WithAzureCredential(uri, credential);
-            
+
+            settings.ReadOnly.Should().BeTrue();
             settings.ServiceName.Should().Be("a");
             settings.HostName.Should().Be("host");
             settings.Port.Should().Be(1234);
@@ -97,6 +101,7 @@ namespace Akka.Discovery.Azure.Tests
             var uri = new Uri("https://whatever.com");
             var credential = new DefaultAzureCredential();
             var setup = new AzureDiscoverySetup()
+                .WithReadOnlyMode(true)
                 .WithServiceName("a")
                 .WithPublicHostName("host")
                 .WithPublicPort(1234)
@@ -109,7 +114,8 @@ namespace Akka.Discovery.Azure.Tests
                 .WithAzureCredential(uri, credential);
             
             var settings = setup.Apply(AzureDiscoverySettings.Empty);
-            
+
+            settings.ReadOnly.Should().BeTrue();
             settings.ServiceName.Should().Be("a");
             settings.HostName.Should().Be("host");
             settings.Port.Should().Be(1234);

--- a/src/discovery/azure/Akka.Discovery.Azure/AkkaDiscoveryOptions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AkkaDiscoveryOptions.cs
@@ -97,12 +97,12 @@ public class AkkaDiscoveryOptions: IHoconOption
                 builder.AddSetup(setup);
             }
 
-            setup.Setups[ConfigPath] = new AzureDiscoverySetup
+            setup.Add(ConfigPath, new AzureDiscoverySetup
             {
                 AzureCredential = AzureCredential,
                 AzureTableEndpoint = AzureTableEndpoint,
                 TableClientOptions = TableClientOptions
-            };
+            });
         }
         
     }

--- a/src/discovery/azure/Akka.Discovery.Azure/AkkaDiscoveryOptions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AkkaDiscoveryOptions.cs
@@ -16,8 +16,6 @@ namespace Akka.Discovery.Azure;
 
 public class AkkaDiscoveryOptions: IHoconOption
 {
-    private const string DefaultPath = "azure";
-    private string FullPath(string path) => $"akka.discovery.{path}";
     
     public string ConfigPath { get; set; } = "azure";
     public Type Class { get; } = typeof(AzureServiceDiscovery);
@@ -42,7 +40,7 @@ public class AkkaDiscoveryOptions: IHoconOption
     public void Apply(AkkaConfigurationBuilder builder, Setup? inputSetup = null)
     {
         var sb = new StringBuilder();
-        sb.AppendLine($"{FullPath(ConfigPath)} {{");
+        sb.AppendLine($"{AzureServiceDiscovery.FullPath(ConfigPath)} {{");
         sb.AppendLine($"class = {Class.AssemblyQualifiedName!.ToHocon()}");
 
         if (ReadOnly is not null)
@@ -74,8 +72,8 @@ public class AkkaDiscoveryOptions: IHoconOption
         builder.AddHocon(sb.ToString(), HoconAddMode.Prepend);
 
         var fallback = AzureServiceDiscovery.DefaultConfig
-            .GetConfig(FullPath(DefaultPath))
-            .MoveTo(FullPath(ConfigPath));
+            .GetConfig(AzureServiceDiscovery.FullPath(AzureServiceDiscovery.DefaultPath))
+            .MoveTo(AzureServiceDiscovery.FullPath(ConfigPath));
         builder.AddHocon(fallback, HoconAddMode.Append);
 
         if (AzureCredential is { })

--- a/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
@@ -241,6 +241,7 @@ namespace Akka.Discovery.Azure
         {
             options.Apply(builder);
 
+            builder.AddHocon(AzureServiceDiscovery.DefaultConfig, HoconAddMode.Append);
             return builder;
         }
     }

--- a/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
@@ -37,6 +37,16 @@ namespace Akka.Discovery.Azure
         ///     The public port of this node, usually for akka management. It will be used by other nodes to connect
         ///     and query this node. Defaults to 8558
         /// </param>
+        /// <param name="discoveryId">
+        ///     The id name this plugin will use. Defaults to "azure"
+        /// </param>
+        /// <param name="readOnly">
+        ///     When set to true, the plugin will not participate in updating the Azure table and operates in
+        ///     a read-only mode.
+        /// </param>
+        /// <param name="isDefaultPlugin">
+        ///     Mark this plugin as the default plugin to be used by ClusterBootstrap
+        /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
@@ -102,6 +112,16 @@ namespace Akka.Discovery.Azure
         /// <param name="publicPort">
         ///     The public port of this node, usually for akka management. It will be used by other nodes to connect
         ///     and query this node. Defaults to 8558
+        /// </param>
+        /// <param name="discoveryId">
+        ///     The id name this plugin will use. Defaults to "azure"
+        /// </param>
+        /// <param name="readOnly">
+        ///     When set to true, the plugin will not participate in updating the Azure table and operates in
+        ///     a read-only mode.
+        /// </param>
+        /// <param name="isDefaultPlugin">
+        ///     Mark this plugin as the default plugin to be used by ClusterBootstrap
         /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.

--- a/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
@@ -68,7 +68,7 @@ namespace Akka.Discovery.Azure
             string? serviceName = null,
             string? publicHostname = null,
             int? publicPort = null,
-            string discoveryId = "azure",
+            string discoveryId = AzureServiceDiscovery.DefaultPath,
             bool? readOnly = null,
             bool isDefaultPlugin = true)
         {
@@ -149,7 +149,7 @@ namespace Akka.Discovery.Azure
             string? serviceName = null,
             string? publicHostname = null,
             int? publicPort = null,
-            string discoveryId = "azure",
+            string discoveryId = AzureServiceDiscovery.DefaultPath,
             bool? readOnly = null,
             bool isDefaultPlugin = true)
         {

--- a/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
@@ -9,7 +9,6 @@ using System.Net;
 using Akka.Actor;
 using Akka.Hosting;
 using Azure.Data.Tables;
-using Azure.Identity;
 using Azure.Core;
 
 namespace Akka.Discovery.Azure
@@ -58,10 +57,16 @@ namespace Akka.Discovery.Azure
             string connectionString,
             string? serviceName = null,
             string? publicHostname = null,
-            int? publicPort = null)
+            int? publicPort = null,
+            string discoveryId = "azure",
+            bool? readOnly = null,
+            bool isDefaultPlugin = true)
         {
             var options = new AkkaDiscoveryOptions
             {
+                IsDefaultPlugin = isDefaultPlugin,
+                ConfigPath = discoveryId,
+                ReadOnly = readOnly,
                 ConnectionString = connectionString,
                 ServiceName = serviceName,
                 HostName = publicHostname,
@@ -123,11 +128,17 @@ namespace Akka.Discovery.Azure
             TableClientOptions? tableClientOptions = null,
             string? serviceName = null,
             string? publicHostname = null,
-            int? publicPort = null)
+            int? publicPort = null,
+            string discoveryId = "azure",
+            bool? readOnly = null,
+            bool isDefaultPlugin = true)
         {
             if (azureCredential == null) throw new ArgumentNullException(nameof(azureCredential));
             var options = new AkkaDiscoveryOptions
             {
+                IsDefaultPlugin = isDefaultPlugin,
+                ConfigPath = discoveryId,
+                ReadOnly = readOnly,
                 AzureTableEndpoint = azureTableEndpoint,
                 AzureCredential = azureCredential,
                 TableClientOptions = tableClientOptions,
@@ -208,11 +219,7 @@ namespace Akka.Discovery.Azure
             this AkkaConfigurationBuilder builder,
             AkkaDiscoveryOptions options)
         {
-            builder.AddHocon(
-                ((Configuration.Config)"akka.discovery.method = azure").WithFallback(AzureServiceDiscovery.DefaultConfig), 
-                HoconAddMode.Prepend);
             options.Apply(builder);
-            builder.AddHocon(AzureServiceDiscovery.DefaultConfig, HoconAddMode.Append);
 
             return builder;
         }

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoveryMultiSetup.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoveryMultiSetup.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Concurrent;
+using Akka.Actor.Setup;
+
+namespace Akka.Discovery.Azure;
+
+internal sealed class AzureDiscoveryMultiSetup : Setup
+{
+    public ConcurrentDictionary<string, AzureDiscoverySetup> Setups { get; } = new();
+}

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoveryMultiSetup.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoveryMultiSetup.cs
@@ -1,9 +1,19 @@
-﻿using System.Collections.Concurrent;
+﻿using System.Collections.Immutable;
 using Akka.Actor.Setup;
 
 namespace Akka.Discovery.Azure;
 
 internal sealed class AzureDiscoveryMultiSetup : Setup
 {
-    public ConcurrentDictionary<string, AzureDiscoverySetup> Setups { get; } = new();
+    public AzureDiscoveryMultiSetup()
+    {
+        Setups = ImmutableDictionary<string, AzureDiscoverySetup>.Empty;
+    }
+    
+    public ImmutableDictionary<string, AzureDiscoverySetup> Setups { get; private set; }
+
+    public void Add(string path, AzureDiscoverySetup setup)
+    {
+        Setups = Setups.SetItem(path, setup);
+    }
 }

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySettings.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySettings.cs
@@ -31,33 +31,40 @@ namespace Akka.Discovery.Azure
             azureCredential: null,
             tableClientOptions: null);
         
+        // Backward compatibility constructor
         public static AzureDiscoverySettings Create(ActorSystem system)
             => Create(system.Settings.Config);
 
-        public static AzureDiscoverySettings Create(Configuration.Config config)
+        public static AzureDiscoverySettings Create(ActorSystem system, Configuration.Config config)
+            => Create(system.Settings.Config, config);
+
+        // Backward compatibility constructor
+        public static AzureDiscoverySettings Create(Configuration.Config systemConfig)
+            => Create(systemConfig, systemConfig.GetConfig("akka.discovery.azure"));
+        
+        public static AzureDiscoverySettings Create(Configuration.Config systemConfig, Configuration.Config config)
         {
-            var cfg = config.GetConfig("akka.discovery.azure");
-            var host = cfg.GetString("public-hostname");
+            var host = config.GetString("public-hostname");
             if (string.IsNullOrWhiteSpace(host))
             {
-                host = config.GetString("akka.remote.dot-netty.tcp.public-hostname");
+                host = systemConfig.GetString("akka.remote.dot-netty.tcp.public-hostname");
                 if (string.IsNullOrWhiteSpace(host))
                     host = Dns.GetHostName();
             }
             
             return new AzureDiscoverySettings(
-                readOnly: cfg.GetBoolean("read-only"),
-                serviceName: cfg.GetString("service-name"),
+                readOnly: config.GetBoolean("read-only"),
+                serviceName: config.GetString("service-name"),
                 hostName: host,
-                port: cfg.GetInt("public-port"),
-                connectionString: cfg.GetString("connection-string"),
-                tableName: cfg.GetString("table-name"),
-                ttlHeartbeatInterval: cfg.GetTimeSpan("ttl-heartbeat-interval"),
-                staleTtlThreshold: cfg.GetTimeSpan("stale-ttl-threshold"),
-                pruneInterval: cfg.GetTimeSpan("prune-interval"),
-                operationTimeout: cfg.GetTimeSpan("operation-timeout"),
-                retryBackoff: cfg.GetTimeSpan("retry-backoff"),
-                maximumRetryBackoff: cfg.GetTimeSpan("max-retry-backoff"),
+                port: config.GetInt("public-port"),
+                connectionString: config.GetString("connection-string"),
+                tableName: config.GetString("table-name"),
+                ttlHeartbeatInterval: config.GetTimeSpan("ttl-heartbeat-interval"),
+                staleTtlThreshold: config.GetTimeSpan("stale-ttl-threshold"),
+                pruneInterval: config.GetTimeSpan("prune-interval"),
+                operationTimeout: config.GetTimeSpan("operation-timeout"),
+                retryBackoff: config.GetTimeSpan("retry-backoff"),
+                maximumRetryBackoff: config.GetTimeSpan("max-retry-backoff"),
                 azureTableEndpoint: null,
                 azureCredential: null,
                 tableClientOptions: null);

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySettings.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySettings.cs
@@ -15,6 +15,7 @@ namespace Akka.Discovery.Azure
     public sealed class AzureDiscoverySettings
     {
         public static readonly AzureDiscoverySettings Empty = new AzureDiscoverySettings(
+            readOnly: false,
             serviceName: "default",
             hostName: Dns.GetHostName(),
             port: 8558,
@@ -45,6 +46,7 @@ namespace Akka.Discovery.Azure
             }
             
             return new AzureDiscoverySettings(
+                readOnly: cfg.GetBoolean("read-only"),
                 serviceName: cfg.GetString("service-name"),
                 hostName: host,
                 port: cfg.GetInt("public-port"),
@@ -62,6 +64,7 @@ namespace Akka.Discovery.Azure
         }
         
         private AzureDiscoverySettings(
+            bool readOnly,
             string serviceName,
             string hostName,
             int port,
@@ -106,7 +109,8 @@ namespace Akka.Discovery.Azure
             
             if(maximumRetryBackoff < retryBackoff)
                 throw new ArgumentException($"Must be greater than {nameof(retryBackoff)}", nameof(maximumRetryBackoff));
-            
+
+            ReadOnly = readOnly;
             ServiceName = serviceName;
             HostName = hostName;
             Port = port;
@@ -123,6 +127,7 @@ namespace Akka.Discovery.Azure
             TableClientOptions = tableClientOptions;
         }
 
+        public bool ReadOnly { get; }
         public string ServiceName { get; }
         public string HostName { get; }
         public int Port { get; }
@@ -193,8 +198,12 @@ namespace Akka.Discovery.Azure
                 azureTableEndpoint: azureTableEndpoint,
                 credential: credential,
                 tableClientOptions: tableClientOptions);
+
+        public AzureDiscoverySettings WithReadOnlyMode(bool readOnly)
+            => Copy(readOnly: readOnly);
         
         private AzureDiscoverySettings Copy(
+            bool? readOnly = null,
             string? serviceName = null,
             string? host = null,
             int? port = null,
@@ -210,6 +219,7 @@ namespace Akka.Discovery.Azure
             TokenCredential? credential = null,
             TableClientOptions? tableClientOptions = null)
             => new (
+                readOnly: readOnly ?? ReadOnly,
                 serviceName: serviceName ?? ServiceName,
                 hostName: host ?? HostName,
                 port: port ?? Port,

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySettings.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySettings.cs
@@ -40,9 +40,9 @@ namespace Akka.Discovery.Azure
 
         // Backward compatibility constructor
         public static AzureDiscoverySettings Create(Configuration.Config systemConfig)
-            => Create(systemConfig, systemConfig.GetConfig("akka.discovery.azure"));
+            => Create(systemConfig, systemConfig.GetConfig(AzureServiceDiscovery.DefaultConfigPath));
         
-        public static AzureDiscoverySettings Create(Configuration.Config systemConfig, Configuration.Config config)
+        private static AzureDiscoverySettings Create(Configuration.Config systemConfig, Configuration.Config config)
         {
             var host = config.GetString("public-hostname");
             if (string.IsNullOrWhiteSpace(host))

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySetup.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoverySetup.cs
@@ -15,6 +15,7 @@ namespace Akka.Discovery.Azure
 {
     public sealed class AzureDiscoverySetup: Setup
     {
+        public bool? ReadOnly { get; set; }
         public string? ServiceName { get; set; }
         public string? HostName { get; set; }
         public int? Port { get; set; }
@@ -29,6 +30,12 @@ namespace Akka.Discovery.Azure
         public Uri? AzureTableEndpoint { get; set; }
         public TokenCredential? AzureCredential { get; set; }
         public TableClientOptions? TableClientOptions { get; set; }
+        public AzureDiscoverySetup WithReadOnlyMode(bool readOnly)
+        {
+            ReadOnly = readOnly;
+            return this;
+        }
+        
         public AzureDiscoverySetup WithServiceName(string serviceName)
         {
             ServiceName = serviceName;
@@ -104,6 +111,8 @@ namespace Akka.Discovery.Azure
         public override string ToString()
         {
             var props = new List<string>();
+            if(ReadOnly != null)
+                props.Add($"{nameof(ReadOnly)}:{ReadOnly}");
             if(ServiceName != null)
                 props.Add($"{nameof(ServiceName)}:{ServiceName}");
             if(HostName != null)
@@ -138,6 +147,8 @@ namespace Akka.Discovery.Azure
         
         public AzureDiscoverySettings Apply(AzureDiscoverySettings setting)
         {
+            if (ReadOnly != null)
+                setting = setting.WithReadOnlyMode(ReadOnly.Value);
             if (ServiceName != null)
                 setting = setting.WithServiceName(ServiceName);
             if (HostName != null)

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureServiceDiscovery.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureServiceDiscovery.cs
@@ -28,13 +28,19 @@ namespace Akka.Discovery.Azure
 
         private readonly IActorRef _guardianActor;
 
+        // Backward compatibility constructor
         public AzureServiceDiscovery(ExtendedActorSystem system)
+            : this(system, system.Settings.Config.GetConfig("akka.discovery.azure"))
+        {
+        }
+        
+        public AzureServiceDiscovery(ExtendedActorSystem system, Configuration.Config config)
         {
             _system = system;
             _log = Logging.GetLogger(system, typeof(AzureServiceDiscovery));
             
             _system.Settings.InjectTopLevelFallback(DefaultConfig);
-            _settings = AzureDiscoverySettings.Create(system);
+            _settings = AzureDiscoverySettings.Create(system, config);
             
             var setup = _system.Settings.Setup.Get<AzureDiscoverySetup>();
             if (setup.HasValue)

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureServiceDiscovery.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureServiceDiscovery.cs
@@ -19,6 +19,9 @@ namespace Akka.Discovery.Azure
 {
     public class AzureServiceDiscovery : ServiceDiscovery
     {
+        internal const string DefaultPath = "azure";
+        internal const string DefaultConfigPath = "akka.discovery." + DefaultPath;
+        internal static string FullPath(string path) => $"akka.discovery.{path}";
         public static readonly Configuration.Config DefaultConfig = 
             ConfigurationFactory.FromResource<AzureServiceDiscovery>("Akka.Discovery.Azure.reference.conf");
         
@@ -30,7 +33,7 @@ namespace Akka.Discovery.Azure
 
         // Backward compatibility constructor
         public AzureServiceDiscovery(ExtendedActorSystem system)
-            : this(system, system.Settings.Config.GetConfig("akka.discovery.azure"))
+            : this(system, system.Settings.Config.GetConfig(DefaultConfigPath))
         {
         }
         
@@ -39,7 +42,7 @@ namespace Akka.Discovery.Azure
             _system = system;
             _log = Logging.GetLogger(system, typeof(AzureServiceDiscovery));
             
-            var fullConfig = config.WithFallback(DefaultConfig.GetConfig("akka.discovery.azure"));
+            var fullConfig = config.WithFallback(DefaultConfig.GetConfig(DefaultConfigPath));
             _settings = AzureDiscoverySettings.Create(system, fullConfig);
             
             var setup = _system.Settings.Setup.Get<AzureDiscoverySetup>();

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureServiceDiscovery.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureServiceDiscovery.cs
@@ -39,8 +39,8 @@ namespace Akka.Discovery.Azure
             _system = system;
             _log = Logging.GetLogger(system, typeof(AzureServiceDiscovery));
             
-            _system.Settings.InjectTopLevelFallback(DefaultConfig);
-            _settings = AzureDiscoverySettings.Create(system, config);
+            var fullConfig = config.WithFallback(DefaultConfig.GetConfig("akka.discovery.azure"));
+            _settings = AzureDiscoverySettings.Create(system, fullConfig);
             
             var setup = _system.Settings.Setup.Get<AzureDiscoverySetup>();
             if (setup.HasValue)

--- a/src/discovery/azure/Akka.Discovery.Azure/Extensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/Extensions.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using Akka.Configuration.Hocon;
+using Akka.Util.Internal;
+
+namespace Akka.Discovery.Azure;
+
+public static class Extensions
+{
+    public static Configuration.Config MoveTo(this Configuration.Config config, string path)
+    {
+        var rootObj = new HoconObject();
+        var rootValue = new HoconValue();
+        rootValue.Values.Add(rootObj);
+            
+        var lastObject = rootObj;
+
+        var keys = path.SplitDottedPathHonouringQuotes().ToArray();
+        for (var i = 0; i < keys.Length - 1; i++)
+        {
+            var key = keys[i];
+            var innerObject = new HoconObject();
+            var innerValue = new HoconValue();
+            innerValue.Values.Add(innerObject);
+                
+            lastObject.GetOrCreateKey(key);
+            lastObject.Items[key] = innerValue;
+            lastObject = innerObject;
+        }
+        lastObject.Items[keys[keys.Length - 1]] = config.Root;
+            
+        return new Configuration.Config(new HoconRoot(rootValue));
+    }
+}

--- a/src/discovery/azure/Akka.Discovery.Azure/Extensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/Extensions.cs
@@ -6,7 +6,7 @@ namespace Akka.Discovery.Azure;
 
 public static class Extensions
 {
-    public static Configuration.Config MoveTo(this Configuration.Config config, string path)
+    internal static Configuration.Config MoveTo(this Configuration.Config config, string path)
     {
         var rootObj = new HoconObject();
         var rootValue = new HoconValue();

--- a/src/discovery/azure/Akka.Discovery.Azure/reference.conf
+++ b/src/discovery/azure/Akka.Discovery.Azure/reference.conf
@@ -8,6 +8,11 @@ akka.discovery {
   azure {
     class = "Akka.Discovery.Azure.AzureServiceDiscovery, Akka.Discovery.Azure"
 
+    # If set to true, the extension will not participate in updating the Azure table.
+    # Only need to be set to true if the extension is being used by a read only extension 
+    # such as ClusterClient contact discovery.
+    read-only = false
+    
     # The public facing IP/host of this node
     # akka.remote.dot-netty.tcp.public-hostname is used if not overriden or empty.
     # if akka.remote.dot-netty.tcp.public-hostname is empty, Dns.GetHostName is used.


### PR DESCRIPTION
## Changes

* Add ability to make the plugin read-only. A read-only plugin does not participate in updating the Azure table entries.
* Add Akka.Hosting support
* Add multi-config support
  * Make discovery plugin id configurable (was hardcoded)
  * Automatically generate default config fallback for each named discovery id
  * Only plugin with IsDefaultPlugin set to true will be used as `akka.discovery.method` value