### PR TITLE
Fix AWS ECS Discovery

### DIFF
--- a/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/Akka.Discovery.AwsApi.Integration.Tests.csproj
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/Akka.Discovery.AwsApi.Integration.Tests.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Docker.DotNet" Version="3.125.15" />
         <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+        <PackageReference Include="Testcontainers.LocalStack" Version="3.9.0" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/AwsIntegrationSpec.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/AwsIntegrationSpec.cs
@@ -49,7 +49,7 @@ akka {{
         [SkippableFact]
         public async Task DiscoveryShouldBeAbleToLookupAwsEc2Instances()
         {
-            Skip.If(_fixture.IsWindows, "LocalStack docker image only available for Linux OS");
+            Skip.If(_fixture.IsWindows, "LocalStack docker image only available for Linux containers");
             
             var discovery = new Ec2TagBasedServiceDiscovery((ExtendedActorSystem)Sys);
             var lookup = new Lookup("fake-api");
@@ -57,6 +57,5 @@ akka {{
             resolved.Addresses.Count.Should().Be(4);
             resolved.Addresses.Select(a => a.Address.ToString()).Should().BeEquivalentTo(_fixture.IpAddresses);
         }
-
     }
 }

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/LocalStackFixture.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/LocalStackFixture.cs
@@ -7,9 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Amazon.CloudFormation;
 using Amazon.EC2;
@@ -17,410 +14,309 @@ using Amazon.EC2.Model;
 using Amazon.Runtime;
 using Amazon.S3;
 using Docker.DotNet;
-using Docker.DotNet.Models;
+using Testcontainers.LocalStack;
 using Xunit;
 
-namespace Akka.Discovery.AwsApi.Integration.Tests
+namespace Akka.Discovery.AwsApi.Integration.Tests;
+
+[CollectionDefinition("AwsSpec")]
+public sealed class AwsSpecsFixture: ICollectionFixture<LocalStackFixture>
 {
-    [CollectionDefinition("AwsSpec")]
-    public sealed class AwsSpecsFixture: ICollectionFixture<LocalStackFixture>
+}
+
+public sealed class LocalStackFixture: IAsyncLifetime
+{
+    private readonly LocalStackContainer _container;
+
+    public bool IsWindows { get; private set; }
+    public string Endpoint { get; private set; }
+    public AmazonCloudFormationClient? CfCClient { get; private set; }
+    public AmazonEC2Client? Ec2Client { get; private set; }
+    public AmazonS3Client? S3Client { get; private set; }
+    public List<string> IpAddresses { get; } = new ();
+        
+    public LocalStackFixture()
     {
+        _container = new LocalStackBuilder()
+            .WithImage("localstack/localstack:3.6.0")
+            .Build();
     }
 
-    public sealed class LocalStackFixture : IAsyncLifetime
+    public async Task InitializeAsync()
     {
-        public const string BucketName = "bucket-test";
-        private readonly string _containerName = $"localstack-{Guid.NewGuid():N}";
-        private readonly DockerClient? _client;
-
-        public int Port { get; }
-
-        public string Endpoint => $"http://localhost:{Port}";
-        
-        public AmazonCloudFormationClient? CfCClient { get; private set; }
-        public AmazonEC2Client? Ec2Client { get; private set; }
-        public AmazonS3Client? S3Client { get; private set; }
-        public List<string> IpAddresses { get; } = new ();
-        
-        public bool IsWindows { get; }
-        
-        public LocalStackFixture()
+        using (var client = new DockerClientConfiguration().CreateClient())
         {
-            DockerClientConfiguration config;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
-                // LocalStack is linux only, we're skipping all tests if we're running in windows.
-                IsWindows = true;
-                return;
-            }
-            else
-                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
+            var sysInfo = await client.System.GetSystemInfoAsync();
+            var osType = sysInfo.OSType;
+            IsWindows = osType is "windows";
+        }
 
-            _client = config.CreateClient();
-            
-            var rnd = new Random();
-            Port = rnd.Next(9000, 10000);
+        if (IsWindows)
+        {
+            Endpoint = string.Empty;
+            return;
         }
         
-        private const string ImageName = "localstack/localstack";
-        private const string Tag = "1.2";
-        private readonly string _localStackImageName = $"{ImageName}:{Tag}";
-
-        public async Task InitializeAsync()
+        await _container.StartAsync();
+        Endpoint = _container.GetConnectionString();
+            
+        // Create clients
+        S3Client = new AmazonS3Client(
+            new BasicAWSCredentials("test", "test"), 
+            new AmazonS3Config
+            {
+                ServiceURL = Endpoint,
+                ForcePathStyle = true,
+                Timeout = TimeSpan.FromSeconds(5)
+            });
+            
+        CfCClient = new AmazonCloudFormationClient(new AmazonCloudFormationConfig
         {
-            // LocalStack is linux only, we're skipping all tests if we're running in windows.
-            if (IsWindows) return;
+            ServiceURL = Endpoint
+        });
             
-            var images = await _client!.Images.ListImagesAsync(new ImagesListParameters
+        Ec2Client = new AmazonEC2Client(
+            new BasicAWSCredentials("test", "test"), 
+            new AmazonEC2Config
             {
-                Filters = new Dictionary<string, IDictionary<string, bool>>
-                {
-                    {"reference", new Dictionary<string, bool> {{_localStackImageName, true}}}
-                }
+                ServiceURL = Endpoint,
             });
-            if (images.Count == 0)
-                await _client.Images.CreateImageAsync(
-                    new ImagesCreateParameters {FromImage = ImageName, Tag = Tag}, 
-                    new AuthConfig(),
-                    new Progress<JSONMessage>(message =>
-                    {
-                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
-                            ? message.ErrorMessage
-                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
-                    }));
+            
+        // Create VPC
+        var vpcResponse = await Ec2Client.CreateVpcAsync(new CreateVpcRequest
+        {
+            CidrBlock = "10.0.0.0/16"
+        });
+        var vpcId = vpcResponse.Vpc.VpcId;
 
-            // create the container
-            await _client.Containers.CreateContainerAsync(new CreateContainerParameters
+        #region Public side
+
+        // Create public subnet using VPC ID
+        var subnetResponse = await Ec2Client.CreateSubnetAsync(new CreateSubnetRequest
+        {
+            VpcId = vpcId,
+            CidrBlock = "10.0.1.0/24"
+        });
+        var publicSubnetId = subnetResponse.Subnet.SubnetId;
+            
+        // Create internet gateway
+        var netGatewayResponse = await Ec2Client.CreateInternetGatewayAsync(new CreateInternetGatewayRequest());
+        var internetGatewayId = netGatewayResponse.InternetGateway.InternetGatewayId;
+            
+        // Attach internet gateway to VPC
+        await Ec2Client.AttachInternetGatewayAsync(new AttachInternetGatewayRequest
+        {
+            VpcId = vpcId,
+            InternetGatewayId = internetGatewayId
+        });
+            
+        // Create route table for the public subnet
+        var routeTableResponse = await Ec2Client.CreateRouteTableAsync(new CreateRouteTableRequest
+        {
+            VpcId = vpcId
+        });
+        var publicRouteTableId = routeTableResponse.RouteTable.RouteTableId;
+
+        // Create route to route all traffic to the internet gateway
+        await Ec2Client.CreateRouteAsync(new CreateRouteRequest
+        {
+            RouteTableId = publicRouteTableId,
+            GatewayId = internetGatewayId,
+            DestinationCidrBlock = "0.0.0.0/0"
+        });
+
+        // Associate route table to public subnet
+        await Ec2Client.AssociateRouteTableAsync(new AssociateRouteTableRequest
+        {
+            SubnetId = publicSubnetId,
+            RouteTableId = publicRouteTableId
+        });
+            
+        #endregion
+
+        #region Private side
+
+        // Create private subnet using VPC ID
+        subnetResponse = await Ec2Client.CreateSubnetAsync(new CreateSubnetRequest
+        {
+            VpcId = vpcId,
+            CidrBlock = "10.0.2.0/24"
+        });
+        var privateSubnetId = subnetResponse.Subnet.SubnetId;
+            
+        // Create NAT address
+        var addressResult = await Ec2Client.AllocateAddressAsync(new AllocateAddressRequest{Domain = DomainType.Vpc});
+        var addressAllocationId = addressResult.AllocationId;
+            
+        // Create NAT gateway
+        var natGatewayResponse = await Ec2Client.CreateNatGatewayAsync(new CreateNatGatewayRequest
+        {
+            SubnetId = publicSubnetId,
+            AllocationId = addressAllocationId
+        });
+        var natGatewayId = natGatewayResponse.NatGateway.NatGatewayId;
+            
+        // Create route table for the private subnet
+        routeTableResponse = await Ec2Client.CreateRouteTableAsync(new CreateRouteTableRequest
+        {
+            VpcId = vpcId
+        });
+        var privateRouteTableId = routeTableResponse.RouteTable.RouteTableId;
+            
+        // Create route to route traffic to the NAT gateway
+        await Ec2Client.CreateRouteAsync(new CreateRouteRequest
+        {
+            RouteTableId = privateRouteTableId,
+            GatewayId = natGatewayId,
+            DestinationCidrBlock = "0.0.0.0/0"
+        });
+            
+        // Associate route table to private subnet
+        await Ec2Client.AssociateRouteTableAsync(new AssociateRouteTableRequest
+        {
+            SubnetId = privateSubnetId,
+            RouteTableId = privateRouteTableId
+        });
+
+        #endregion
+
+        #region Security group
+
+        // Create security group for the VPC
+        var groupResponse = await Ec2Client.CreateSecurityGroupAsync(new CreateSecurityGroupRequest
+        {
+            GroupName = "akka-cluster",
+            Description = "Akka cluster security group",
+            VpcId = vpcId
+        });
+        var securityGroupId = groupResponse.GroupId;
+            
+        // Open port 22
+        await Ec2Client.AuthorizeSecurityGroupIngressAsync(new AuthorizeSecurityGroupIngressRequest
+        {
+            GroupId = securityGroupId,
+            IpPermissions = new List<IpPermission>
             {
-                Image = _localStackImageName,
-                Name = _containerName,
-                Tty = true,
-                ExposedPorts = new Dictionary<string, EmptyStruct>
+                new IpPermission
                 {
-                    {"4566", default},
-                },
-                HostConfig = new HostConfig
-                {
-                    PortBindings = new Dictionary<string, IList<PortBinding>>
+                    IpProtocol = "tcp",
+                    FromPort = 22,
+                    ToPort = 22,
+                    Ipv4Ranges = new List<IpRange>
                     {
+                        new IpRange
                         {
-                            "4566", new List<PortBinding> {new PortBinding {HostPort = $"{Port}"}}
-                        },
-                    }
-                },
-                Env = new List<string>
-                {
-                    "AWS_ACCESS_KEY_ID=test",
-                    "AWS_SECRET_ACCESS_KEY=test",
-                    "DEBUG=1",
-                }
-            });
-
-            // start the container
-            await _client.Containers.StartContainerAsync(_containerName, new ContainerStartParameters());
-            
-            // Wait until LocalStack is completely ready
-            var logStream = await _client.Containers.GetContainerLogsAsync(_containerName, new ContainerLogsParameters
-            {
-                Follow = true,
-                ShowStdout = true,
-                ShowStderr = true
-            });
-
-            string? line = null;
-            var timeoutInMilis = 60000;
-            using (var reader = new StreamReader(logStream))
-            {
-                var stopwatch = Stopwatch.StartNew();
-                while (stopwatch.ElapsedMilliseconds < timeoutInMilis && (line = await reader.ReadLineAsync()) != null)
-                {
-                    if (line is "Ready.")
-                    {
-                        break;
-                    }
-                }
-                stopwatch.Stop();
-            }
-#if NET471
-            logStream.Dispose();
-#else
-            await logStream.DisposeAsync();
-#endif
-            if (line != "Ready.")
-                throw new Exception("LocalStack docker image failed to run.");
-            
-            // Create clients
-            S3Client = new AmazonS3Client(
-                new BasicAWSCredentials("test", "test"), 
-                new AmazonS3Config
-                {
-                    ServiceURL = Endpoint,
-                    ForcePathStyle = true,
-                    Timeout = TimeSpan.FromSeconds(5)
-                });
-            
-            CfCClient = new AmazonCloudFormationClient(new AmazonCloudFormationConfig
-            {
-                ServiceURL = Endpoint
-            });
-            
-            Ec2Client = new AmazonEC2Client(
-                new BasicAWSCredentials("test", "test"), 
-                new AmazonEC2Config
-                {
-                    ServiceURL = Endpoint,
-                });
-            
-            // Create VPC
-            var vpcResponse = await Ec2Client.CreateVpcAsync(new CreateVpcRequest
-            {
-                CidrBlock = "10.0.0.0/16"
-            });
-            var vpcId = vpcResponse.Vpc.VpcId;
-
-            #region Public side
-
-            // Create public subnet using VPC ID
-            var subnetResponse = await Ec2Client.CreateSubnetAsync(new CreateSubnetRequest
-            {
-                VpcId = vpcId,
-                CidrBlock = "10.0.1.0/24"
-            });
-            var publicSubnetId = subnetResponse.Subnet.SubnetId;
-            
-            // Create internet gateway
-            var netGatewayResponse = await Ec2Client.CreateInternetGatewayAsync(new CreateInternetGatewayRequest());
-            var internetGatewayId = netGatewayResponse.InternetGateway.InternetGatewayId;
-            
-            // Attach internet gateway to VPC
-            await Ec2Client.AttachInternetGatewayAsync(new AttachInternetGatewayRequest
-            {
-                VpcId = vpcId,
-                InternetGatewayId = internetGatewayId
-            });
-            
-            // Create route table for the public subnet
-            var routeTableResponse = await Ec2Client.CreateRouteTableAsync(new CreateRouteTableRequest
-            {
-                VpcId = vpcId
-            });
-            var publicRouteTableId = routeTableResponse.RouteTable.RouteTableId;
-
-            // Create route to route all traffic to the internet gateway
-            await Ec2Client.CreateRouteAsync(new CreateRouteRequest
-            {
-                RouteTableId = publicRouteTableId,
-                GatewayId = internetGatewayId,
-                DestinationCidrBlock = "0.0.0.0/0"
-            });
-
-            // Associate route table to public subnet
-            await Ec2Client.AssociateRouteTableAsync(new AssociateRouteTableRequest
-            {
-                SubnetId = publicSubnetId,
-                RouteTableId = publicRouteTableId
-            });
-            
-            #endregion
-
-            #region Private side
-
-            // Create private subnet using VPC ID
-            subnetResponse = await Ec2Client.CreateSubnetAsync(new CreateSubnetRequest
-            {
-                VpcId = vpcId,
-                CidrBlock = "10.0.2.0/24"
-            });
-            var privateSubnetId = subnetResponse.Subnet.SubnetId;
-            
-            // Create NAT address
-            var addressResult = await Ec2Client.AllocateAddressAsync(new AllocateAddressRequest{Domain = DomainType.Vpc});
-            var addressAllocationId = addressResult.AllocationId;
-            
-            // Create NAT gateway
-            var natGatewayResponse = await Ec2Client.CreateNatGatewayAsync(new CreateNatGatewayRequest
-            {
-                SubnetId = publicSubnetId,
-                AllocationId = addressAllocationId
-            });
-            var natGatewayId = natGatewayResponse.NatGateway.NatGatewayId;
-            
-            // Create route table for the private subnet
-            routeTableResponse = await Ec2Client.CreateRouteTableAsync(new CreateRouteTableRequest
-            {
-                VpcId = vpcId
-            });
-            var privateRouteTableId = routeTableResponse.RouteTable.RouteTableId;
-            
-            // Create route to route traffic to the NAT gateway
-            await Ec2Client.CreateRouteAsync(new CreateRouteRequest
-            {
-                RouteTableId = privateRouteTableId,
-                GatewayId = natGatewayId,
-                DestinationCidrBlock = "0.0.0.0/0"
-            });
-            
-            // Associate route table to private subnet
-            await Ec2Client.AssociateRouteTableAsync(new AssociateRouteTableRequest
-            {
-                SubnetId = privateSubnetId,
-                RouteTableId = privateRouteTableId
-            });
-
-            #endregion
-
-            #region Security group
-
-            // Create security group for the VPC
-            var groupResponse = await Ec2Client.CreateSecurityGroupAsync(new CreateSecurityGroupRequest
-            {
-                GroupName = "akka-cluster",
-                Description = "Akka cluster security group",
-                VpcId = vpcId
-            });
-            var securityGroupId = groupResponse.GroupId;
-            
-            // Open port 22
-            await Ec2Client.AuthorizeSecurityGroupIngressAsync(new AuthorizeSecurityGroupIngressRequest
-            {
-                GroupId = securityGroupId,
-                IpPermissions = new List<IpPermission>
-                {
-                    new IpPermission
-                    {
-                        IpProtocol = "tcp",
-                        FromPort = 22,
-                        ToPort = 22,
-                        Ipv4Ranges = new List<IpRange>
-                        {
-                            new IpRange
-                            {
-                                CidrIp = "0.0.0.0/0"
-                            }
+                            CidrIp = "0.0.0.0/0"
                         }
                     }
                 }
-            });
+            }
+        });
             
-            // Open port 80
-            await Ec2Client.AuthorizeSecurityGroupIngressAsync(new AuthorizeSecurityGroupIngressRequest
+        // Open port 80
+        await Ec2Client.AuthorizeSecurityGroupIngressAsync(new AuthorizeSecurityGroupIngressRequest
+        {
+            GroupId = securityGroupId,
+            IpPermissions = new List<IpPermission>
             {
-                GroupId = securityGroupId,
-                IpPermissions = new List<IpPermission>
+                new IpPermission
                 {
-                    new IpPermission
+                    IpProtocol = "tcp",
+                    FromPort = 80,
+                    ToPort = 80,
+                    Ipv4Ranges = new List<IpRange>
                     {
-                        IpProtocol = "tcp",
-                        FromPort = 80,
-                        ToPort = 80,
-                        Ipv4Ranges = new List<IpRange>
+                        new IpRange
                         {
-                            new IpRange
-                            {
-                                CidrIp = "0.0.0.0/0"
-                            }
+                            CidrIp = "0.0.0.0/0"
                         }
                     }
                 }
-            });
-            #endregion
-            
-            // Create key-pair
-            var keyName = "cli-keyPair";
-            var keyPairResponse = await Ec2Client.CreateKeyPairAsync(new CreateKeyPairRequest
-            {
-                KeyName = keyName
-            });
-            var keyPairMaterial = keyPairResponse.KeyPair.KeyMaterial; // the PEM
-
-            var instanceResponse = await Ec2Client.RunInstancesAsync(new RunInstancesRequest
-            {
-                ImageId = "ami-fake",
-                InstanceType = InstanceType.T2Micro,
-                MinCount = 2,
-                MaxCount = 2,
-                SecurityGroupIds = new List<string> {securityGroupId},
-                KeyName = keyName,
-                NetworkInterfaces = new List<InstanceNetworkInterfaceSpecification>
-                {
-                    new InstanceNetworkInterfaceSpecification
-                    {
-                        DeviceIndex = 0,
-                        AssociatePublicIpAddress = true,
-                        SubnetId = publicSubnetId
-                    }
-                }
-            });
-            var instanceIds = new List<string>();
-            foreach (var instance in instanceResponse.Reservation.Instances)
-            {
-                instanceIds.Add(instance.InstanceId);
-                IpAddresses.Add(instance.PrivateIpAddress);
             }
+        });
+        #endregion
             
-            instanceResponse = await Ec2Client.RunInstancesAsync(new RunInstancesRequest
-            {
-                ImageId = "ami-fake",
-                InstanceType = InstanceType.T2Micro, 
-                MinCount = 2,
-                MaxCount = 2,
-                SecurityGroupIds = new List<string> {securityGroupId},
-                KeyName = keyName,
-                NetworkInterfaces = new List<InstanceNetworkInterfaceSpecification>
-                {
-                    new InstanceNetworkInterfaceSpecification
-                    {
-                        DeviceIndex = 0,
-                        AssociatePublicIpAddress = true,
-                        SubnetId = privateSubnetId
-                    }
-                }
-            });
-            foreach (var instance in instanceResponse.Reservation.Instances)
-            {
-                instanceIds.Add(instance.InstanceId);
-                IpAddresses.Add(instance.PrivateIpAddress);
-            }
-
-            // Tag instance with service name
-            await Ec2Client.CreateTagsAsync(new CreateTagsRequest
-            {
-                Resources = instanceIds,
-                Tags = new List<Tag>
-                {
-                    new Tag
-                    {
-                        Key = "service",
-                        Value = "fake-api"
-                    }
-                }
-            });
-
-            await Ec2Client.ModifyVpcAttributeAsync(new ModifyVpcAttributeRequest
-            {
-                VpcId = vpcId,
-                EnableDnsHostnames = true
-            });            
-        }
-
-        public async Task DisposeAsync()
+        // Create key-pair
+        var keyName = "cli-keyPair";
+        var keyPairResponse = await Ec2Client.CreateKeyPairAsync(new CreateKeyPairRequest
         {
-            if (_client != null)
+            KeyName = keyName
+        });
+        var keyPairMaterial = keyPairResponse.KeyPair.KeyMaterial; // the PEM
+
+        var instanceResponse = await Ec2Client.RunInstancesAsync(new RunInstancesRequest
+        {
+            ImageId = "ami-fake",
+            InstanceType = InstanceType.T2Micro,
+            MinCount = 2,
+            MaxCount = 2,
+            SecurityGroupIds = new List<string> {securityGroupId},
+            KeyName = keyName,
+            NetworkInterfaces = new List<InstanceNetworkInterfaceSpecification>
             {
-                // Delay to make sure that all tests has completed cleanup.
-                await Task.Delay(TimeSpan.FromSeconds(5));
-    
-                // Kill the container, we can't simply stop the container because Redis can hung indefinetly
-                // if we simply stop the container.
-                await _client.Containers.KillContainerAsync(_containerName, new ContainerKillParameters());
-    
-                await _client.Containers.RemoveContainerAsync(_containerName,
-                    new ContainerRemoveParameters {Force = true});
-                _client.Dispose();
+                new InstanceNetworkInterfaceSpecification
+                {
+                    DeviceIndex = 0,
+                    AssociatePublicIpAddress = true,
+                    SubnetId = publicSubnetId
+                }
             }
+        });
+        var instanceIds = new List<string>();
+        foreach (var instance in instanceResponse.Reservation.Instances)
+        {
+            instanceIds.Add(instance.InstanceId);
+            IpAddresses.Add(instance.PrivateIpAddress);
         }
+            
+        instanceResponse = await Ec2Client.RunInstancesAsync(new RunInstancesRequest
+        {
+            ImageId = "ami-fake",
+            InstanceType = InstanceType.T2Micro, 
+            MinCount = 2,
+            MaxCount = 2,
+            SecurityGroupIds = new List<string> {securityGroupId},
+            KeyName = keyName,
+            NetworkInterfaces = new List<InstanceNetworkInterfaceSpecification>
+            {
+                new InstanceNetworkInterfaceSpecification
+                {
+                    DeviceIndex = 0,
+                    AssociatePublicIpAddress = true,
+                    SubnetId = privateSubnetId
+                }
+            }
+        });
+        foreach (var instance in instanceResponse.Reservation.Instances)
+        {
+            instanceIds.Add(instance.InstanceId);
+            IpAddresses.Add(instance.PrivateIpAddress);
+        }
+
+        // Tag instance with service name
+        await Ec2Client.CreateTagsAsync(new CreateTagsRequest
+        {
+            Resources = instanceIds,
+            Tags = new List<Tag>
+            {
+                new Tag
+                {
+                    Key = "service",
+                    Value = "fake-api"
+                }
+            }
+        });
+
+        await Ec2Client.ModifyVpcAttributeAsync(new ModifyVpcAttributeRequest
+        {
+            VpcId = vpcId,
+            EnableDnsHostnames = true
+        });            
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _container.StopAsync();
+        await _container.DisposeAsync();
     }
 }


### PR DESCRIPTION
AWS ECS tag matching logic is wrong, it assumes that all of the tags have to match exactly

## Changes

* Change the tag matching logic to match what Scala Akka is doing
* Make sure that the `Diff()` logic follows Scala `list[T].diff()` behavior exactly