### PR TITLE
Fix hostname case sensitivity issue in cluster bootstrap self-join

### DIFF
--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/JoinDeciderSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/JoinDeciderSpec.cs
@@ -426,6 +426,41 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
             (await decider.Decide(_seedNodes)).Should().Be(KeepProbing.Instance);
         }
 
+        [Fact(DisplayName = "SelfAwareJoinDecider should match hostnames with different case")]
+        public void ShouldMatchHostnamesWithDifferentCase()
+        {
+            ClusterBootstrap.Get(System!).SetSelfContactPoint(new Uri($"http://host123:{ManagementPort}/test"));
+            var decider = new LowestAddressJoinDecider(System!, _settings!);
+            var selfContactPoint = decider.SelfContactPoint();
+            
+            // Create a target with uppercase hostname while self has lowercase
+            var targetWithUppercaseHost = new ResolvedTarget(
+                host: "HOST123", 
+                port: ManagementPort, 
+                address: null);
+            
+            // Should match despite case difference
+            decider.MatchesSelf(targetWithUppercaseHost, selfContactPoint).Should().BeTrue();
+            
+            // Create a target with mixed case hostname
+            var targetWithMixedCaseHost = new ResolvedTarget(
+                host: "Host123", 
+                port: ManagementPort, 
+                address: null);
+            
+            // Should match despite case difference
+            decider.MatchesSelf(targetWithMixedCaseHost, selfContactPoint).Should().BeTrue();
+            
+            // Create a target with completely different hostname
+            var targetWithDifferentHost = new ResolvedTarget(
+                host: "different-host", 
+                port: ManagementPort, 
+                address: null);
+            
+            // Should not match
+            decider.MatchesSelf(targetWithDifferentHost, selfContactPoint).Should().BeFalse();
+        }
+
         protected override Task Start()
         {
             _settings = ClusterBootstrapSettings.Create(System!.Settings.Config, Log!);
@@ -502,6 +537,41 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
             ClusterBootstrap.Get(System!).SetSelfContactPoint(new Uri($"http://10.0.0.2:{ManagementPort}/test"));
             var decider = new LowestAddressJoinDecider(System!, _settings);
             (await decider.Decide(_seedNodes)).Should().Be(KeepProbing.Instance);
+        }
+
+        [Fact(DisplayName = "SelfAwareJoinDecider should match hostnames with different case")]
+        public void ShouldMatchHostnamesWithDifferentCase()
+        {
+            ClusterBootstrap.Get(System!).SetSelfContactPoint(new Uri($"http://host123:{ManagementPort}/test"));
+            var decider = new LowestAddressJoinDecider(System!, _settings!);
+            var selfContactPoint = decider.SelfContactPoint();
+            
+            // Create a target with uppercase hostname while self has lowercase
+            var targetWithUppercaseHost = new ResolvedTarget(
+                host: "HOST123", 
+                port: ManagementPort, 
+                address: null);
+            
+            // Should match despite case difference
+            decider.MatchesSelf(targetWithUppercaseHost, selfContactPoint).Should().BeTrue();
+            
+            // Create a target with mixed case hostname
+            var targetWithMixedCaseHost = new ResolvedTarget(
+                host: "Host123", 
+                port: ManagementPort, 
+                address: null);
+            
+            // Should match despite case difference
+            decider.MatchesSelf(targetWithMixedCaseHost, selfContactPoint).Should().BeTrue();
+            
+            // Create a target with completely different hostname
+            var targetWithDifferentHost = new ResolvedTarget(
+                host: "different-host", 
+                port: ManagementPort, 
+                address: null);
+            
+            // Should not match
+            decider.MatchesSelf(targetWithDifferentHost, selfContactPoint).Should().BeFalse();
         }
 
         protected override Task Start()

--- a/src/management/Akka.Management/Cluster/Bootstrap/SelfAwareJoinDecider.cs
+++ b/src/management/Akka.Management/Cluster/Bootstrap/SelfAwareJoinDecider.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -67,7 +68,8 @@ namespace Akka.Management.Cluster.Bootstrap
         public bool HostMatches(string host, ServiceDiscovery.ResolvedTarget target)
         {
             var cleaned = _hostReplaceRegex.Replace(host, "");
-            return host == target.Host || (target.Address?.ToString() ?? "").Contains(cleaned);
+            return string.Equals(host, target.Host, StringComparison.OrdinalIgnoreCase) || 
+                   (target.Address?.ToString() ?? "").Contains(cleaned);
         }
 
         public abstract Task<IJoinDecision> Decide(SeedNodesInformation info);


### PR DESCRIPTION
- Modified SelfAwareJoinDecider.HostMatches to use case-insensitive string comparison
- Fixes issue where hostname casing differences between management/remote hostname and what's returned by Akka.Discovery causes self-join to fail
- Added comprehensive test to verify hostname matching works with different case variations
- Resolves issue #3361
