### PR TITLE
Fix Microsoft.Identity.Client documentation security issue

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,8 @@
     <AzureIdentityVersion>1.13.2</AzureIdentityVersion>
     <ProtobufVersion>3.30.2</ProtobufVersion>
     <GrpcToolsVersion>2.71.0</GrpcToolsVersion>
+    <!-- Needed to fix Microsoft.Identity.Client typosquatting phishing link bug (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5278) -->
+    <MicrosoftIdentityVersion>4.73.1</MicrosoftIdentityVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
+++ b/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
@@ -18,6 +18,7 @@
 		<PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
 		<PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
 		<PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityVersion)" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
 		<PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
 		<PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">

--- a/src/discovery/azure/Akka.Discovery.Azure/Akka.Discovery.Azure.csproj
+++ b/src/discovery/azure/Akka.Discovery.Azure/Akka.Discovery.Azure.csproj
@@ -19,6 +19,7 @@
       <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
       <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
       <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
+      <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityVersion)" />
       <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Changes

* Add explicit reference to the newest Microsoft.Identity.Client package due to https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5278

Apparently, the typo URL is being typosquatted by a phishing site and is a security risk.