### PR TITLE
Release 1.5.55

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.52</VersionPrefix>
-    <PackageReleaseNotes>* Update to [Akka.NET v1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55)
-* Update to [Akka.Hosting v1.5.55](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.55)</PackageReleaseNotes>
+    <VersionPrefix>1.5.55</VersionPrefix>
+    <PackageReleaseNotes>* [Improve logging for Cluster.Bootstrap hostname matching diagnostics](https://github.com/akkadotnet/Akka.Management/pull/3388) - fixes [#3387](https://github.com/akkadotnet/Akka.Management/issues/3387)
+* [Update Akka.Hosting and Pbm versions](https://github.com/akkadotnet/Akka.Management/pull/3389)</PackageReleaseNotes>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Management</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.55 October 26th 2025 ####
+
+* [Improve logging for Cluster.Bootstrap hostname matching diagnostics](https://github.com/akkadotnet/Akka.Management/pull/3388) - fixes [#3387](https://github.com/akkadotnet/Akka.Management/issues/3387)
+* [Update Akka.Hosting and Pbm versions](https://github.com/akkadotnet/Akka.Management/pull/3389)
+
 #### 1.5.52 October 9th 2025 ####
 
 * Update to [Akka.NET v1.5.52](https://github.com/akkadotnet/akka.net/releases/tag/1.5.52)


### PR DESCRIPTION
## Release 1.5.55

This PR prepares the release for version 1.5.55.

### Changes

* [Improve logging for Cluster.Bootstrap hostname matching diagnostics](https://github.com/akkadotnet/Akka.Management/pull/3388) - fixes [#3387](https://github.com/akkadotnet/Akka.Management/issues/3387)
* [Update Akka.Hosting and Pbm versions](https://github.com/akkadotnet/Akka.Management/pull/3389)

### Files Updated

- `RELEASE_NOTES.md` - Added release notes for version 1.5.55
- `Directory.Build.props` - Updated version metadata