### PR TITLE
Update Discovery.KubernetesApi to support multi-config

### DIFF
--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/AkkaHostingExtensions.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/AkkaHostingExtensions.cs
@@ -130,8 +130,6 @@ namespace Akka.Discovery.KubernetesApi
             KubernetesDiscoveryOptions options)
         {
             options.Apply(builder);
-            builder.AddHocon($"akka.discovery.method = {options.ConfigPath}", HoconAddMode.Prepend);
-            builder.AddHocon(KubernetesDiscovery.DefaultConfiguration(), HoconAddMode.Append);
             
             // Force start the module
             builder.AddStartup((system, _) =>

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Extensions.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Extensions.cs
@@ -5,6 +5,10 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Linq;
+using Akka.Configuration.Hocon;
+using Akka.Util.Internal;
+
 namespace Akka.Discovery.KubernetesApi
 {
     internal static class ConfigExtensions
@@ -13,6 +17,31 @@ namespace Akka.Discovery.KubernetesApi
         {
             var value = config.GetString(key);
             return string.IsNullOrWhiteSpace(value) || value.Equals($"<{key}>") ? null : value;
+        }
+        
+        internal static Configuration.Config MoveTo(this Configuration.Config config, string path)
+        {
+            var rootObj = new HoconObject();
+            var rootValue = new HoconValue();
+            rootValue.Values.Add(rootObj);
+
+            var lastObject = rootObj;
+
+            var keys = path.SplitDottedPathHonouringQuotes().ToArray();
+            for (var i = 0; i < keys.Length - 1; i++)
+            {
+                var key = keys[i];
+                var innerObject = new HoconObject();
+                var innerValue = new HoconValue();
+                innerValue.Values.Add(innerObject);
+
+                lastObject.GetOrCreateKey(key);
+                lastObject.Items[key] = innerValue;
+                lastObject = innerObject;
+            }
+            lastObject.Items[keys[keys.Length - 1]] = config.Root;
+
+            return new Configuration.Config(new HoconRoot(rootValue));
         }
     }
 

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesDiscovery.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesDiscovery.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
 using Akka.Configuration;
 
@@ -18,8 +19,10 @@ namespace Akka.Discovery.KubernetesApi
         public static KubernetesDiscovery Get(ActorSystem system)
             => system.WithExtension<KubernetesDiscovery, KubernetesDiscoveryProvider>();
 
+        [Obsolete("The Settings property is now deprecated. Since 1.5.26")]
         public readonly KubernetesDiscoverySettings Settings;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public KubernetesDiscovery(ExtendedActorSystem system)
         {
             system.Settings.InjectTopLevelFallback(DefaultConfiguration());
@@ -29,6 +32,7 @@ namespace Akka.Discovery.KubernetesApi
             if (setup.HasValue)
                 Settings = setup.Value.Apply(Settings);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     public class KubernetesDiscoveryProvider : ExtensionIdProvider<KubernetesDiscovery>

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesDiscoverySettings.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/KubernetesDiscoverySettings.cs
@@ -12,10 +12,10 @@ namespace Akka.Discovery.KubernetesApi
     public sealed class KubernetesDiscoverySettings
     {
         public static readonly KubernetesDiscoverySettings Empty =
-            Create(KubernetesDiscovery.DefaultConfiguration().GetConfig("akka.discovery.kubernetes-api"));
+            Create(KubernetesDiscovery.DefaultConfiguration().GetConfig(KubernetesApiServiceDiscovery.DefaultConfigPath));
         
         public static KubernetesDiscoverySettings Create(ActorSystem system)
-            => Create(system.Settings.Config.GetConfig("akka.discovery.kubernetes-api"));
+            => Create(system.Settings.Config.GetConfig(KubernetesApiServiceDiscovery.DefaultConfigPath));
 
         public static KubernetesDiscoverySettings Create(Configuration.Config config)
             => new (


### PR DESCRIPTION
## Changes

* Add Akka.Hosting support
* Add multi-config support
  * Make discovery plugin id configurable (was hardcoded)
  * Automatically generate default config fallback for each named discovery id
  * Only plugin with IsDefaultPlugin set to true will be used as `akka.discovery.method` value