### PR TITLE
Discovery.Azure: Fix missing TableClientOptions client ctor argument

### DIFF
--- a/src/discovery/azure/Akka.Discovery.Azure/ClusterMemberTableClient.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/ClusterMemberTableClient.cs
@@ -36,7 +36,7 @@ namespace Akka.Discovery.Azure
             _serviceName = settings.ServiceName;
             _client = (settings.AzureAzureCredential != null && settings.AzureTableEndpoint != null)
                 ? new TableClient(settings.AzureTableEndpoint, settings.TableName, settings.AzureAzureCredential, settings.TableClientOptions)
-                : new TableClient(settings.ConnectionString, settings.TableName);
+                : new TableClient(settings.ConnectionString, settings.TableName, settings.TableClientOptions);
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

Pass the TableClientOptions to the TableClient ctor argument