### PR TITLE
Update RELEASE_NOTES.md for 1.5.50 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,19 +1,9 @@
-#### 1.5.48 August 29th 2025 ####
+#### 1.5.50 September 23rd 2025 ####
 
-**Major Feature: Akka.Discovery.Dns**
+* Update to [Akka.NET v1.5.50](https://github.com/akkadotnet/akka.net/releases/tag/1.5.50)
+* Update to [Akka.Hosting v1.5.50](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.50)
+* [Bump KubernetesClient to 17.0.14](https://github.com/akkadotnet/Akka.Management/pull/3381) 
 
-This release introduces the new [**Akka.Discovery.Dns** module](https://github.com/akkadotnet/Akka.Management/tree/dev/src/discovery/dns/Akka.Discovery.Dns), providing native DNS-based service discovery for Akka.NET clusters! This powerful addition enables:
-
-* **DNS-based Service Discovery**: Automatically discover Akka.NET nodes using DNS SRV and A records
-* **Cloud-Native Integration**: Seamlessly integrate with Kubernetes DNS, Azure DNS, AWS Route 53, and other DNS providers
-* **Zero-Configuration Discovery**: Works out-of-the-box with standard DNS infrastructure
-* **Cluster Bootstrap Support**: Full integration with Akka.Management cluster bootstrap for automatic cluster formation
-
-The DNS discovery mechanism is ideal for containerized environments, cloud deployments, and any infrastructure with DNS-based service registration.
-
-**Other Improvements:**
-
-* Update to [Akka.NET v1.5.48](https://github.com/akkadotnet/akka.net/releases/tag/1.5.48)
-* Update to [Akka.Hosting v1.5.48](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.48)
-* [Make AWS ECS Service discovery mechanism public and non-sealed for extensibility](https://github.com/akkadotnet/Akka.Management/pull/3375) - AWS ECS discovery can now be extended and customized
-* [Bump Azure.Identity dependencies](https://github.com/akkadotnet/Akka.Management/pull/3373)
+> [!NOTE]
+> We're dropping .NET Standard 2.0 and .NET 6.0 support for all Kubernetes based projects due to [CVE-2025-9708](https://github.com/advisories/GHSA-w7r3-mgwf-4mqq).
+> KubernetesClient has been bumped to 17.0.14, which requires all Kubernetes project to only support .NET 8.0


### PR DESCRIPTION
#### 1.5.50 September 23rd 2025 ####

* Update to [Akka.NET v1.5.50](https://github.com/akkadotnet/akka.net/releases/tag/1.5.50)
* Update to [Akka.Hosting v1.5.50](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.50)
* [Bump KubernetesClient to 17.0.14](https://github.com/akkadotnet/Akka.Management/pull/3381) 

> [!NOTE]
> We're dropping .NET Standard 2.0 and .NET 6.0 support for all Kubernetes based projects due to [CVE-2025-9708](https://github.com/advisories/GHSA-w7r3-mgwf-4mqq).
> KubernetesClient has been bumped to 17.0.14, which requires all Kubernetes project to only support .NET 8.0