### PR TITLE
Fix premature `LeaseAcquired` in `LeaseActor` Granting state

### DIFF
--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -393,6 +393,86 @@ namespace Akka.Coordination.Azure.Tests
             // TODO this could accumulate senders and reply to all, atm it'll log saying previous action hasn't finished
         }
 
+        // Regression test: when a write conflict occurs in Granting state and the blob has no owner,
+        // LeaseAcquired must NOT be sent until the retry write succeeds. Sending it prematurely causes
+        // the shard to start without localGranted=true and without heartbeats, leading to a shard-level
+        // split brain if another node takes the lease before the retry completes.
+        [Fact(DisplayName = "LeaseActor should not send LeaseAcquired prematurely on conflict retry in Granting state")]
+        public void ShouldNotSendLeaseAcquiredPrematurelyOnConflictRetry()
+        {
+            RunTest(() =>
+            {
+                // Start acquiring: read returns empty lease
+                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
+                LeaseProbe.ExpectMsg(LeaseName);
+                LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
+
+                // First write attempt
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+
+                // Conflict: version moved but no owner (another node wrote and released)
+                var conflictVersion = new ETag((CurrentVersionCount + 3).ToString());
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource("", conflictVersion, CurrentTime)));
+
+                // LeaseAcquired must NOT have been sent yet — the retry hasn't completed
+                SenderProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+
+                // Retry write is issued with the new version
+                UpdateProbe.ExpectMsg((OwnerName, conflictVersion));
+
+                // Retry also conflicts, but this time another node owns it
+                var stolenVersion = new ETag((CurrentVersionCount + 5).ToString());
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource("another-node", stolenVersion, CurrentTime)));
+
+                // Now the caller should get LeaseTaken (not a stale LeaseAcquired)
+                SenderProbe.ExpectMsg<LeaseActor.LeaseTaken>();
+                Granted.Value.Should().BeFalse();
+            });
+        }
+
+        // Verify that conflict retry with no owner eventually succeeds and properly
+        // transitions to Granted state with heartbeats enabled
+        [Fact(DisplayName = "LeaseActor should acquire lease after conflict retry succeeds")]
+        public void ShouldAcquireLeaseAfterConflictRetrySucceeds()
+        {
+            RunTest(() =>
+            {
+                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
+                LeaseProbe.ExpectMsg(LeaseName);
+                LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
+
+                // First write attempt
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+
+                // Conflict: version moved but no owner
+                var conflictVersion = new ETag((CurrentVersionCount + 3).ToString());
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource("", conflictVersion, CurrentTime)));
+
+                // No premature LeaseAcquired
+                SenderProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+
+                // Retry write succeeds
+                UpdateProbe.ExpectMsg((OwnerName, conflictVersion));
+                var grantedVersion = new ETag((CurrentVersionCount + 6).ToString());
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, grantedVersion, CurrentTime)));
+
+                // NOW LeaseAcquired should be sent
+                SenderProbe.ExpectMsg<LeaseActor.LeaseAcquired>();
+                Granted.Value.Should().BeTrue();
+
+                // Heartbeat should be running (proves we're in Granted state)
+                UpdateProbe.ExpectMsg((OwnerName, grantedVersion));
+            });
+        }
+
         [Fact(DisplayName = "LeaseActor should return lease taken if conflict when updating lease")]
         public void ReturnLeaseTakenIfConflictWhenUpdatingLease()
         {

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -6,6 +6,9 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -393,83 +396,37 @@ namespace Akka.Coordination.Azure.Tests
             // TODO this could accumulate senders and reply to all, atm it'll log saying previous action hasn't finished
         }
 
