### PR TITLE
Add ClusterClientReceptionist actor path and Remote address endpoint

### DIFF
--- a/src/management/Akka.Management.Tests/AkkaManagementSettingsSpec.cs
+++ b/src/management/Akka.Management.Tests/AkkaManagementSettingsSpec.cs
@@ -39,9 +39,17 @@ namespace Akka.Management.Tests
             http.EffectiveBindHostname.Should().Be(defaultHostname);
             http.EffectiveBindPort.Should().Be(8558);
             http.BasePath.Should().BeEmpty();
-            http.RouteProviders.Count.Should().Be(1);
+            http.RouteProviders.Count.Should().Be(3);
+            
             http.RouteProviders[0].Name.Should().Be("cluster-bootstrap");
             http.RouteProviders[0].FullyQualifiedClassName.Should().Be("Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management");
+            
+            http.RouteProviders[1].Name.Should().Be("remote-address");
+            http.RouteProviders[1].FullyQualifiedClassName.Should().Be("Akka.Management.Routes.AddressRouteProvider, Akka.Management");
+            
+            http.RouteProviders[2].Name.Should().Be("cluster-client-receptionist");
+            http.RouteProviders[2].FullyQualifiedClassName.Should().Be("Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management");
+            
             http.RouteProvidersReadOnly.Should().BeTrue();
         }
 
@@ -64,9 +72,17 @@ namespace Akka.Management.Tests
             http.EffectiveBindHostname.Should().Be(defaultHostname);
             http.EffectiveBindPort.Should().Be(8558);
             http.BasePath.Should().BeEmpty();
-            http.RouteProviders.Count.Should().Be(1);
+            http.RouteProviders.Count.Should().Be(3);
+            
             http.RouteProviders[0].Name.Should().Be("cluster-bootstrap");
             http.RouteProviders[0].FullyQualifiedClassName.Should().Be("Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management");
+            
+            http.RouteProviders[1].Name.Should().Be("remote-address");
+            http.RouteProviders[1].FullyQualifiedClassName.Should().Be("Akka.Management.Routes.AddressRouteProvider, Akka.Management");
+            
+            http.RouteProviders[2].Name.Should().Be("cluster-client-receptionist");
+            http.RouteProviders[2].FullyQualifiedClassName.Should().Be("Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management");
+            
             http.RouteProvidersReadOnly.Should().BeTrue();
         }
         
@@ -91,10 +107,14 @@ namespace Akka.Management.Tests
             http.EffectiveBindHostname.Should().Be("b");
             http.EffectiveBindPort.Should().Be(1235);
             http.BasePath.Should().Be("c");
-            http.RouteProviders.Count.Should().Be(2);
+            http.RouteProviders.Count.Should().Be(4);
             http.RouteProviders[0].Should()
                 .BeEquivalentTo(new NamedRouteProvider("cluster-bootstrap", "Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management"));
             http.RouteProviders[1].Should()
+                .BeEquivalentTo(new NamedRouteProvider("remote-address", "Akka.Management.Routes.AddressRouteProvider, Akka.Management"));
+            http.RouteProviders[2].Should()
+                .BeEquivalentTo(new NamedRouteProvider("cluster-client-receptionist", "Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management"));
+            http.RouteProviders[3].Should()
                 .BeEquivalentTo(new NamedRouteProvider("test", typeof(FakeRouteProvider).AssemblyQualifiedName));
             http.RouteProvidersReadOnly.Should().BeFalse();
         }
@@ -124,10 +144,14 @@ namespace Akka.Management.Tests
             http.EffectiveBindHostname.Should().Be("b");
             http.EffectiveBindPort.Should().Be(1235);
             http.BasePath.Should().Be("c");
-            http.RouteProviders.Count.Should().Be(2);
+            http.RouteProviders.Count.Should().Be(4);
             http.RouteProviders[0].Should()
                 .BeEquivalentTo(new NamedRouteProvider("cluster-bootstrap", "Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management"));
             http.RouteProviders[1].Should()
+                .BeEquivalentTo(new NamedRouteProvider("remote-address", "Akka.Management.Routes.AddressRouteProvider, Akka.Management"));
+            http.RouteProviders[2].Should()
+                .BeEquivalentTo(new NamedRouteProvider("cluster-client-receptionist", "Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management"));
+            http.RouteProviders[3].Should()
                 .BeEquivalentTo(new NamedRouteProvider("test", typeof(FakeRouteProvider).AssemblyQualifiedName));
             http.RouteProvidersReadOnly.Should().BeFalse();
         }

