### PR TITLE
Fix: Use windows-2022 explicitly in release pipeline

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -2,7 +2,7 @@
 # See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
 
 pool:
-  vmImage: windows-latest
+  vmImage: windows-2022
   demands: Cmd
 
 trigger:


### PR DESCRIPTION
Azure DevOps has a known bug where `windows-latest` still resolves to `windows-2019` in some cases, even after the image was retired.

This change explicitly uses `windows-2022` to work around the issue.

See: https://learn.microsoft.com/en-us/answers/questions/2280894/azure-devops-pipeline-specifies-windows-latest-but