### PR TITLE
Migrate to Central Package Management (CPM)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,14 +29,14 @@
     <AkkaHostingVersion>1.5.55</AkkaHostingVersion>
     <PbmVersion>1.4.5</PbmVersion>
     <KubernetesClientVersionNet>17.0.14</KubernetesClientVersionNet>
-    <MicrosoftExtensionsVersion>[6.0.*,)</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>
     <AzureIdentityVersion>1.14.2</AzureIdentityVersion>
     <ProtobufVersion>3.30.2</ProtobufVersion>
     <GrpcToolsVersion>2.71.0</GrpcToolsVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,85 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!-- Akka.NET packages -->
+  <ItemGroup>
+    <PackageVersion Include="Akka" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Cluster" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Cluster.Tools" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Coordination" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Discovery" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Remote.Hosting" Version="$(AkkaHostingVersion)" />
+    <PackageVersion Include="Akka.TestKit" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+  </ItemGroup>
+
+  <!-- Akka.Hosting packages -->
+  <ItemGroup>
+    <PackageVersion Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
+    <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
+    <PackageVersion Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
+  </ItemGroup>
+
+  <!-- AWS SDK packages -->
+  <ItemGroup>
+    <PackageVersion Include="AWSSDK.CloudFormation" Version="3.7.403.18" />
+    <PackageVersion Include="AWSSDK.EC2" Version="3.7.437.13" />
+    <PackageVersion Include="AWSSDK.ECS" Version="3.7.409.1" />
+    <PackageVersion Include="AWSSDK.S3" Version="3.7.416.13" />
+  </ItemGroup>
+
+  <!-- Azure packages -->
+  <ItemGroup>
+    <PackageVersion Include="Azure.Data.Tables" Version="12.10.0" />
+    <PackageVersion Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.23.0" />
+  </ItemGroup>
+
+  <!-- Kubernetes packages -->
+  <ItemGroup>
+    <PackageVersion Include="KubernetesClient" Version="$(KubernetesClientVersionNet)" />
+  </ItemGroup>
+
+  <!-- Microsoft Extensions packages -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
+  </ItemGroup>
+
+  <!-- Testing packages -->
+  <ItemGroup>
+    <PackageVersion Include="xunit" Version="$(XunitVersion)" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageVersion Include="coverlet.collector" Version="$(CoverletVersion)" />
+    <PackageVersion Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
+    <PackageVersion Include="WireMock.Net" Version="$(WireMockVersion)" />
+    <PackageVersion Include="Testcontainers.Azurite" Version="4.4.0" />
+    <PackageVersion Include="Testcontainers.LocalStack" Version="4.4.0" />
+  </ItemGroup>
+
+  <!-- Protobuf and gRPC packages -->
+  <ItemGroup>
+    <PackageVersion Include="Google.Protobuf" Version="$(ProtobufVersion)" />
+    <PackageVersion Include="Grpc.Tools" Version="$(GrpcToolsVersion)" />
+  </ItemGroup>
+
+  <!-- Petabridge packages -->
+  <ItemGroup>
+    <PackageVersion Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
+    <PackageVersion Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
+  </ItemGroup>
+
+  <!-- Other packages -->
+  <ItemGroup>
+    <PackageVersion Include="Ceen.Httpd" Version="0.9.9" />
+    <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/cluster.bootstrap/examples/discovery/azure/AzureCluster/AzureCluster.csproj
+++ b/src/cluster.bootstrap/examples/discovery/azure/AzureCluster/AzureCluster.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="Akka.Cluster.Tools" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
-        <PackageReference Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
-        <PackageReference Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+        <PackageReference Include="Akka.Cluster.Hosting" />
+        <PackageReference Include="Akka.Cluster.Tools" />
+        <PackageReference Include="Akka.DependencyInjection" />
+        <PackageReference Include="Petabridge.Cmd.Cluster" />
+        <PackageReference Include="Petabridge.Cmd.Remote" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/cluster.bootstrap/examples/discovery/dns/src/DnsCluster.csproj
+++ b/src/cluster.bootstrap/examples/discovery/dns/src/DnsCluster.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
-    <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-    <PackageReference Include="Akka.Cluster.Tools" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
-    <PackageReference Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
-    <PackageReference Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Akka.Hosting" />
+    <PackageReference Include="Akka.Cluster.Hosting" />
+    <PackageReference Include="Akka.Cluster.Tools" />
+    <PackageReference Include="Akka.DependencyInjection" />
+    <PackageReference Include="Petabridge.Cmd.Cluster" />
+    <PackageReference Include="Petabridge.Cmd.Remote" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/KubernetesCluster.csproj
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/KubernetesCluster.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="Akka.Cluster.Tools" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
-        <PackageReference Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
-        <PackageReference Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+        <PackageReference Include="Akka.Cluster.Hosting" />
+        <PackageReference Include="Akka.Cluster.Tools" />
+        <PackageReference Include="Akka.DependencyInjection" />
+        <PackageReference Include="Petabridge.Cmd.Cluster" />
+        <PackageReference Include="Petabridge.Cmd.Remote" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/Akka.Coordination.Azure.Tests.csproj
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/Akka.Coordination.Azure.Tests.csproj
@@ -6,19 +6,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="Akka.Cluster.Tools" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="Testcontainers.Azurite" Version="4.4.0" />
-        <PackageReference Include="WireMock.Net" Version="$(WireMockVersion)" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
+        <PackageReference Include="Akka.Hosting.TestKit" />
+        <PackageReference Include="Akka.Cluster.Tools" />
+        <PackageReference Include="Akka.TestKit.Xunit2" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Testcontainers.Azurite" />
+        <PackageReference Include="WireMock.Net" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
+++ b/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
@@ -13,14 +13,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Akka.Discovery" Version="$(AkkaVersion)" />
-		<PackageReference Include="Akka.Cluster" Version="$(AkkaVersion)" />
-		<PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
-		<PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-		<PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
-		<PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-		<PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
-		<PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">
+		<PackageReference Include="Akka.Discovery" />
+		<PackageReference Include="Akka.Cluster" />
+		<PackageReference Include="Akka.Hosting" />
+		<PackageReference Include="Akka.Cluster.Hosting" />
+		<PackageReference Include="Azure.Identity" />
+		<PackageReference Include="Azure.Storage.Blobs" />
+		<PackageReference Include="Google.Protobuf" />
+		<PackageReference Include="Grpc.Tools">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/coordination/examples/azure/Azure.StressTest/Azure.StressTest.csproj
+++ b/src/coordination/examples/azure/Azure.StressTest/Azure.StressTest.csproj
@@ -10,12 +10,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Cluster.Tools" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
-        <PackageReference Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+        <PackageReference Include="Akka.Cluster.Tools" />
+        <PackageReference Include="Akka.DependencyInjection" />
+        <PackageReference Include="Akka.Cluster.Hosting" />
+        <PackageReference Include="Petabridge.Cmd.Cluster" />
+        <PackageReference Include="Petabridge.Cmd.Remote" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/coordination/examples/kubernetes/Kubernetes.StressTest/Kubernetes.StressTest.csproj
+++ b/src/coordination/examples/kubernetes/Kubernetes.StressTest/Kubernetes.StressTest.csproj
@@ -9,15 +9,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="Akka.Cluster.Tools" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
-        <PackageReference Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
-        <PackageReference Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+        <PackageReference Include="Akka.Cluster.Hosting" />
+        <PackageReference Include="Akka.Cluster.Tools" />
+        <PackageReference Include="Akka.DependencyInjection" />
+        <PackageReference Include="Petabridge.Cmd.Cluster" />
+        <PackageReference Include="Petabridge.Cmd.Remote" />
+        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/Akka.Coordination.KubernetesApi.Tests.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/Akka.Coordination.KubernetesApi.Tests.csproj
@@ -6,17 +6,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="WireMock.Net" Version="$(WireMockVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
+        <PackageReference Include="Akka.TestKit.Xunit2" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="WireMock.Net" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Coordination" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNet)" />
+        <PackageReference Include="Akka.Coordination" />
+        <PackageReference Include="Akka.Hosting" />
+        <PackageReference Include="Akka.Cluster.Hosting" />
+        <PackageReference Include="KubernetesClient" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/Akka.Discovery.AwsApi.Integration.Tests.csproj
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/Akka.Discovery.AwsApi.Integration.Tests.csproj
@@ -6,25 +6,25 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Cluster" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.TestKit" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
-        <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.403.18" />
-        <PackageReference Include="AWSSDK.S3" Version="3.7.416.13" />
-        <PackageReference Include="Docker.DotNet" Version="3.125.15" />
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="Testcontainers.LocalStack" Version="4.4.0" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
+        <PackageReference Include="Akka.Cluster" />
+        <PackageReference Include="Akka.TestKit" />
+        <PackageReference Include="Akka.TestKit.Xunit2" />
+        <PackageReference Include="AWSSDK.CloudFormation" />
+        <PackageReference Include="AWSSDK.S3" />
+        <PackageReference Include="Docker.DotNet" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Testcontainers.LocalStack" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+        <PackageReference Include="Xunit.SkippableFact" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Akka.Discovery.AwsApi.Tests.csproj
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Akka.Discovery.AwsApi.Tests.csproj
@@ -6,14 +6,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVersion)">
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/discovery/aws/Akka.Discovery.AwsApi/Akka.Discovery.AwsApi.csproj
+++ b/src/discovery/aws/Akka.Discovery.AwsApi/Akka.Discovery.AwsApi.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Akka.Discovery" Version="$(AkkaVersion)" />
-      <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
-      <PackageReference Include="AWSSDK.EC2" Version="3.7.437.13" />
-      <PackageReference Include="AWSSDK.ECS" Version="3.7.409.1" />
+      <PackageReference Include="Akka.Discovery" />
+      <PackageReference Include="Akka.Hosting" />
+      <PackageReference Include="AWSSDK.EC2" />
+      <PackageReference Include="AWSSDK.ECS" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/Akka.Discovery.Azure.Tests.csproj
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/Akka.Discovery.Azure.Tests.csproj
@@ -6,18 +6,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-        <PackageReference Include="Testcontainers.Azurite" Version="4.4.0" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
+        <PackageReference Include="Akka.Cluster.Hosting" />
+        <PackageReference Include="Akka.TestKit.Xunit2" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Testcontainers.Azurite" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/discovery/azure/Akka.Discovery.Azure/Akka.Discovery.Azure.csproj
+++ b/src/discovery/azure/Akka.Discovery.Azure/Akka.Discovery.Azure.csproj
@@ -13,13 +13,13 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Akka.Discovery" Version="$(AkkaVersion)" />
-      <PackageReference Include="Akka.Cluster" Version="$(AkkaVersion)" />
-      <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
-      <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
-      <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
-      <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
-      <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">
+      <PackageReference Include="Akka.Discovery" />
+      <PackageReference Include="Akka.Cluster" />
+      <PackageReference Include="Akka.Hosting" />
+      <PackageReference Include="Azure.Data.Tables" />
+      <PackageReference Include="Azure.Identity" />
+      <PackageReference Include="Google.Protobuf" />
+      <PackageReference Include="Grpc.Tools">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>

