### PR TITLE
Make AWS ECS Service discovery mechanism public and non-sealed (#3366)

### DIFF
--- a/src/discovery/aws/Akka.Discovery.AwsApi/Ecs/EcsServiceDiscovery.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi/Ecs/EcsServiceDiscovery.cs
@@ -19,7 +19,7 @@ using EcsTask = Amazon.ECS.Model.Task;
 
 namespace Akka.Discovery.AwsApi.Ecs
 {
-    internal sealed class EcsServiceDiscovery : ServiceDiscovery
+    public class EcsServiceDiscovery : ServiceDiscovery
     {
         public static readonly EcsTagComparer TagComparer = new ();
         


### PR DESCRIPTION
Fixes #3366

## Changes

Opens the `EcsServiceDiscovery` class to extension by making it public and non-sealed. This will allow consumers of the library to override it and provide custom implementations. 

For example, out of the box, the library supports discovering "neighboring" nodes only from containers running in the same ECS Service. But as described in #3366, "neighboring" nodes may have to be discovered from multiple ECS Services that are part of an ECS Cluster. With this change, consumers of the library can use the decorator pattern to extend and modify the default behavior of the `EcsServiceDiscovery` class.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #3366

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

No impact on performance as a result of this PR.
