### PR TITLE
Update probe-interval and stale contact point timeout calculation

### DIFF
--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/ClusterBootstrapSettingsSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/ClusterBootstrapSettingsSpec.cs
@@ -42,8 +42,8 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
             settings.ContactPoint.FallbackPort.Should().BeNull();
             settings.ContactPoint.FilterOnFallbackPort.Should().BeTrue();
             settings.ContactPoint.ProbingFailureTimeout.Should().Be(TimeSpan.FromSeconds(3));
-            settings.ContactPoint.StaleContactPointTimeout.Should().Be(3.Seconds());
-            settings.ContactPoint.ProbeInterval.Should().Be(TimeSpan.FromSeconds(1));
+            settings.ContactPoint.StaleContactPointTimeout.Should().BeNull();
+            settings.ContactPoint.ProbeInterval.Should().Be(TimeSpan.FromSeconds(5));
             settings.ContactPoint.ProbeIntervalJitter.Should().Be(0.2);
             settings.JoinDecider.ImplClass.Should()
                 .Be("Akka.Management.Cluster.Bootstrap.LowestAddressJoinDecider, Akka.Management");
@@ -80,7 +80,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                     FilterOnFallbackPort = false,
                     StaleContactPointTimeout = 1.Seconds(),
                     ProbeInterval = 2.Seconds(),
-                    ProbingFailureTimeout = 3.Seconds(),
+                    ProbingFailureTimeout = 4.Seconds(),
                     ProbeIntervalJitter = 1.0
                 },
                 JoinDecider = new JoinDeciderSetup
@@ -108,7 +108,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
             settings.ContactPoint.FilterOnFallbackPort.Should().BeFalse();
             settings.ContactPoint.StaleContactPointTimeout.Should().Be(1.Seconds());
             settings.ContactPoint.ProbeInterval.Should().Be(2.Seconds());
-            settings.ContactPoint.ProbingFailureTimeout.Should().Be(3.Seconds());
+            settings.ContactPoint.ProbingFailureTimeout.Should().Be(4.Seconds());
             settings.ContactPoint.ProbeIntervalJitter.Should().Be(1.0);
             
             settings.JoinDecider.ImplClass.Should()

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/ClusterBootstrapSettingsSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/ClusterBootstrapSettingsSpec.cs
@@ -42,7 +42,6 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
             settings.ContactPoint.FallbackPort.Should().BeNull();
             settings.ContactPoint.FilterOnFallbackPort.Should().BeTrue();
             settings.ContactPoint.ProbingFailureTimeout.Should().Be(TimeSpan.FromSeconds(3));
-            settings.ContactPoint.StaleContactPointTimeout.Should().BeNull();
             settings.ContactPoint.ProbeInterval.Should().Be(TimeSpan.FromSeconds(5));
             settings.ContactPoint.ProbeIntervalJitter.Should().Be(0.2);
             settings.JoinDecider.ImplClass.Should()