--- a/src/discovery/dns/Akka.Discovery.Dns.Tests/Akka.Discovery.Dns.Tests.csproj
+++ b/src/discovery/dns/Akka.Discovery.Dns.Tests/Akka.Discovery.Dns.Tests.csproj
@@ -6,15 +6,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVersion)">
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Akka.TestKit.Xunit2" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/discovery/dns/Akka.Discovery.Dns/Akka.Discovery.Dns.csproj
+++ b/src/discovery/dns/Akka.Discovery.Dns/Akka.Discovery.Dns.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Akka.Discovery" Version="$(AkkaVersion)" />
-      <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
+      <PackageReference Include="Akka.Discovery" />
+      <PackageReference Include="Akka.Hosting" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/discovery/examples/Aws.Ecs/Aws.Ecs.csproj
+++ b/src/discovery/examples/Aws.Ecs/Aws.Ecs.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-      <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" />
+      <PackageReference Include="Akka.Cluster.Hosting" />
     </ItemGroup>
 
 </Project>

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/Akka.Discovery.KubernetesApi.Tests.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/Akka.Discovery.KubernetesApi.Tests.csproj
@@ -6,15 +6,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Discovery" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
-        <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersionNet)" />
+        <PackageReference Include="Akka.Discovery" />
+        <PackageReference Include="Akka.Hosting" />
+        <PackageReference Include="KubernetesClient" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/management/Akka.Http.Shim.Tests/Akka.Http.Shim.Tests.csproj
+++ b/src/management/Akka.Http.Shim.Tests/Akka.Http.Shim.Tests.csproj
@@ -6,15 +6,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
+        <PackageReference Include="Akka.TestKit.Xunit2" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/management/Akka.Http.Shim/Akka.Http.Shim.csproj
+++ b/src/management/Akka.Http.Shim/Akka.Http.Shim.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="$(AkkaVersion)" />
-    <PackageReference Include="Ceen.Httpd" Version="0.9.9" />
+    <PackageReference Include="Akka" />
+    <PackageReference Include="Ceen.Httpd" />
   </ItemGroup>
 
 </Project>

