### PR TITLE
Update outdated health check reference in reference.conf

### DIFF
--- a/src/management/Akka.Management/Resources/reference.conf
+++ b/src/management/Akka.Management/Resources/reference.conf
@@ -53,8 +53,9 @@ akka.management {
     # The FQCN is the fully qualified class name of the `ManagementRoutesProvider`.
     #
     # Unlike the scala version, Akka.NET Akka.Management does not provide any health check capability but
-    # provides cluster bootstrap functionality instead. If you need any health check capability, 
-    # please install the Akka.HealthCheck NuGet package.
+    # provides cluster bootstrap functionality instead. If you need any health check capability,
+    # Akka.Hosting v1.5.48.1+ has built-in Microsoft.Extensions.HealthChecks integration.
+    # See https://petabridge.com/blog/you-dont-need-akka-healthchecks-anymore/
     #
     routes {
         # registers bootstrap routes to be included in akka-management's http endpoint


### PR DESCRIPTION
## Summary

- Updated the comment in `reference.conf` that pointed users to the deprecated `Akka.HealthCheck` NuGet package
- `Akka.Hosting` v1.5.48.1+ now has built-in `Microsoft.Extensions.HealthChecks` integration which replaces it
- Added link to the blog post explaining the migration: https://petabridge.com/blog/you-dont-need-akka-healthchecks-anymore/

## Test plan

- [x] Comment-only change in `reference.conf`, no code behavior affected