@@ -78,7 +77,6 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                 {
                     FallbackPort = 1234,
                     FilterOnFallbackPort = false,
-                    StaleContactPointTimeout = 1.Seconds(),
                     ProbeInterval = 2.Seconds(),
                     ProbingFailureTimeout = 4.Seconds(),
                     ProbeIntervalJitter = 1.0
@@ -106,7 +104,6 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
 
             settings.ContactPoint.FallbackPort.Should().Be(1234);
             settings.ContactPoint.FilterOnFallbackPort.Should().BeFalse();
-            settings.ContactPoint.StaleContactPointTimeout.Should().Be(1.Seconds());
             settings.ContactPoint.ProbeInterval.Should().Be(2.Seconds());
             settings.ContactPoint.ProbingFailureTimeout.Should().Be(4.Seconds());
             settings.ContactPoint.ProbeIntervalJitter.Should().Be(1.0);

--- a/src/management/Akka.Management/Cluster/Bootstrap/ClusterBootstrapOptions.cs
+++ b/src/management/Akka.Management/Cluster/Bootstrap/ClusterBootstrapOptions.cs
@@ -233,12 +233,6 @@ public sealed class ContactPointOptions
     /// </summary>
     public double? ProbeIntervalJitter { get; set; }
     
-    /// <summary>
-    /// Set the time for bootstrap coordinator to consider that previously discovered contact point
-    /// were considered to be stale and needs to be re-discovered by the HTTP probes.
-    /// </summary>
-    public TimeSpan? StaleContactPointTimeout { get; set; }
-
     internal void Apply(StringBuilder sb)
     {
         sb.AppendLine("contact-point {");
@@ -253,8 +247,6 @@ public sealed class ContactPointOptions
             sb.AppendLine($"probe-interval = {ProbeInterval.ToHocon()}");
         if (ProbeIntervalJitter is { })
             sb.AppendLine($"probe-interval-jitter = {ProbeIntervalJitter.ToHocon()}");
-        if (StaleContactPointTimeout is not null)
-            sb.AppendLine($"stale-contact-point-timeout = {StaleContactPointTimeout.ToHocon()}");
         
         sb.AppendLine("}");
     }

--- a/src/management/Akka.Management/Cluster/Bootstrap/ClusterBootstrapSettings.cs
+++ b/src/management/Akka.Management/Cluster/Bootstrap/ClusterBootstrapSettings.cs
@@ -153,24 +153,12 @@ namespace Akka.Management.Cluster.Bootstrap
                 var fallbackPort = string.IsNullOrWhiteSpace(fallback) || fallback == "<fallback-port>"
                     ? (int?) null : int.Parse(fallback);
                 
-                var probeInterval = contactPointConfig.GetTimeSpan("probe-interval", TimeSpan.FromSeconds(5), false);
-                var probeFailureTimeout = contactPointConfig.GetTimeSpan("probing-failure-timeout", TimeSpan.FromSeconds(3), false);
-                
-                var staleEntryTimeoutStr = contactPointConfig.GetString("stale-contact-point-timeout");
-                var staleEntryTimeout = string.IsNullOrWhiteSpace(staleEntryTimeoutStr)
-                                        || staleEntryTimeoutStr is "off"
-                                        || staleEntryTimeoutStr is "false"
-                                        || staleEntryTimeoutStr is "no"
-                        ? (TimeSpan?) null 
-                        : contactPointConfig.GetTimeSpan("stale-contact-point-timeout");
-                
                 return new ContactPointSettings(
                     fallbackPort: fallbackPort,
                     filterOnFallbackPort: contactPointConfig.GetBoolean("filter-on-fallback-port"),
-                    probingFailureTimeout: probeFailureTimeout,
-                    probeInterval: probeInterval,
-                    probeIntervalJitter: contactPointConfig.GetDouble("probe-interval-jitter"),
-                    staleContactPointTimeout: staleEntryTimeout);
+                    probingFailureTimeout: contactPointConfig.GetTimeSpan("probing-failure-timeout", TimeSpan.FromSeconds(3), false),
+                    probeInterval: contactPointConfig.GetTimeSpan("probe-interval", TimeSpan.FromSeconds(5), false),
+                    probeIntervalJitter: contactPointConfig.GetDouble("probe-interval-jitter"));
             }
             
             private ContactPointSettings(
@@ -178,15 +166,13 @@ namespace Akka.Management.Cluster.Bootstrap
                 bool filterOnFallbackPort,
                 TimeSpan probingFailureTimeout,
                 TimeSpan probeInterval,
-                double probeIntervalJitter,
-                TimeSpan? staleContactPointTimeout)
+                double probeIntervalJitter)
             {
                 FallbackPort = fallbackPort;
                 FilterOnFallbackPort = filterOnFallbackPort;
                 ProbingFailureTimeout = probingFailureTimeout;
                 ProbeInterval = probeInterval;
                 ProbeIntervalJitter = probeIntervalJitter;
-                StaleContactPointTimeout = staleContactPointTimeout;
             }
             
             public int? FallbackPort { get; }
@@ -195,22 +181,19 @@ namespace Akka.Management.Cluster.Bootstrap
             public TimeSpan ProbeInterval { get; }
             public double ProbeIntervalJitter { get; }
             public int MaxSeedNodesToExpose { get; } = 5;
-            public TimeSpan? StaleContactPointTimeout { get; }
 
             internal ContactPointSettings Copy(
                 int? fallbackPort,
                 bool? filterOnFallbackPort,
                 TimeSpan? probingFailureTimeout,
                 TimeSpan? probeInterval,
-                double? probeIntervalJitter,
-                TimeSpan? staleContactPointTimeout)
+                double? probeIntervalJitter)
                 => new ContactPointSettings(
                     fallbackPort: fallbackPort ?? FallbackPort,
                     filterOnFallbackPort: filterOnFallbackPort ?? FilterOnFallbackPort,
                     probingFailureTimeout: probingFailureTimeout ?? ProbingFailureTimeout,
                     probeInterval: probeInterval ?? ProbeInterval,
-                    probeIntervalJitter: probeIntervalJitter ?? ProbeIntervalJitter,
-                    staleContactPointTimeout: staleContactPointTimeout ?? StaleContactPointTimeout);
+                    probeIntervalJitter: probeIntervalJitter ?? ProbeIntervalJitter);
         }
         
         public sealed class JoinDeciderSettings