--- a/src/management/Akka.Management/Resources/reference.conf
+++ b/src/management/Akka.Management/Resources/reference.conf
@@ -59,6 +59,10 @@ akka.management {
     routes {
         # registers bootstrap routes to be included in akka-management's http endpoint
         cluster-bootstrap = "Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management"
+        # register remoting address routes to be included in akka-management's http endpoint
+        remote-address = "Akka.Management.Routes.AddressRouteProvider, Akka.Management"
+        # register ClusterClientReceptionist actor path routes to be included in akka-management's http endpoint
+        cluster-client-receptionist = "Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management"
     }
 
     # Should Management route providers only expose read only endpoints? It is up to each route provider

--- a/src/management/Akka.Management/Routes/AddressRouteProvider.cs
+++ b/src/management/Akka.Management/Routes/AddressRouteProvider.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Http.Dsl;
+using Akka.Management.Dsl;
+using Akka.Remote;
+using Ceen;
+using Newtonsoft.Json;
+using Route = System.ValueTuple<string, Akka.Http.Dsl.HttpModuleBase>;
+
+namespace Akka.Management.Routes;
+
+public class AddressRouteProvider: IManagementRouteProvider
+{
+    public Route[] Routes(ManagementRouteProviderSettings settings)
+    {
+        return new HttpAddressRoutes().Routes;
+    }
+}
+
+internal class HttpAddressRoutes : HttpModuleBase
+{
+    public Route[] Routes => new Route[] { ("/remote/address", this) };
+    
+    public override async Task<bool> HandleAsync(IAkkaHttpContext context)
+    {
+        if (context.HttpContext.Request.Method.ToLowerInvariant() != "get")
+            return false;
+        
+        // Check that remoting is in effect
+        if (((ExtendedActorSystem)context.ActorSystem).Provider is not IRemoteActorRefProvider actorProvider)
+        {
+            context.HttpContext.Response.StatusCode = HttpStatusCode.ServiceUnavailable;
+            var response = JsonConvert.SerializeObject(new
+            {
+                error = new
+                {
+                    reason = "not available",
+                    message = "Remoting is not available"
+                },
+                code = (int)HttpStatusCode.ServiceUnavailable,
+                message = "Remoting is not available"
+            });
+            await context.HttpContext.Response.WriteAllJsonAsync(response);
+            return true;
+        }
+        
+        var json = JsonConvert.SerializeObject(new
+        {
+            Address = actorProvider.DefaultAddress.ToString()
+        });
+        
+        await context.HttpContext.Response.WriteAllJsonAsync(json);
+        
+        return true;
+    }
+}

--- a/src/management/Akka.Management/Routes/ClusterClientReceptionistRouteProvider.cs
+++ b/src/management/Akka.Management/Routes/ClusterClientReceptionistRouteProvider.cs
@@ -1,0 +1,91 @@
+﻿using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster;
+using Akka.Http.Dsl;
+using Akka.Management.Dsl;
+using Akka.Remote;
+using Ceen;
+using Newtonsoft.Json;
+using Route = System.ValueTuple<string, Akka.Http.Dsl.HttpModuleBase>;
+
+namespace Akka.Management.Routes;
+
+public class ClusterClientReceptionistRouteProvider: IManagementRouteProvider
+{
+    public Route[] Routes(ManagementRouteProviderSettings settings)
+    {
+        return new HttpClusterClientReceptionistRoutes().Routes;
+    }
+}
+
+internal class HttpClusterClientReceptionistRoutes : HttpModuleBase
+{
+    public Route[] Routes => new Route[] { ("/cluster-client/receptionist", this) };
+    
+    public override async Task<bool> HandleAsync(IAkkaHttpContext context)
+    {
+        if (context.HttpContext.Request.Method.ToLowerInvariant() != "get")
+            return false;
+        
+        // Check that remoting is in effect
+        if (((ExtendedActorSystem)context.ActorSystem).Provider is not IRemoteActorRefProvider actorProvider)
+        {
+            context.HttpContext.Response.StatusCode = HttpStatusCode.ServiceUnavailable;
+            var response = JsonConvert.SerializeObject(new
+            {
+                error = new
+                {
+                    reason = "not available",
+                    message = "Remoting is not available"
+                },
+                code = (int)HttpStatusCode.ServiceUnavailable,
+                message = "Remoting is not available"
+            });
+            await context.HttpContext.Response.WriteAllJsonAsync(response);
+            return true;
+        }
+        
+        // Check that clustering is in effect
+        if (((ExtendedActorSystem)context.ActorSystem).Provider is not IClusterActorRefProvider)
+        {
+            context.HttpContext.Response.StatusCode = HttpStatusCode.ServiceUnavailable;
+            var response = JsonConvert.SerializeObject(new
+            {
+                error = new
+                {
+                    reason = "not available",
+                    message = "Clustering is not available"
+                },
+                code = (int)HttpStatusCode.ServiceUnavailable,
+                message = "Clustering is not available"
+            });
+            await context.HttpContext.Response.WriteAllJsonAsync(response);
+            return true;
+        }
+        
+        // Check that ClusterClientReceptionist is available
+        var config = context.ActorSystem.Settings.Config.GetConfig("akka.cluster.client.receptionist");
+        if(config is null)
+        {
+            context.HttpContext.Response.StatusCode = HttpStatusCode.ServiceUnavailable;
+            var response = JsonConvert.SerializeObject(new
+            {
+                error = new
+                {
+                    reason = "not available",
+                    message = "ClusterClientReceptionist is not available"
+                },
+                code = (int)HttpStatusCode.ServiceUnavailable,
+                message = "ClusterClientReceptionist is not available"
+            });
+            await context.HttpContext.Response.WriteAllJsonAsync(response);
+            return true;
+        }
+        
+        var actorPath = new RootActorPath(actorProvider.DefaultAddress) / "system" / config.GetString("name"); 
+        var json = JsonConvert.SerializeObject(new { ReceptionistPath = actorPath.ToString() });
+        await context.HttpContext.Response.WriteAllJsonAsync(json);
+        
+        return true;
+    }
+}


### PR DESCRIPTION
## Changes

* Add ClusterClientReceptionist ActorPath HTTP query endpoint at "/cluster-client/receptionist"
* Add Akka.Remote Address HTTP query endpoint at "/remote/address/"
* Both endpoint routes are loaded by `Akka.Management` by default.