### PR TITLE
Modernize Coordination.KubernetesApi code

### DIFF
--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLease.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/KubernetesLease.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -83,23 +84,20 @@ namespace Akka.Coordination.KubernetesApi
         public override bool CheckLease()
             => _leaseTaken.Value;
         
-        public override Task<bool> Release()
+        public override async Task<bool> Release()
         {
             // replace with transform once 2.11 dropped
             try
             {
                 if(_log.IsDebugEnabled)
                     _log.Debug("Releasing lease");
-                return _leaseActor.Ask(LeaseActor.Release.Instance, _timeout)
-                    .ContinueWith(t =>
-                    {
-                        return t.Result switch
-                        {
-                            LeaseActor.LeaseReleased _ => true,
-                            LeaseActor.InvalidRequest req => throw new LeaseException(req.Reason),
-                            _ => false
-                        };
-                    });
+                var result = await _leaseActor.Ask(LeaseActor.Release.Instance, _timeout);
+                return result switch
+                {
+                    LeaseActor.LeaseReleased _ => true,
+                    LeaseActor.InvalidRequest req => throw new LeaseException(req.Reason),
+                    _ => false
+                };
             }
             catch (AskTimeoutException)
             {
@@ -111,24 +109,21 @@ namespace Akka.Coordination.KubernetesApi
         public override Task<bool> Acquire()
             => Acquire(null);
 
-        public override Task<bool> Acquire(Action<Exception?>? leaseLostCallback)
+        public override async Task<bool> Acquire(Action<Exception?>? leaseLostCallback)
         {
             // replace with transform once 2.11 dropped
             try
             {
                 if(_log.IsDebugEnabled)
                     _log.Debug("Acquiring lease");
-                return _leaseActor.Ask(new LeaseActor.Acquire(leaseLostCallback), _timeout)
-                    .ContinueWith(t =>
-                    {
-                        return t.Result switch
-                        {
-                            LeaseActor.LeaseAcquired _ => true,
-                            LeaseActor.LeaseTaken _ => false,
-                            LeaseActor.InvalidRequest req => throw new LeaseException(req.Reason),
-                            _ => false
-                        };
-                    });
+                var result = await _leaseActor.Ask(new LeaseActor.Acquire(leaseLostCallback), _timeout);
+                return result switch
+                {
+                    LeaseActor.LeaseAcquired _ => true,
+                    LeaseActor.LeaseTaken _ => false,
+                    LeaseActor.InvalidRequest req => throw new LeaseException(req.Reason),
+                    _ => false
+                };
             }
             catch (AskTimeoutException)
             {


### PR DESCRIPTION
## Changes

Modernize Akka.Coordination.KubernetesApi code, there should not be any behavior changes.
* Implement actual async-await code by removing `ContinueWith` and using the `async` keyword
* Remove `ContinueWith` and move the success path into `PipeTo` instead.