--- a/src/management/Akka.Management/Cluster/Bootstrap/ClusterBootstrapSettings.cs
+++ b/src/management/Akka.Management/Cluster/Bootstrap/ClusterBootstrapSettings.cs
@@ -152,21 +152,23 @@ namespace Akka.Management.Cluster.Bootstrap
                 var fallback = contactPointConfig.GetString("fallback-port");
                 var fallbackPort = string.IsNullOrWhiteSpace(fallback) || fallback == "<fallback-port>"
                     ? (int?) null : int.Parse(fallback);
-                var probeFailureTimeout = contactPointConfig.GetTimeSpan("probing-failure-timeout", null, false);
+                
+                var probeInterval = contactPointConfig.GetTimeSpan("probe-interval", TimeSpan.FromSeconds(5), false);
+                var probeFailureTimeout = contactPointConfig.GetTimeSpan("probing-failure-timeout", TimeSpan.FromSeconds(3), false);
+                
                 var staleEntryTimeoutStr = contactPointConfig.GetString("stale-contact-point-timeout");
                 var staleEntryTimeout = string.IsNullOrWhiteSpace(staleEntryTimeoutStr)
                                         || staleEntryTimeoutStr is "off"
                                         || staleEntryTimeoutStr is "false"
                                         || staleEntryTimeoutStr is "no"
-                        ? probeFailureTimeout
+                        ? (TimeSpan?) null 
                         : contactPointConfig.GetTimeSpan("stale-contact-point-timeout");
-                                        
                 
                 return new ContactPointSettings(
                     fallbackPort: fallbackPort,
                     filterOnFallbackPort: contactPointConfig.GetBoolean("filter-on-fallback-port"),
                     probingFailureTimeout: probeFailureTimeout,
-                    probeInterval: contactPointConfig.GetTimeSpan("probe-interval", null, false),
+                    probeInterval: probeInterval,
                     probeIntervalJitter: contactPointConfig.GetDouble("probe-interval-jitter"),
                     staleContactPointTimeout: staleEntryTimeout);
             }
@@ -177,7 +179,7 @@ namespace Akka.Management.Cluster.Bootstrap
                 TimeSpan probingFailureTimeout,
                 TimeSpan probeInterval,
                 double probeIntervalJitter,
-                TimeSpan staleContactPointTimeout)
+                TimeSpan? staleContactPointTimeout)
             {
                 FallbackPort = fallbackPort;
                 FilterOnFallbackPort = filterOnFallbackPort;
@@ -193,7 +195,7 @@ namespace Akka.Management.Cluster.Bootstrap
             public TimeSpan ProbeInterval { get; }
             public double ProbeIntervalJitter { get; }
             public int MaxSeedNodesToExpose { get; } = 5;
-            public TimeSpan StaleContactPointTimeout { get; }
+            public TimeSpan? StaleContactPointTimeout { get; }
 
             internal ContactPointSettings Copy(
                 int? fallbackPort,

--- a/src/management/Akka.Management/Cluster/Bootstrap/ClusterBootstrapSetup.cs
+++ b/src/management/Akka.Management/Cluster/Bootstrap/ClusterBootstrapSetup.cs
@@ -201,8 +201,6 @@ namespace Akka.Management.Cluster.Bootstrap
         /// Max amount of jitter to be added on retries
         /// </summary>
         public double? ProbeIntervalJitter { get; set; }
-        
-        public TimeSpan? StaleContactPointTimeout { get; set; }
 
         internal ClusterBootstrapSettings.ContactPointSettings Apply(ClusterBootstrapSettings.ContactPointSettings settings)
             => settings.Copy(
@@ -210,8 +208,7 @@ namespace Akka.Management.Cluster.Bootstrap
                 filterOnFallbackPort: FilterOnFallbackPort,
                 probingFailureTimeout: ProbingFailureTimeout,
                 probeInterval: ProbeInterval,
-                probeIntervalJitter: ProbeIntervalJitter,
-                staleContactPointTimeout: StaleContactPointTimeout);
+                probeIntervalJitter: ProbeIntervalJitter);
     }
     
     public sealed class JoinDeciderSetup

--- a/src/management/Akka.Management/Cluster/Bootstrap/Internal/BootstrapCoordinator.cs
+++ b/src/management/Akka.Management/Cluster/Bootstrap/Internal/BootstrapCoordinator.cs
@@ -162,14 +162,7 @@ namespace Akka.Management.Cluster.Bootstrap.Internal
             _settings = settings;
 
             var cps = _settings.ContactPoint;