--- a/src/management/Akka.Management.Tests/Akka.Management.Tests.csproj
+++ b/src/management/Akka.Management.Tests/Akka.Management.Tests.csproj
@@ -6,21 +6,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
-    <PackageReference Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-    <PackageReference Include="Akka.Remote.Hosting" Version="$(AkkaHostingVersion)" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
+    <PackageReference Include="Akka.Hosting.TestKit" />
+    <PackageReference Include="Akka.Cluster.Hosting" />
+    <PackageReference Include="Akka.Remote.Hosting" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.TestKit.Xunit2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/management/Akka.Management/Akka.Management.csproj
+++ b/src/management/Akka.Management/Akka.Management.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Cluster" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Discovery" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
+    <PackageReference Include="Akka.Cluster" />
+    <PackageReference Include="Akka.Discovery" />
+    <PackageReference Include="Akka.Hosting" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

This PR migrates Akka.Management to use NuGet's Central Package Management (CPM) feature for cleaner, more maintainable package version management.

## Changes

- **Added** `Directory.Packages.props` with all package versions organized by category (Akka.NET, AWS, Azure, Kubernetes, Testing, etc.)
- **Enabled** `ManagePackageVersionsCentrally` in `Directory.Build.props`
- **Removed** `Version` attributes from all `PackageReference` elements across 23 `.csproj` files
- **Fixed** floating version `[6.0.*,)` → `6.0.0` for Microsoft.Extensions packages (CPM doesn't support version ranges)
- **Updated** Microsoft.SourceLink.GitHub reference to use centralized versioning

## Benefits

- **Cleaner project files** - No version attributes cluttering `.csproj` files
- **Centralized management** - All package versions in one location (`Directory.Packages.props`)
- **Easier updates** - Update package versions in a single file
- **Consistency enforcement** - NuGet automatically ensures version consistency across projects
- **Better IDE support** - Modern IDEs provide enhanced tooling for CPM

## Testing

✅ Full solution build completed successfully with no errors (only pre-existing warnings)

## Migration Notes

The project was already using centralized version variables in `Directory.Build.props` (e.g., `$(AkkaVersion)`), so this migration was straightforward. CPM is the modern, recommended approach for multi-project solutions.