### PR TITLE
Retry heartbeat on transient failure instead of immediately surrendering lease

### DIFF
--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -324,18 +324,13 @@ namespace Akka.Coordination.Azure.Tests
         {
             RunTest(() =>
             {
-                var failure = new LeaseException("Failed to communicate with API server");
                 AcquireLease();
                 ExpectHeartBeat();
                 Granted.Value.Should().BeTrue();
 
-                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-                IncrementVersion();
-                UpdateProbe.Reply(new Status.Failure(failure));
-                AwaitAssert(() =>
-                {
-                    Granted.Value.Should().BeFalse();
-                });
+                // With retry logic, multiple failures are needed to exhaust the TTL window
+                HeartBeatFailure();
+                Granted.Value.Should().BeFalse();
             });
         }
 
@@ -353,13 +348,104 @@ namespace Akka.Coordination.Azure.Tests
                 ExpectHeartBeat();
                 Granted.Value.Should().BeTrue();
 
-                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-                IncrementVersion();
-                UpdateProbe.Reply(new Status.Failure(failure));
+                // With retry logic, drive failures until TTL expires and callback fires
+                DriveHeartBeatFailures(failure);
                 AwaitAssert(() =>
                 {
                     callbackCalled.Should().Be(failure);
                 });
+            });
+        }
+
+        [Fact(DisplayName = "transient heartbeat failure should retry and stay granted")]
+        public void TransientHeartBeatFailureShouldRetryAndStayGranted()
+        {
+            RunTest(() =>
+            {
+                AcquireLease();
+                ExpectHeartBeat();
+                Granted.Value.Should().BeTrue();
+
+                // First heartbeat fails transiently
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                UpdateProbe.Reply(new Status.Failure(new LeaseException("Transient failure")));
+
+                // Should still be granted — actor retries within TTL window
+                Granted.Value.Should().BeTrue();
+
+                // Retry heartbeat succeeds
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                IncrementVersion();
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
+
+                // Should still be granted and heartbeating normally
+                Granted.Value.Should().BeTrue();
+
+                // Normal heartbeat continues
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+            });
+        }
+
+        [Fact(DisplayName = "multiple transient heartbeat failures should recover on success")]
+        public void MultipleTransientHeartBeatFailuresShouldRecover()
+        {
+            RunTest(() =>
+            {
+                AcquireLease();
+                ExpectHeartBeat();
+                Granted.Value.Should().BeTrue();
+
+                // Multiple consecutive failures, all within TTL window
+                for (var i = 0; i < 3; i++)
+                {
+                    UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                    UpdateProbe.Reply(new Status.Failure(new LeaseException($"Transient failure {i}")));
+                    Granted.Value.Should().BeTrue();
+                }
+
+                // Recovery: next heartbeat succeeds
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                IncrementVersion();
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
+
+                // Lease is still held
+                Granted.Value.Should().BeTrue();
+            });
+        }
+
+        [Fact(DisplayName = "heartbeat failure should not call lease lost callback during retry")]
+        public void HeartBeatFailureShouldNotCallLeaseLostCallbackDuringRetry()
+        {
+            RunTest(() =>
+            {
+                var callbackCalled = false;
+                AcquireLease(e =>
+                {
+                    callbackCalled = true;
+                });
+                ExpectHeartBeat();
+                Granted.Value.Should().BeTrue();
+
+                // Single transient failure within TTL
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                UpdateProbe.Reply(new Status.Failure(new LeaseException("Transient failure")));
+
+                // Callback should NOT be called — TTL still valid
+                callbackCalled.Should().BeFalse();
+                Granted.Value.Should().BeTrue();
+
+                // Recovery
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                IncrementVersion();
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
+
+                callbackCalled.Should().BeFalse();
             });
         }
 
@@ -745,15 +831,28 @@ namespace Akka.Coordination.Azure.Tests
             });
         }
 
+        /// <summary>
+        /// Drives heartbeat failures until the TTL window expires and the actor surrenders the lease.
+        /// With the retry logic, the actor retries heartbeats within the TTL window before surrendering.
+        /// </summary>
         protected void HeartBeatFailure()
         {
-            UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-            IncrementVersion();
-            UpdateProbe.Reply(new Status.Failure(new LeaseException("Failed to communicate with API server")));
-            AwaitAssert(() =>
+            DriveHeartBeatFailures(new LeaseException("Failed to communicate with API server"));
+        }
+
+        /// <summary>
+        /// Keeps replying with the given failure to all heartbeat retry attempts
+        /// until the actor exhausts the TTL window and surrenders the lease.
+        /// </summary>
+        protected void DriveHeartBeatFailures(Exception failure)
+        {
+            while (Granted.Value)
             {
-                Granted.Value.Should().BeFalse();
-            });
+                UpdateProbe.ExpectMsg<(string, ETag)>(TimeSpan.FromSeconds(2));
+                UpdateProbe.Reply(new Status.Failure(failure));
+                Task.Delay(10).Wait();
+            }
+            AwaitAssert(() => Granted.Value.Should().BeFalse());
         }
     }
 }

