### PR TITLE
Update RELEASE_NOTES.md for 1.5.30 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.5.30 October 1st 2024 ####
+#### 1.5.30 October 3rd 2024 ####
 
 * Update to [Akka.NET v1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
 * Update to [Akka.Hosting v1.5.30](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.30)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,16 @@
+#### 1.5.30 October 1st 2024 ####
+
+* Update to [Akka.NET v1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
+* Update to [Akka.Hosting v1.5.30](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.30)
+* [Bump Grpc/Tools from 2.64.0 to 2.66.0](https://github.com/akkadotnet/Akka.Management/pull/2734)
+
 #### 1.5.29 October 1st 2024 ####
+
+> [!NOTE]
+>
+> **Deprecated**
+>
+> Deprecated due to Akka.NET 1.5.29 deprecation. Please use 1.5.30 instead.
 
 * Update to [Akka.NET v1.5.29](https://github.com/akkadotnet/akka.net/releases/tag/1.5.29)
 * Update to [Akka.Hosting v1.5.29](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.29)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,8 +31,8 @@ Update all AWSSDK versions</PackageReleaseNotes>
         <TestSdkVersion>17.10.0</TestSdkVersion>
         <WireMockVersion>1.6.2</WireMockVersion>
         
-        <AkkaVersion>1.5.29</AkkaVersion>
-        <AkkaHostingVersion>1.5.29</AkkaHostingVersion>
+        <AkkaVersion>1.5.30</AkkaVersion>
+        <AkkaHostingVersion>1.5.30</AkkaHostingVersion>
         <PbmVersion>1.4.3</PbmVersion>
         
         <KubernetesClientVersionNetStandard>4.0.26</KubernetesClientVersionNetStandard>


### PR DESCRIPTION
## 1.5.30 October 3rd 2024

* Update to [Akka.NET v1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
* Update to [Akka.Hosting v1.5.30](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.30)
* [Bump Grpc/Tools from 2.64.0 to 2.66.0](https://github.com/akkadotnet/Akka.Management/pull/2734)