### PR TITLE
Refactor `AkkaDiscoveryOptions` to `AzureDiscoveryOptions`

### DIFF
--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/HostingSpecs.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/HostingSpecs.cs
@@ -107,7 +107,7 @@ namespace Akka.Discovery.Azure.Tests
                 },
                 builder =>
                 {
-                    builder.WithAzureDiscovery(setup =>
+                    builder.WithAzureDiscovery((AzureDiscoveryOptions setup) =>
                     {
                         setup.ConnectionString = ConnectionString;
                         setup.ServiceName = "testService";
@@ -117,7 +117,7 @@ namespace Akka.Discovery.Azure.Tests
                 },
                 builder =>
                 {
-                    var setup = new AkkaDiscoveryOptions
+                    var setup = new AzureDiscoveryOptions
                     {
                         ConnectionString = ConnectionString,
                         ServiceName = "testService",

--- a/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
@@ -72,7 +72,7 @@ namespace Akka.Discovery.Azure
             bool? readOnly = null,
             bool isDefaultPlugin = true)
         {
-            var options = new AkkaDiscoveryOptions
+            var options = new AzureDiscoveryOptions
             {
                 IsDefaultPlugin = isDefaultPlugin,
                 ConfigPath = discoveryId,
@@ -154,7 +154,7 @@ namespace Akka.Discovery.Azure
             bool isDefaultPlugin = true)
         {
             if (azureCredential == null) throw new ArgumentNullException(nameof(azureCredential));
-            var options = new AkkaDiscoveryOptions
+            var options = new AzureDiscoveryOptions
             {
                 IsDefaultPlugin = isDefaultPlugin,
                 ConfigPath = discoveryId,
@@ -198,11 +198,50 @@ namespace Akka.Discovery.Azure
         ///     }
         ///   </code>
         /// </example>
+        [Obsolete("Use AzureDiscoveryOptions instead. Since 1.5.26")]
         public static AkkaConfigurationBuilder WithAzureDiscovery(
             this AkkaConfigurationBuilder builder,
             Action<AkkaDiscoveryOptions> configure)
         {
             var setup = new AkkaDiscoveryOptions();
+            configure(setup);
+            return builder.WithAzureDiscovery(setup);
+        }
+
+        /// <summary>
+        ///     Adds Akka.Discovery.Azure support to the <see cref="ActorSystem"/>.
+        ///     Note that this only adds the discovery plugin, you will still need to add ClusterBootstrap for
+        ///     a complete solution.
+        /// </summary>
+        /// <param name="builder">
+        ///     The builder instance being configured.
+        /// </param>
+        /// <param name="configure">
+        ///     An action that modifies an <see cref="AzureDiscoveryOptions"/> instance, used
+        ///     to configure Akka.Discovery.Azure.
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        /// <example>
+        ///   <code>
+        ///     services.AddAkka("mySystem", builder => {
+        ///         builder.WithClusterBootstrap(options =>
+        ///         {
+        ///             options.ContactPointDiscovery.ServiceName = "testService";
+        ///             options.ContactPointDiscovery.RequiredContactPointsNr = 1;
+        ///         }, autoStart: true)
+        ///         builder.WithAzureDiscovery( options => {
+        ///             options.ConnectionString = "UseDevelopmentStorage=true"
+        ///         });
+        ///     }
+        ///   </code>
+        /// </example>
+        public static AkkaConfigurationBuilder WithAzureDiscovery(
+            this AkkaConfigurationBuilder builder,
+            Action<AzureDiscoveryOptions> configure)
+        {
+            var setup = new AzureDiscoveryOptions();
             configure(setup);
             return builder.WithAzureDiscovery(setup);
         }
@@ -235,9 +274,48 @@ namespace Akka.Discovery.Azure
         ///     }
         ///   </code>
         /// </example>
+        [Obsolete("Use AzureDiscoveryOptions instead. Since 1.5.26")]
         public static AkkaConfigurationBuilder WithAzureDiscovery(
             this AkkaConfigurationBuilder builder,
             AkkaDiscoveryOptions options)
+        {
+            options.Apply(builder);
+
+            builder.AddHocon(AzureServiceDiscovery.DefaultConfig, HoconAddMode.Append);
+            return builder;
+        }
+
+        /// <summary>
+        ///     Adds Akka.Discovery.Azure support to the <see cref="ActorSystem"/>.
+        ///     Note that this only adds the discovery plugin, you will still need to add ClusterBootstrap for
+        ///     a complete solution.
+        /// </summary>
+        /// <param name="builder">
+        ///     The builder instance being configured.
+        /// </param>
+        /// <param name="options">
+        ///     The <see cref="AzureDiscoveryOptions"/> instance used to configure Akka.Discovery.Azure.
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        /// <example>
+        ///   <code>
+        ///     services.AddAkka("mySystem", builder => {
+        ///         builder.WithClusterBootstrap(options =>
+        ///         {
+        ///             options.ContactPointDiscovery.ServiceName = "testService";
+        ///             options.ContactPointDiscovery.RequiredContactPointsNr = 1;
+        ///         }, autoStart: true)
+        ///         builder.WithAzureDiscovery( new AkkaDiscoveryOptions {
+        ///             ConnectionString = "UseDevelopmentStorage=true"
+        ///         });
+        ///     }
+        ///   </code>
+        /// </example>
+        public static AkkaConfigurationBuilder WithAzureDiscovery(
+            this AkkaConfigurationBuilder builder,
+            AzureDiscoveryOptions options)
         {
             options.Apply(builder);
 

--- a/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AkkaHostingExtensions.cs
@@ -323,7 +323,7 @@ namespace Akka.Discovery.Azure
         {
             options.Apply(builder);
 
-            builder.AddHocon(AzureServiceDiscovery.DefaultConfig, HoconAddMode.Append);
+            builder.AddHocon(AzureDiscovery.DefaultConfiguration(), HoconAddMode.Append);
             return builder;
         }
     }

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoveryOptions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoveryOptions.cs
@@ -15,8 +15,7 @@ using Azure.Data.Tables;
 
 namespace Akka.Discovery.Azure;
 
-[Obsolete("Please use AzureDiscoveryOptions instead. Since 1.5.26")]
-public class AkkaDiscoveryOptions: IHoconOption
+public class AzureDiscoveryOptions: IHoconOption
 {
     
     public string ConfigPath { get; set; } = "azure";

--- a/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoveryOptions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/AzureDiscoveryOptions.cs
@@ -164,7 +164,7 @@ public class AzureDiscoveryOptions: IHoconOption
         
         builder.AddHocon(sb.ToString(), HoconAddMode.Prepend);
 
-        var fallback = AzureServiceDiscovery.DefaultConfig
+        var fallback = AzureDiscovery.DefaultConfiguration()
             .GetConfig(AzureServiceDiscovery.FullPath(AzureServiceDiscovery.DefaultPath))
             .MoveTo(AzureServiceDiscovery.FullPath(ConfigPath));
         builder.AddHocon(fallback, HoconAddMode.Append);


### PR DESCRIPTION
## Changes

Refactor `Akka.Discovery.Azure` misnamed `AkkaDiscoveryOptions` to `AzureDiscoveryOptions`