### PR TITLE
Improve logging for Cluster.Bootstrap hostname matching diagnostics

### DIFF
--- a/src/management/Akka.Management/Cluster/Bootstrap/SelfAwareJoinDecider.cs
+++ b/src/management/Akka.Management/Cluster/Bootstrap/SelfAwareJoinDecider.cs
@@ -51,9 +51,12 @@ namespace Akka.Management.Cluster.Bootstrap
             
             if (!info.ContactPoints.Any(t => MatchesSelf(t, self)))
             {
-                Log.Warning("Self contact point [{0}] not found in targets {1}",
+                Log.Warning(
+                    "Self contact point [{0}] (hostname: {1}, port: {2}) not found in targets [{3}]",
                     ContactPointString(self),
-                    string.Join(", ", info.ContactPoints));
+                    self.host,
+                    self.port,
+                    string.Join(", ", info.ContactPoints.Select(ContactPointString)));
             }
             return false;
         }
@@ -62,14 +65,38 @@ namespace Akka.Management.Cluster.Bootstrap
         {
             if (target.Port == null)
                 return HostMatches(contactPoint.host, target);
-            return HostMatches(contactPoint.host, target) && contactPoint.port == target.Port;
+
+            var hostMatches = HostMatches(contactPoint.host, target);
+            var portMatches = contactPoint.port == target.Port;
+            var result = hostMatches && portMatches;
+
+            if (Log.IsDebugEnabled && hostMatches && !portMatches)
+            {
+                Log.Debug(
+                    "MatchesSelf: Hostname matched but port mismatch - self port={0}, target port={1}",
+                    contactPoint.port, target.Port);
+            }
+
+            return result;
         }
 
         public bool HostMatches(string host, ServiceDiscovery.ResolvedTarget target)
         {
             var cleaned = _hostReplaceRegex.Replace(host, "");
-            return string.Equals(host, target.Host, StringComparison.OrdinalIgnoreCase) || 
-                   (target.Address?.ToString() ?? "").Contains(cleaned);
+            var directMatch = string.Equals(host, target.Host, StringComparison.OrdinalIgnoreCase);
+            var addressString = target.Address?.ToString() ?? "";
+            var containsMatch = addressString.Contains(cleaned);
+            var result = directMatch || containsMatch;
+
+            if (Log.IsDebugEnabled)
+            {
+                Log.Debug(
+                    "HostMatches comparison: self hostname='{0}', target hostname='{1}', target address='{2}', " +
+                    "direct match={3}, contains match={4}, result={5}",
+                    host, target.Host, addressString, directMatch, containsMatch, result);
+            }
+
+            return result;
         }
 
         public abstract Task<IJoinDecision> Decide(SeedNodesInformation info);

--- a/src/management/Akka.Management/Dsl/AkkaManagement.cs
+++ b/src/management/Akka.Management/Dsl/AkkaManagement.cs
@@ -128,7 +128,8 @@ namespace Akka.Management.Dsl
                 var effectiveBindPort = Settings.Http.EffectiveBindPort;
                 var effectiveProviderSettings = transformSettings(ProviderSettings());
 
-                _log.Info("Binding Akka Management (HTTP) endpoint to: {0}:{1}", effectiveBindHostname, effectiveBindPort);
+                _log.Info("Binding Akka Management (HTTP) endpoint to: {0}:{1}, advertising as hostname: {2}",
+                    effectiveBindHostname, effectiveBindPort, Settings.Http.Hostname);
 
                 var combinedRoutes = PrepareCombinedRoutes(effectiveProviderSettings);
 


### PR DESCRIPTION
## Summary

Addresses #3387 by adding detailed diagnostic logging to help debug hostname/IP mismatch issues during cluster bootstrap.

## Changes

1. **HostMatches method** - Added DEBUG logging showing:
   - Self hostname being compared
   - Target hostname from discovery
   - Target IP address (if available)
   - Direct string match result
   - Contains match result
   - Final match result

2. **MatchesSelf method** - Added DEBUG logging for the edge case where hostname matches but port doesn't

3. **CanJoinSelf warning** - Enhanced to separately display hostname and port values when self contact point is not found in discovered targets

4. **AkkaManagement binding log** - Now shows the advertised hostname alongside the bind address to clarify the difference

## Example Logs

**Before:**
```
[INFO] Binding Akka Management (HTTP) endpoint to: 0.0.0.0:8558
[INFO] Located service members based on: [Lookup(drawtogether, management, tcp)]: [ResolvedTarget(10.1.2.138, 8558, 10.1.2.138)], filtered to [10.1.2.138:8558]
[INFO] Contact point [akka.tcp://DrawTogether@drawtogether-0.drawtogether:5055] returned [0] seed-nodes []
```

**After (with DEBUG enabled):**
```
[INFO] Binding Akka Management (HTTP) endpoint to: 0.0.0.0:8558, advertising as hostname: drawtogether-0.drawtogether
[DEBUG] HostMatches comparison: self hostname='drawtogether-0.drawtogether', target hostname='10.1.2.138', target address='10.1.2.138', direct match=False, contains match=False, result=False
[WARN] Self contact point [drawtogether-0.drawtogether:8558] (hostname: drawtogether-0.drawtogether, port: 8558) not found in targets [10.1.2.138:8558]
```

## Testing

No new tests required - these are purely observability improvements that don't change any logic or require infrastructure modifications.

Fixes #3387