### PR TITLE
Bump Azure.Identity

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,7 @@
     <KubernetesClientVersionNetStandard>4.0.26</KubernetesClientVersionNetStandard>
     <KubernetesClientVersionNet>13.0.26</KubernetesClientVersionNet>
     <MicrosoftExtensionsVersion>[6.0.*,)</MicrosoftExtensionsVersion>
-    <AzureIdentityVersion>1.13.2</AzureIdentityVersion>
+    <AzureIdentityVersion>1.14.2</AzureIdentityVersion>
     <ProtobufVersion>3.30.2</ProtobufVersion>
     <GrpcToolsVersion>2.71.0</GrpcToolsVersion>
     <!-- Needed to fix Microsoft.Identity.Client typosquatting phishing link bug (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5278) -->

--- a/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
+++ b/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
@@ -18,7 +18,6 @@
 		<PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
 		<PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
 		<PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityVersion)" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
 		<PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
 		<PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">

--- a/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
+++ b/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-    <TargetFrameworks>$(LibraryFramework);$(NetFramework)</TargetFrameworks>
+	<TargetFrameworks>$(LibraryFramework);$(NetFramework)</TargetFrameworks>
 		<Description>Akka.NET coordination module for Microsoft Azure</Description>
 		<PackageTags>$(AkkaPackageTags);Azure;</PackageTags>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <None Remove="protobuf\LeaseResource.proto" />
+		<None Remove="protobuf\LeaseResource.proto" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -27,7 +27,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <EmbeddedResource Include="reference.conf" />
+		<EmbeddedResource Include="reference.conf" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/discovery/azure/Akka.Discovery.Azure/Akka.Discovery.Azure.csproj
+++ b/src/discovery/azure/Akka.Discovery.Azure/Akka.Discovery.Azure.csproj
@@ -19,7 +19,6 @@
       <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
       <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
       <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
-      <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityVersion)" />
       <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Ref: https://github.com/akkadotnet/Akka.Management/pull/3370/files#r2201789201

## Changes

Bumps Azure.Identity to 1.14.2 which updates its transitive dependency on Microsoft.Identity.Client to 4.73.1
https://github.com/Azure/azure-sdk-for-net/releases/tag/Azure.Identity_1.14.2

Fixed minor indentation issues
(Note that the two changed `.csproj` files use different indentation tab vs spaces, opportunity for future improvement, I see there's no `.editorconfig` that could help for future changes. Opened an issue in the build system template https://github.com/akkadotnet/build-system-template/issues/27)