-            if(cps.StaleContactPointTimeout is not null)
-            {
-                _staleContactPointTimeout = cps.ProbeInterval + cps.StaleContactPointTimeout.Value;
-            }
-            else
-            {
-                _staleContactPointTimeout = new TimeSpan((cps.ProbeInterval.Ticks + cps.ProbingFailureTimeout.Ticks) * 2);
-            }
+            _staleContactPointTimeout = cps.ProbeInterval + cps.ProbingFailureTimeout;
 
             _log = Context.GetLogger();
             _cluster = Akka.Cluster.Cluster.Get(Context.System);

--- a/src/management/Akka.Management/Cluster/Bootstrap/Internal/BootstrapCoordinator.cs
+++ b/src/management/Akka.Management/Cluster/Bootstrap/Internal/BootstrapCoordinator.cs
@@ -160,7 +160,16 @@ namespace Akka.Management.Cluster.Bootstrap.Internal
             _discovery = discovery;
             _joinDecider = joinDecider;
             _settings = settings;
-            _staleContactPointTimeout = _settings.ContactPoint.ProbeInterval + _settings.ContactPoint.StaleContactPointTimeout;
+
+            var cps = _settings.ContactPoint;
+            if(cps.StaleContactPointTimeout is not null)
+            {
+                _staleContactPointTimeout = cps.ProbeInterval + cps.StaleContactPointTimeout.Value;
+            }
+            else
+            {
+                _staleContactPointTimeout = new TimeSpan((cps.ProbeInterval.Ticks + cps.ProbingFailureTimeout.Ticks) * 2);
+            }
 
             _log = Context.GetLogger();
             _cluster = Akka.Cluster.Cluster.Get(Context.System);

--- a/src/management/Akka.Management/Resources/reference.conf
+++ b/src/management/Akka.Management/Resources/reference.conf
@@ -178,17 +178,6 @@ akka.management {
       # probe-interval + probing-failure-timeout, or 8 seconds by default
       probing-failure-timeout = 3s
       
-      # Set the time for bootstrap coordinator to consider that previously discovered contact point
-      # were considered to be stale and needs to be re-discovered by the HTTP probes.
-      #
-      # The legacy value for this is equals to the value of `probing-failure-timeout`. This is the value
-      # that will be used if `stale-contact-point-timeout` is set to `off`, `false`, `no`, or empty.
-      #
-      # Note that the effective final value being used to calculate stale contact point timeout is 
-      # probe-interval + stale-contact-point-timeout if this setting is set, 
-      # or ( probe-interval + probing-failure-timeout ) * 2 if this setting is not set.
-      stale-contact-point-timeout = off
-  
       # Interval at which contact points should be polled
       # the effective interval used is this value plus the same value multiplied by the jitter value
       probe-interval = 5s

--- a/src/management/Akka.Management/Resources/reference.conf
+++ b/src/management/Akka.Management/Resources/reference.conf
@@ -175,7 +175,7 @@ akka.management {
       # it will initiate rediscovery again instead of keep trying.
       #
       # Note that the effective final value being used to calculate probing timeout is 
-      # probe-interval + probing-failure-timeout, or 4 seconds by default
+      # probe-interval + probing-failure-timeout, or 8 seconds by default
       probing-failure-timeout = 3s
       
       # Set the time for bootstrap coordinator to consider that previously discovered contact point
@@ -186,12 +186,12 @@ akka.management {
       #
       # Note that the effective final value being used to calculate stale contact point timeout is 
       # probe-interval + stale-contact-point-timeout if this setting is set, 
-      # or probe-interval + probing-failure-timeout if this setting is not set.
+      # or ( probe-interval + probing-failure-timeout ) * 2 if this setting is not set.
       stale-contact-point-timeout = off
   
       # Interval at which contact points should be polled
       # the effective interval used is this value plus the same value multiplied by the jitter value
-      probe-interval = 1s
+      probe-interval = 5s
   
       # Max amount of jitter to be added on retries
       probe-interval-jitter = 0.2


### PR DESCRIPTION
Fixes #2571

## Changes

* Change probe-interval default value to 5s
* Move all effective value calculation out of the settings file
* Removed `stale-contact-point-timeout` HOCON setting
* Change calculation for stale contact point timeout inside `BootstrapCoordinator` to `( ProbeInterval + ProbeFailureTimeout )`, it was `ProbeFailureTimeout` before.