### PR TITLE
Bump KubernetesClient to 17.0.14

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,8 +43,7 @@ The DNS discovery mechanism is ideal for containerized environments, cloud deplo
     <AkkaVersion>1.5.48</AkkaVersion>
     <AkkaHostingVersion>1.5.48</AkkaHostingVersion>
     <PbmVersion>1.4.4</PbmVersion>
-    <KubernetesClientVersionNetStandard>4.0.26</KubernetesClientVersionNetStandard>
-    <KubernetesClientVersionNet>13.0.26</KubernetesClientVersionNet>
+    <KubernetesClientVersionNet>17.0.14</KubernetesClientVersionNet>
     <MicrosoftExtensionsVersion>[6.0.*,)</MicrosoftExtensionsVersion>
     <AzureIdentityVersion>1.14.2</AzureIdentityVersion>
     <ProtobufVersion>3.30.2</ProtobufVersion>

--- a/src/cluster.bootstrap/examples/discovery/hocon-kubernetes/src/HoconKubernetesCluster/HoconKubernetesCluster.csproj
+++ b/src/cluster.bootstrap/examples/discovery/hocon-kubernetes/src/HoconKubernetesCluster/HoconKubernetesCluster.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/KubernetesCluster.csproj
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/KubernetesCluster.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>$(LibraryFramework);$(NetFramework)</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <Description>Akka.NET coordination module for Kubernetes</Description>
         <PackageTags>$(AkkaPackageTags);Kubernetes;</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -12,28 +12,6 @@
         <PackageReference Include="Akka.Coordination" Version="$(AkkaVersion)" />
         <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
         <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == '$(LibraryFramework)' ">
-        <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNetStandard)" />
-
-        <!--
-          These reference is added to resolve CVE-2024-21319 because KubernetesClient 4.0.26 references the bad version
-          of this package. This can be removed if KubernetesClient ever release a clean version in the future (not 
-          likely) or if we drop .NET Standard 2.0 support
-        -->
-        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.7.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
-
-        <!--
-          These reference is added to resolve CVE-2022-26907 because KubernetesClient 4.0.26 references the bad version
-          of this package. This can be removed if KubernetesClient ever release a clean version in the future (not 
-          likely) or if we drop .NET Standard 2.0 support
-        -->
-        <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFramework)' ">
         <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNet)" />
     </ItemGroup>
 

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>$(LibraryFramework);$(NetFramework)</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <Description>Akka.NET discovery module for Kubernetes</Description>
         <PackageTags>$(AkkaPackageTags);Kubernetes;</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,28 +11,6 @@
     <ItemGroup>
         <PackageReference Include="Akka.Discovery" Version="$(AkkaVersion)" />
         <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
-    </ItemGroup>
-    
-    <ItemGroup Condition=" '$(TargetFramework)' == '$(LibraryFramework)' ">
-        <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNetStandard)" />
-
-        <!--
-          These reference is added to resolve CVE-2024-21319 because KubernetesClient 4.0.26 references the bad version
-          of this package. This can be removed if KubernetesClient ever release a clean version in the future (not 
-          likely) or if we drop .NET Standard 2.0 support
-        -->
-        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.7.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
-
-        <!--
-          These reference is added to resolve CVE-2022-26907 because KubernetesClient 4.0.26 references the bad version
-          of this package. This can be removed if KubernetesClient ever release a clean version in the future (not 
-          likely) or if we drop .NET Standard 2.0 support
-        -->
-        <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFramework)' ">
         <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNet)" />
     </ItemGroup>
 


### PR DESCRIPTION
Fixes [CVE-2025-9708](https://github.com/advisories/GHSA-w7r3-mgwf-4mqq)

> [!NOTE]
> The fix is only available for net8.0, this forces us to drop support for netstandard2.0 and net6.0 for anything related to Kubernetes

## Changes

* Bump KubernetesClient to 17.0.14
* Remove dual targeting
* Targets .NET 8.0
