### PR TITLE
Build: no code coverage reports if no `.cobertura.xml` files found

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -48,14 +48,18 @@ jobs:
           failTaskOnFailedTests: false
           publishRunAttachments: true
 
-      # Only run if coverage files exist
+      - pwsh: |
+          $coverageFiles = Get-ChildItem -Path "$(Build.SourcesDirectory)/TestResults" -Filter "*.cobertura.xml" -Recurse
+          $hasCoverageFiles = $coverageFiles.Count -gt 0
+          Write-Host "##vso[task.setvariable variable=HasCoverageFiles]$hasCoverageFiles"
+        displayName: 'Check for Coverage Files'
+        condition: always()
+        continueOnError: true
+
       - task: reportgenerator@5
         displayName: ReportGenerator
-        condition: >-
-          and(
-            always(),
-            gt(countFiles('$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'), 0)
-          )
+        # Only run if coverage files exist
+        condition: and(always(), eq(variables['HasCoverageFiles'], 'True'))
         continueOnError: true
         inputs:
           reports: '$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'
@@ -64,14 +68,10 @@ jobs:
           assemblyfilters: '-xunit*'
           publishCodeCoverageResults: true
 
-       # Only run if coverage files exist
       - publish: $(Build.SourcesDirectory)/coveragereport
         displayName: 'Publish Coverage Report'
-        condition: >-
-          and(
-            always(),
-            gt(countFiles('$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'), 0)
-          )
+        # Only run if coverage files exist
+        condition: and(always(), eq(variables['HasCoverageFiles'], 'True'))
         continueOnError: true
         artifact: 'CoverageReports-$(Agent.OS)-$(Build.BuildId)'
           

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -48,9 +48,9 @@ jobs:
           failTaskOnFailedTests: false
           publishRunAttachments: true
 
+      # Only run if coverage files exist
       - task: reportgenerator@5
         displayName: ReportGenerator
-        # Only run if coverage files exist
         condition: >-
           and(
             always(),
@@ -64,9 +64,9 @@ jobs:
           assemblyfilters: '-xunit*'
           publishCodeCoverageResults: true
 
+       # Only run if coverage files exist
       - publish: $(Build.SourcesDirectory)/coveragereport
         displayName: 'Publish Coverage Report'
-        # Only run if coverage files exist
         condition: >-
           and(
             always(),

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -50,11 +50,12 @@ jobs:
 
       - task: reportgenerator@5
         displayName: ReportGenerator
+        # Only run if coverage files exist
         condition: >-
           and(
             always(),
             gt(countFiles('$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'), 0)
-          ) # Only run on PRs and if coverage files exist
+          )
         continueOnError: true
         inputs:
           reports: '$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'
@@ -65,11 +66,12 @@ jobs:
 
       - publish: $(Build.SourcesDirectory)/coveragereport
         displayName: 'Publish Coverage Report'
+        # Only run if coverage files exist
         condition: >-
           and(
             always(),
             gt(countFiles('$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'), 0)
-          ) # Only run on PRs and if coverage files exist
+          )
         continueOnError: true
         artifact: 'CoverageReports-$(Agent.OS)-$(Build.BuildId)'
           

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -50,7 +50,11 @@ jobs:
 
       - task: reportgenerator@5
         displayName: ReportGenerator
-        condition: and(always(), eq(variables['Build.Reason'], 'PullRequest')) # Only run on PRs
+        condition: >-
+          and(
+            always(),
+            gt(countFiles('$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'), 0)
+          ) # Only run on PRs and if coverage files exist
         continueOnError: true
         inputs:
           reports: '$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'
@@ -61,7 +65,11 @@ jobs:
 
       - publish: $(Build.SourcesDirectory)/coveragereport
         displayName: 'Publish Coverage Report'
-        condition: and(always(), eq(variables['Build.Reason'], 'PullRequest')) # Only run on PRs
+        condition: >-
+          and(
+            always(),
+            gt(countFiles('$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'), 0)
+          ) # Only run on PRs and if coverage files exist
         continueOnError: true
         artifact: 'CoverageReports-$(Agent.OS)-$(Build.BuildId)'
           

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - task: reportgenerator@5
         displayName: ReportGenerator
-        condition: always() # Run this step regardless of previous step outcomes
+        condition: and(always(), eq(variables['Build.Reason'], 'PullRequest')) # Only run on PRs
         continueOnError: true
         inputs:
           reports: '$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'
@@ -61,9 +61,9 @@ jobs:
 
       - publish: $(Build.SourcesDirectory)/coveragereport
         displayName: 'Publish Coverage Report'
-        condition: and(always(), eq(variables['Agent.OS'], 'Windows_NT'))
+        condition: and(always(), eq(variables['Build.Reason'], 'PullRequest')) # Only run on PRs
         continueOnError: true
-        artifact: 'CoverageReports-$(Build.BuildId)'
+        artifact: 'CoverageReports-$(Agent.OS)-$(Build.BuildId)'
           
       - script: dotnet pack -c Release --no-build -o $(Build.ArtifactStagingDirectory)/nuget
         displayName: 'Create packages'


### PR DESCRIPTION
Should stop the build system from erroring out when we don't run all tests