### PR TITLE
Fix seed-nodes endpoint used by ClusterBootstrap

### DIFF
--- a/src/management/Akka.Management/Cluster/Bootstrap/ContactPoint/HttpClusterBootstrapRoutes.cs
+++ b/src/management/Akka.Management/Cluster/Bootstrap/ContactPoint/HttpClusterBootstrapRoutes.cs
@@ -63,7 +63,9 @@ namespace Akka.Management.Cluster.Bootstrap.ContactPoint
                 or MemberStatus.Leaving
                 or MemberStatus.Removed)
             {
-                context.HttpContext.Response.StatusCode = HttpStatusCode.ServiceUnavailable;
+                var body = JsonConvert.SerializeObject(
+                    new SeedNodes(cluster.SelfMember.UniqueAddress.Address, ImmutableList<ClusterMember>.Empty));
+                await context.HttpContext.Response.WriteAllJsonAsync(body);
                 return true;
             }
             


### PR DESCRIPTION
## Changes

Make the "bootstrap/seed-nodes" endpoint return an empty seed node list if it is downed, exiting, leaving, or removed from the cluster.