### PR TITLE
[Management] Harden ClusterClientReceptionist actor path endpoint

### DIFF
--- a/src/management/Akka.Management/Routes/ClusterClientReceptionistRouteProvider.cs
+++ b/src/management/Akka.Management/Routes/ClusterClientReceptionistRouteProvider.cs
@@ -81,8 +81,27 @@ internal class HttpClusterClientReceptionistRoutes : HttpModuleBase
             await context.HttpContext.Response.WriteAllJsonAsync(response);
             return true;
         }
+
+        // Check that ClusterClientReceptionist name is valid
+        var name = config.GetString("name");
+        if (string.IsNullOrWhiteSpace(name) || !ActorPath.IsValidPathElement(name))
+        {
+            context.HttpContext.Response.StatusCode = HttpStatusCode.InternalServerError;
+            var response = JsonConvert.SerializeObject(new
+            {
+                error = new
+                {
+                    reason = "not available",
+                    message = "ClusterClientReceptionist name is invalid"
+                },
+                code = (int)HttpStatusCode.InternalServerError,
+                message = "ClusterClientReceptionist name is invalid"
+            });
+            await context.HttpContext.Response.WriteAllJsonAsync(response);
+            return true;
+        }
         
-        var actorPath = new RootActorPath(actorProvider.DefaultAddress) / "system" / config.GetString("name"); 
+        var actorPath = new RootActorPath(actorProvider.DefaultAddress) / "system" / name; 
         var json = JsonConvert.SerializeObject(new { ReceptionistPath = actorPath.ToString() });
         await context.HttpContext.Response.WriteAllJsonAsync(json);
         


### PR DESCRIPTION
## Changes

Harden ClusterClientReceptionist ActorPath endpoint validation to also validate the receptionist name. Returns 500 - Internal Server Error if receptionist name is null, empty, whitespace, or is an invalid actor name