-        // Regression test: when a write conflict occurs in Granting state and the blob has no owner,
-        // LeaseAcquired must NOT be sent until the retry write succeeds. Sending it prematurely causes
-        // the shard to start without localGranted=true and without heartbeats, leading to a shard-level
-        // split brain if another node takes the lease before the retry completes.
-        [Fact(DisplayName = "LeaseActor should not send LeaseAcquired prematurely on conflict retry in Granting state")]
-        public void ShouldNotSendLeaseAcquiredPrematurelyOnConflictRetry()
+        // Regression test: when a CAS conflict occurs in Granting state and the blob is unowned,
+        // the actor retries the write. If the retry is then stolen by another node, the caller
+        // should receive exactly one message: LeaseTaken — not a premature LeaseAcquired.
+        [Fact(DisplayName = "LeaseActor should not send premature LeaseAcquired when conflict retry is stolen")]
+        public void ShouldNotSendPrematureLeaseAcquiredWhenConflictRetryIsStolen()
         {
             RunTest(() =>
             {
-                // Start acquiring: read returns empty lease
                 UnderTest.Tell(new LeaseActor.Acquire(), Sender);
                 LeaseProbe.ExpectMsg(LeaseName);
                 LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
 
-                // First write attempt
+                // First write: conflict with unowned blob — triggers retry
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-
-                // Conflict: version moved but no owner (another node wrote and released)
                 var conflictVersion = new ETag((CurrentVersionCount + 3).ToString());
                 UpdateProbe.Reply(
                     new Left<LeaseResource, LeaseResource>(
                         new LeaseResource("", conflictVersion, CurrentTime)));
 
-                // LeaseAcquired must NOT have been sent yet — the retry hasn't completed
-                SenderProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-
-                // Retry write is issued with the new version
+                // Retry write dispatched, then stolen by another node
                 UpdateProbe.ExpectMsg((OwnerName, conflictVersion));
-
-                // Retry also conflicts, but this time another node owns it
                 var stolenVersion = new ETag((CurrentVersionCount + 5).ToString());
                 UpdateProbe.Reply(
                     new Left<LeaseResource, LeaseResource>(
                         new LeaseResource("another-node", stolenVersion, CurrentTime)));
 
-                // Now the caller should get LeaseTaken (not a stale LeaseAcquired)
-                SenderProbe.ExpectMsg<LeaseActor.LeaseTaken>();
+                // Single-sender ordering: if the premature LeaseAcquired was sent,
+                // it arrives before LeaseTaken. So the first message tells us everything.
+                SenderProbe.ExpectMsg<object>().Should().BeOfType<LeaseActor.LeaseTaken>(
+                    "caller should receive LeaseTaken, not a premature LeaseAcquired");
                 Granted.Value.Should().BeFalse();
-            });
-        }
-
-        // Verify that conflict retry with no owner eventually succeeds and properly
-        // transitions to Granted state with heartbeats enabled
-        [Fact(DisplayName = "LeaseActor should acquire lease after conflict retry succeeds")]
-        public void ShouldAcquireLeaseAfterConflictRetrySucceeds()
-        {
-            RunTest(() =>
-            {
-                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
-                LeaseProbe.ExpectMsg(LeaseName);
-                LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
-
-                // First write attempt
-                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-
-                // Conflict: version moved but no owner
-                var conflictVersion = new ETag((CurrentVersionCount + 3).ToString());
-                UpdateProbe.Reply(
-                    new Left<LeaseResource, LeaseResource>(
-                        new LeaseResource("", conflictVersion, CurrentTime)));
-
-                // No premature LeaseAcquired
-                SenderProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-
-                // Retry write succeeds
-                UpdateProbe.ExpectMsg((OwnerName, conflictVersion));
-                var grantedVersion = new ETag((CurrentVersionCount + 6).ToString());
-                UpdateProbe.Reply(
-                    new Right<LeaseResource, LeaseResource>(
-                        new LeaseResource(OwnerName, grantedVersion, CurrentTime)));
-
-                // NOW LeaseAcquired should be sent
-                SenderProbe.ExpectMsg<LeaseActor.LeaseAcquired>();
-                Granted.Value.Should().BeTrue();
-
-                // Heartbeat should be running (proves we're in Granted state)
-                UpdateProbe.ExpectMsg((OwnerName, grantedVersion));
             });
         }
 

--- a/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
@@ -359,7 +359,6 @@ namespace Akka.Coordination.Azure
                         throw new LeaseException(
                             $"Update response from Azure Blob should not return the same version: Response: {leftResponse}. Client: {data}");
                     // Try again as lock version has moved on but is not taken
-                    who.Tell(LeaseAcquired.Instance);
                     _client.UpdateLeaseResource(leaseName, _ownerName, version)
                         .ContinueWith(t => new WriteResponse(t.Result))
                         .PipeTo(Self, failure: FlattenAggregateException);

--- a/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
@@ -358,7 +358,9 @@ namespace Akka.Coordination.Azure
                     if (oldVersion == leftResponse.Version)
                         throw new LeaseException(
                             $"Update response from Azure Blob should not return the same version: Response: {leftResponse}. Client: {data}");
-                    // Try again as lock version has moved on but is not taken
+                    // Try again as lock version has moved on but is not taken.
+                    // Do NOT reply yet — wait for the WriteResponse.
+                    // On success the existing Right<> branch will send LeaseAcquired and go to Granted.
                     _client.UpdateLeaseResource(leaseName, _ownerName, version)
                         .ContinueWith(t => new WriteResponse(t.Result))
                         .PipeTo(Self, failure: FlattenAggregateException);


### PR DESCRIPTION
Fixes #3402

### Problem

When a write conflict occurs in the `Granting` state and the blob has no owner, `LeaseActor` sends `LeaseAcquired` to the caller **before** the retry write completes. The `Ask` future completes immediately, the shard starts running, but:

- `localGranted` stays `false` (only set on successful `Right` response)
- Heartbeat timer never starts (only starts on transition to `Granted`)
- `LeaseLost` callback is lost when FSM drops to `Idle`

If the retry write then fails (another node takes the lease), two nodes can run the same shard simultaneously — a shard-level split brain. The shard has no mechanism to detect this because `Akka.Cluster.Sharding` relies on the `LeaseLost` callback (not `CheckLease()` polling) and that callback is gone.

### Race condition

```
1. Node B writes to acquire    → 409 conflict
2. Conflict read: no owner     → sends LeaseAcquired (BUG) → shard starts
3. Retry write                 → 409 conflict, Node A now owns it
4. Sends LeaseTaken to caller  → dead letters (Ask already completed)
5. FSM → Idle                  → no heartbeats, no lease, no detection
6. After 96s TTL               → Node A also acquires shard → split brain
```

### Fix

Removed `who.Tell(LeaseAcquired.Instance)` from the conflict-retry path in the `Granting` handler. The FSM stays in `Granting` with the same `OperationInProgress` data, preserving `who`, `leaseLostCallback`, and `operationStartTime`. `LeaseAcquired` is only sent after a successful write response, which sets `localGranted = true` and transitions to `Granted`.

### Files changed

| File | Change |
|------|--------|
| `src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs` | Remove premature `who.Tell(LeaseAcquired.Instance)` in Granting conflict-retry path |
| `src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs` | Add two regression tests |

### Test plan

- [x] `ShouldNotSendLeaseAcquiredPrematurelyOnConflictRetry` — conflict with no owner → retry → stolen → verifies `LeaseTaken` returned (not premature `LeaseAcquired`), `Granted` stays `false`
- [x] `ShouldAcquireLeaseAfterConflictRetrySucceeds` — conflict with no owner → retry succeeds → verifies `LeaseAcquired` only after success, `Granted` is `true`, heartbeat running
- [x] All 29 existing tests pass (1 pre-existing skip), 0 regressions