--- a/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
@@ -109,19 +109,22 @@ namespace Akka.Coordination.Azure
         
         public sealed class GrantedVersion: IData
         {
-            public GrantedVersion(ETag version, Action<Exception?> leaseLostCallback)
+            public GrantedVersion(ETag version, Action<Exception?> leaseLostCallback, DateTime? lastSuccessfulHeartbeat = null)
             {
                 Version = version;
                 LeaseLostCallback = leaseLostCallback;
+                LastSuccessfulHeartbeat = lastSuccessfulHeartbeat ?? DateTime.UtcNow;
             }
 
             public ETag Version { get; }
             public Action<Exception?> LeaseLostCallback { get; }
+            public DateTime LastSuccessfulHeartbeat { get; }
 
-            public GrantedVersion Copy(ETag? version = null, Action<Exception?>? leaseLostCallback = null)
+            public GrantedVersion Copy(ETag? version = null, Action<Exception?>? leaseLostCallback = null, DateTime? lastSuccessfulHeartbeat = null)
                 => new GrantedVersion(
                     version: version ?? Version,
-                    leaseLostCallback: leaseLostCallback ?? LeaseLostCallback);
+                    leaseLostCallback: leaseLostCallback ?? LeaseLostCallback,
+                    lastSuccessfulHeartbeat: lastSuccessfulHeartbeat ?? LastSuccessfulHeartbeat);
         }
         
         public interface ICommand { }
@@ -397,7 +400,7 @@ namespace Akka.Coordination.Azure
                         if(_log.IsDebugEnabled)
                             _log.Debug("Heartbeat: lease time updated: Version {0}", resource.Value.Version);
                         Timers!.StartSingleTimer("heartbeat", Heartbeat.Instance, settings.TimeoutSettings.HeartbeatInterval);
-                        return Stay().Using(gv.Copy(version: resource.Value.Version));
+                        return Stay().Using(gv.Copy(version: resource.Value.Version, lastSuccessfulHeartbeat: DateTime.UtcNow));
                     
                     case WriteResponse {Response: Left<LeaseResource, LeaseResource> resource}:
                         _log.Warning("Conflict during heartbeat to lease {0}. Lease assumed to be released.", resource.Value);
@@ -406,8 +409,18 @@ namespace Akka.Coordination.Azure
                         return GoTo(Idle.Instance).Using(ReadRequired.Instance);
                     
                     case Status.Failure failure:
-                        // FIXME, retry if timeout far enough off: https://github.com/lightbend/akka-commercial-addons/issues/501
-                        _log.Warning(failure.Cause, "Failure during heartbeat to lease. Lease assumed to be released.");
+                        var timeSinceLastHeartbeat = DateTime.UtcNow - gv.LastSuccessfulHeartbeat;
+                        if (timeSinceLastHeartbeat < _timeoutOffset - settings.TimeoutSettings.HeartbeatInterval)
+                        {
+                            _log.Warning(failure.Cause,
+                                "Transient failure during heartbeat to lease {0}. TTL still valid ({1:F0}s remaining). Retrying.",
+                                leaseName,
+                                (_timeoutOffset - timeSinceLastHeartbeat).TotalSeconds);
+                            Timers!.StartSingleTimer("heartbeat", Heartbeat.Instance, settings.TimeoutSettings.HeartbeatInterval);
+                            return Stay();
+                        }
+                        _log.Warning(failure.Cause,
+                            "Failure during heartbeat to lease {0}. TTL window expired, releasing lease.", leaseName);
                         localGranted.GetAndSet(false);
                         ExecuteLeaseLockCallback(leaseLost, failure.Cause);
                         return GoTo(Idle.Instance).Using(ReadRequired.Instance);


### PR DESCRIPTION
Fixes #3404

## Changes

- Fixed a bug where a single transient heartbeat failure (network timeout, Azure 503, DNS blip) caused the `LeaseActor` to immediately surrender a lease it still legitimately held
- The actor now retries heartbeats within the TTL safety window before giving up, matching the intent of the existing `// FIXME` comment in the code
- Added 3 regression tests for the new retry behavior; updated 2 existing tests

**`LeaseActor.cs`**

1. **`GrantedVersion`** — added `LastSuccessfulHeartbeat` timestamp field (defaults to `DateTime.UtcNow` on construction)
2. **Heartbeat success path** — records `DateTime.UtcNow` on each successful heartbeat write
3. **Heartbeat failure path** — checks remaining TTL before deciding:
   - If `timeSinceLastHeartbeat < _timeoutOffset - heartbeatInterval` → log warning, schedule retry, stay in `Granted`
   - Otherwise → surrender the lease (same behavior as before)

With default settings (`heartbeatTimeout=120s`, `heartbeatInterval=12s`), this gives a **84-second retry window** allowing up to **7 consecutive transient failures** before the lease is surrendered.

**`LeaseActorSpec.cs`**

- Updated `HeartBeatFailure()` helper and `DriveHeartBeatFailures()` to drive retries until TTL expires
- Updated `HeartBeatFailShouldSetGrantedToFalse` and `HeartBeatFailShouldCallLeaseLostCallback` to work with retry behavior
- Added 3 new regression tests:
  - `TransientHeartBeatFailureShouldRetryAndStayGranted` — single failure recovers on next success
  - `MultipleTransientHeartBeatFailuresShouldRecover` — 3 consecutive failures all recover
  - `HeartBeatFailureShouldNotCallLeaseLostCallbackDuringRetry` — callback only fires when TTL expires

## Test plan

- [x] All 49 existing tests pass (1 skipped)
- [x] Single transient failure retries and stays `Granted`
- [x] Multiple consecutive transient failures recover when next heartbeat succeeds
- [x] `LeaseLost` callback is not invoked during retry window
- [x] `LeaseLost` callback fires correctly when TTL window is exhausted
- [x] `Granted` flag remains `true` during retries, set to `false` only on surrender
- [x] Existing heartbeat conflict (`Left` response) behavior is unchanged
