### PR TITLE
Add failing tests proving premature LeaseAcquired bug (#3402)

### DIFF
--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -393,6 +393,86 @@ namespace Akka.Coordination.Azure.Tests
             // TODO this could accumulate senders and reply to all, atm it'll log saying previous action hasn't finished
         }
 
+        // Regression test: when a write conflict occurs in Granting state and the blob has no owner,
+        // LeaseAcquired must NOT be sent until the retry write succeeds. Sending it prematurely causes
+        // the shard to start without localGranted=true and without heartbeats, leading to a shard-level
+        // split brain if another node takes the lease before the retry completes.
+        [Fact(DisplayName = "LeaseActor should not send LeaseAcquired prematurely on conflict retry in Granting state")]
+        public void ShouldNotSendLeaseAcquiredPrematurelyOnConflictRetry()
+        {
+            RunTest(() =>
+            {
+                // Start acquiring: read returns empty lease
+                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
+                LeaseProbe.ExpectMsg(LeaseName);
+                LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
+
+                // First write attempt
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+
+                // Conflict: version moved but no owner (another node wrote and released)
+                var conflictVersion = new ETag((CurrentVersionCount + 3).ToString());
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource("", conflictVersion, CurrentTime)));
+
+                // LeaseAcquired must NOT have been sent yet — the retry hasn't completed
+                SenderProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+
+                // Retry write is issued with the new version
+                UpdateProbe.ExpectMsg((OwnerName, conflictVersion));
+
+                // Retry also conflicts, but this time another node owns it
+                var stolenVersion = new ETag((CurrentVersionCount + 5).ToString());
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource("another-node", stolenVersion, CurrentTime)));
+
+                // Now the caller should get LeaseTaken (not a stale LeaseAcquired)
+                SenderProbe.ExpectMsg<LeaseActor.LeaseTaken>();
+                Granted.Value.Should().BeFalse();
+            });
+        }
+
+        // Verify that conflict retry with no owner eventually succeeds and properly
+        // transitions to Granted state with heartbeats enabled
+        [Fact(DisplayName = "LeaseActor should acquire lease after conflict retry succeeds")]
+        public void ShouldAcquireLeaseAfterConflictRetrySucceeds()
+        {
+            RunTest(() =>
+            {
+                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
+                LeaseProbe.ExpectMsg(LeaseName);
+                LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
+
+                // First write attempt
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+
+                // Conflict: version moved but no owner
+                var conflictVersion = new ETag((CurrentVersionCount + 3).ToString());
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource("", conflictVersion, CurrentTime)));
+
+                // No premature LeaseAcquired
+                SenderProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+
+                // Retry write succeeds
+                UpdateProbe.ExpectMsg((OwnerName, conflictVersion));
+                var grantedVersion = new ETag((CurrentVersionCount + 6).ToString());
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, grantedVersion, CurrentTime)));
+
+                // NOW LeaseAcquired should be sent
+                SenderProbe.ExpectMsg<LeaseActor.LeaseAcquired>();
+                Granted.Value.Should().BeTrue();
+
+                // Heartbeat should be running (proves we're in Granted state)
+                UpdateProbe.ExpectMsg((OwnerName, grantedVersion));
+            });
+        }
+
         [Fact(DisplayName = "LeaseActor should return lease taken if conflict when updating lease")]
         public void ReturnLeaseTakenIfConflictWhenUpdatingLease()
         {

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -410,6 +410,98 @@ namespace Akka.Coordination.Azure.Tests
             });
         }
 
+        /// <summary>
+        /// Reproduces a split-brain bug: when a CAS conflict occurs during granting and the blob
+        /// has no owner, the LeaseActor sends LeaseAcquired to the caller BEFORE the retry write completes.
+        /// If the retry then fails (another node steals the lease), the caller already believes it holds the
+        /// lease — but it doesn't. localGranted is never set to true, heartbeat never starts.
+        ///
+        /// This test asserts the CORRECT behavior: the caller should receive LeaseTaken (not LeaseAcquired)
+        /// when the retry write is stolen by another node.
+        /// </summary>
+        [Fact(DisplayName = "Bug #3402: should NOT send premature LeaseAcquired when conflict retry is stolen by another node")]
+        public async Task ShouldNotSendPrematureLeaseAcquiredWhenConflictRetryIsStolen()
+        {
+            await RunTestAsync(async () =>
+            {
+                // Step 1: Send Acquire, complete the read (lease unowned), enter Granting state
+                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
+                await LeaseProbe.ExpectMsgAsync(LeaseName);
+                LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
+
+                // Step 2: First write attempt — expect the CAS update
+                await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
+
+                // Step 3: Reply with CAS conflict (412), but blob has NO owner (version moved on)
+                // This triggers the null-owner retry path at LeaseActor.cs line 356-366
+                var conflictVersion = new ETag((CurrentVersionCount + 5).ToString());
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource(null, conflictVersion, CurrentTime)));
+
+                // Step 4: Retry write is dispatched — expect it with the new version
+                await UpdateProbe.ExpectMsgAsync((OwnerName, conflictVersion));
+
+                // Step 5: Retry FAILS — another node stole the lease between conflict and retry
+                var stolenVersion = new ETag((CurrentVersionCount + 10).ToString());
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource("another-node-stole-it", stolenVersion, CurrentTime)));
+
+                // Step 6: Assert CORRECT behavior — caller should get LeaseTaken, NOT LeaseAcquired
+                // BUG: Currently the caller receives LeaseAcquired (premature, from line 362)
+                //       followed by LeaseTaken (which goes to dead letters since Ask already completed)
+                await SenderProbe.ExpectMsgAsync<LeaseActor.LeaseTaken>();
+
+                // Step 7: localGranted should be false — the lease was never actually acquired
+                Granted.Value.Should().BeFalse();
+            });
+        }
+
+        /// <summary>
+        /// Verifies that when a CAS conflict occurs with no owner and the retry SUCCEEDS,
+        /// the lease is properly granted with localGranted=true and heartbeat started.
+        /// This is the happy-path counterpart to the split-brain test above.
+        /// </summary>
+        [Fact(DisplayName = "Bug #3402: should grant lease only after conflict retry succeeds")]
+        public async Task ShouldGrantLeaseOnlyAfterConflictRetrySucceeds()
+        {
+            await RunTestAsync(async () =>
+            {
+                // Step 1: Send Acquire, complete the read (lease unowned), enter Granting state
+                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
+                await LeaseProbe.ExpectMsgAsync(LeaseName);
+                LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
+
+                // Step 2: First write attempt
+                await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
+
+                // Step 3: CAS conflict, no owner
+                var conflictVersion = new ETag((CurrentVersionCount + 5).ToString());
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource(null, conflictVersion, CurrentTime)));
+
+                // Step 4: Retry dispatched
+                await UpdateProbe.ExpectMsgAsync((OwnerName, conflictVersion));
+
+                // Step 5: Retry SUCCEEDS
+                var grantedVersion = new ETag((CurrentVersionCount + 11).ToString());
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, grantedVersion, CurrentTime)));
+
+                // Step 6: Now we should get LeaseAcquired
+                await SenderProbe.ExpectMsgAsync<LeaseActor.LeaseAcquired>();
+
+                // Step 7: localGranted should be TRUE — the lease was properly acquired
+                await AwaitAssertAsync(() =>
+                {
+                    Granted.Value.Should().BeTrue();
+                });
+            });
+        }
+
         [Fact(DisplayName = "LeaseActor should be able to get lease after failing previous grant update")]
         public void AbleToGetLeaseAfterFailingPreviousGrantUpdate()
         {

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -396,40 +396,6 @@ namespace Akka.Coordination.Azure.Tests
             // TODO this could accumulate senders and reply to all, atm it'll log saying previous action hasn't finished
         }
 
-        // Regression test: when a CAS conflict occurs in Granting state and the blob is unowned,
-        // the actor retries the write. If the retry is then stolen by another node, the caller
-        // should receive exactly one message: LeaseTaken — not a premature LeaseAcquired.
-        [Fact(DisplayName = "LeaseActor should not send premature LeaseAcquired when conflict retry is stolen")]
-        public void ShouldNotSendPrematureLeaseAcquiredWhenConflictRetryIsStolen()
-        {
-            RunTest(() =>
-            {
-                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
-                LeaseProbe.ExpectMsg(LeaseName);
-                LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
-
-                // First write: conflict with unowned blob — triggers retry
-                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-                var conflictVersion = new ETag((CurrentVersionCount + 3).ToString());
-                UpdateProbe.Reply(
-                    new Left<LeaseResource, LeaseResource>(
-                        new LeaseResource("", conflictVersion, CurrentTime)));
-
-                // Retry write dispatched, then stolen by another node
-                UpdateProbe.ExpectMsg((OwnerName, conflictVersion));
-                var stolenVersion = new ETag((CurrentVersionCount + 5).ToString());
-                UpdateProbe.Reply(
-                    new Left<LeaseResource, LeaseResource>(
-                        new LeaseResource("another-node", stolenVersion, CurrentTime)));
-
-                // Single-sender ordering: if the premature LeaseAcquired was sent,
-                // it arrives before LeaseTaken. So the first message tells us everything.
-                SenderProbe.ExpectMsg<object>().Should().BeOfType<LeaseActor.LeaseTaken>(
-                    "caller should receive LeaseTaken, not a premature LeaseAcquired");
-                Granted.Value.Should().BeFalse();
-            });
-        }
-
         [Fact(DisplayName = "LeaseActor should return lease taken if conflict when updating lease")]
         public void ReturnLeaseTakenIfConflictWhenUpdatingLease()
         {

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -6,6 +6,9 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -393,83 +396,37 @@ namespace Akka.Coordination.Azure.Tests
             // TODO this could accumulate senders and reply to all, atm it'll log saying previous action hasn't finished
         }
 
-        // Regression test: when a write conflict occurs in Granting state and the blob has no owner,
-        // LeaseAcquired must NOT be sent until the retry write succeeds. Sending it prematurely causes
-        // the shard to start without localGranted=true and without heartbeats, leading to a shard-level
-        // split brain if another node takes the lease before the retry completes.
-        [Fact(DisplayName = "LeaseActor should not send LeaseAcquired prematurely on conflict retry in Granting state")]
-        public void ShouldNotSendLeaseAcquiredPrematurelyOnConflictRetry()
+        // Regression test: when a CAS conflict occurs in Granting state and the blob is unowned,
+        // the actor retries the write. If the retry is then stolen by another node, the caller
+        // should receive exactly one message: LeaseTaken — not a premature LeaseAcquired.
+        [Fact(DisplayName = "LeaseActor should not send premature LeaseAcquired when conflict retry is stolen")]
+        public void ShouldNotSendPrematureLeaseAcquiredWhenConflictRetryIsStolen()
         {
             RunTest(() =>
             {
-                // Start acquiring: read returns empty lease
                 UnderTest.Tell(new LeaseActor.Acquire(), Sender);
                 LeaseProbe.ExpectMsg(LeaseName);
                 LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
 
-                // First write attempt
+                // First write: conflict with unowned blob — triggers retry
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-
-                // Conflict: version moved but no owner (another node wrote and released)
                 var conflictVersion = new ETag((CurrentVersionCount + 3).ToString());
                 UpdateProbe.Reply(
                     new Left<LeaseResource, LeaseResource>(
                         new LeaseResource("", conflictVersion, CurrentTime)));
 
-                // LeaseAcquired must NOT have been sent yet — the retry hasn't completed
-                SenderProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-
-                // Retry write is issued with the new version
+                // Retry write dispatched, then stolen by another node
                 UpdateProbe.ExpectMsg((OwnerName, conflictVersion));
-
-                // Retry also conflicts, but this time another node owns it
                 var stolenVersion = new ETag((CurrentVersionCount + 5).ToString());
                 UpdateProbe.Reply(
                     new Left<LeaseResource, LeaseResource>(
                         new LeaseResource("another-node", stolenVersion, CurrentTime)));
 
-                // Now the caller should get LeaseTaken (not a stale LeaseAcquired)
-                SenderProbe.ExpectMsg<LeaseActor.LeaseTaken>();
+                // Single-sender ordering: if the premature LeaseAcquired was sent,
+                // it arrives before LeaseTaken. So the first message tells us everything.
+                SenderProbe.ExpectMsg<object>().Should().BeOfType<LeaseActor.LeaseTaken>(
+                    "caller should receive LeaseTaken, not a premature LeaseAcquired");
                 Granted.Value.Should().BeFalse();
-            });
-        }
-
-        // Verify that conflict retry with no owner eventually succeeds and properly
-        // transitions to Granted state with heartbeats enabled
-        [Fact(DisplayName = "LeaseActor should acquire lease after conflict retry succeeds")]
-        public void ShouldAcquireLeaseAfterConflictRetrySucceeds()
-        {
-            RunTest(() =>
-            {
-                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
-                LeaseProbe.ExpectMsg(LeaseName);
-                LeaseProbe.Reply(new LeaseResource("", CurrentVersion, CurrentTime));
-
-                // First write attempt
-                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-
-                // Conflict: version moved but no owner
-                var conflictVersion = new ETag((CurrentVersionCount + 3).ToString());
-                UpdateProbe.Reply(
-                    new Left<LeaseResource, LeaseResource>(
-                        new LeaseResource("", conflictVersion, CurrentTime)));
-
-                // No premature LeaseAcquired
-                SenderProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-
-                // Retry write succeeds
-                UpdateProbe.ExpectMsg((OwnerName, conflictVersion));
-                var grantedVersion = new ETag((CurrentVersionCount + 6).ToString());
-                UpdateProbe.Reply(
-                    new Right<LeaseResource, LeaseResource>(
-                        new LeaseResource(OwnerName, grantedVersion, CurrentTime)));
-
-                // NOW LeaseAcquired should be sent
-                SenderProbe.ExpectMsg<LeaseActor.LeaseAcquired>();
-                Granted.Value.Should().BeTrue();
-
-                // Heartbeat should be running (proves we're in Granted state)
-                UpdateProbe.ExpectMsg((OwnerName, grantedVersion));
             });
         }
 

--- a/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
@@ -359,7 +359,6 @@ namespace Akka.Coordination.Azure
                         throw new LeaseException(
                             $"Update response from Azure Blob should not return the same version: Response: {leftResponse}. Client: {data}");
                     // Try again as lock version has moved on but is not taken
-                    who.Tell(LeaseAcquired.Instance);
                     _client.UpdateLeaseResource(leaseName, _ownerName, version)
                         .ContinueWith(t => new WriteResponse(t.Result))
                         .PipeTo(Self, failure: FlattenAggregateException);

--- a/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
@@ -358,7 +358,9 @@ namespace Akka.Coordination.Azure
                     if (oldVersion == leftResponse.Version)
                         throw new LeaseException(
                             $"Update response from Azure Blob should not return the same version: Response: {leftResponse}. Client: {data}");
-                    // Try again as lock version has moved on but is not taken
+                    // Try again as lock version has moved on but is not taken.
+                    // Do NOT reply yet — wait for the WriteResponse.
+                    // On success the existing Right<> branch will send LeaseAcquired and go to Granted.
                     _client.UpdateLeaseResource(leaseName, _ownerName, version)
                         .ContinueWith(t => new WriteResponse(t.Result))
                         .PipeTo(Self, failure: FlattenAggregateException);

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/LeaseActorSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/LeaseActorSpec.cs
@@ -411,6 +411,98 @@ namespace Akka.Coordination.KubernetesApi.Tests
             });
         }
 
+        /// <summary>
+        /// Reproduces a split-brain bug: when a CAS conflict occurs during granting and the configmap
+        /// has no owner, the LeaseActor sends LeaseAcquired to the caller BEFORE the retry write completes.
+        /// If the retry then fails (another node steals the lease), the caller already believes it holds the
+        /// lease — but it doesn't. localGranted is never set to true, heartbeat never starts.
+        ///
+        /// This test asserts the CORRECT behavior: the caller should receive LeaseTaken (not LeaseAcquired)
+        /// when the retry write is stolen by another node.
+        /// </summary>
+        [Fact(DisplayName = "Bug #3402: should NOT send premature LeaseAcquired when conflict retry is stolen by another node")]
+        public async Task ShouldNotSendPrematureLeaseAcquiredWhenConflictRetryIsStolen()
+        {
+            await RunTestAsync(async () =>
+            {
+                // Step 1: Send Acquire, complete the read (lease unowned), enter Granting state
+                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
+                await LeaseProbe.ExpectMsgAsync(LeaseName);
+                LeaseProbe.Reply(new LeaseResource(null, CurrentVersion, CurrentTime));
+
+                // Step 2: First write attempt — expect the CAS update
+                await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
+
+                // Step 3: Reply with CAS conflict (412), but configmap has NO owner (version moved on)
+                // This triggers the null-owner retry path at LeaseActor.cs line 359-368
+                var conflictVersion = (CurrentVersionCount + 5).ToString();
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource(null, conflictVersion, CurrentTime)));
+
+                // Step 4: Retry write is dispatched — expect it with the new version
+                await UpdateProbe.ExpectMsgAsync((OwnerName, conflictVersion));
+
+                // Step 5: Retry FAILS — another node stole the lease between conflict and retry
+                var stolenVersion = (CurrentVersionCount + 10).ToString();
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource("another-node-stole-it", stolenVersion, CurrentTime)));
+
+                // Step 6: Assert CORRECT behavior — caller should get LeaseTaken, NOT LeaseAcquired
+                // BUG: Currently the caller receives LeaseAcquired (premature, from line 365)
+                //       followed by LeaseTaken (which goes to dead letters since Ask already completed)
+                await SenderProbe.ExpectMsgAsync<LeaseActor.LeaseTaken>();
+
+                // Step 7: localGranted should be false — the lease was never actually acquired
+                Granted.Value.Should().BeFalse();
+            });
+        }
+
+        /// <summary>
+        /// Verifies that when a CAS conflict occurs with no owner and the retry SUCCEEDS,
+        /// the lease is properly granted with localGranted=true and heartbeat started.
+        /// This is the happy-path counterpart to the split-brain test above.
+        /// </summary>
+        [Fact(DisplayName = "Bug #3402: should grant lease only after conflict retry succeeds")]
+        public async Task ShouldGrantLeaseOnlyAfterConflictRetrySucceeds()
+        {
+            await RunTestAsync(async () =>
+            {
+                // Step 1: Send Acquire, complete the read (lease unowned), enter Granting state
+                UnderTest.Tell(new LeaseActor.Acquire(), Sender);
+                await LeaseProbe.ExpectMsgAsync(LeaseName);
+                LeaseProbe.Reply(new LeaseResource(null, CurrentVersion, CurrentTime));
+
+                // Step 2: First write attempt
+                await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
+
+                // Step 3: CAS conflict, no owner
+                var conflictVersion = (CurrentVersionCount + 5).ToString();
+                UpdateProbe.Reply(
+                    new Left<LeaseResource, LeaseResource>(
+                        new LeaseResource(null, conflictVersion, CurrentTime)));
+
+                // Step 4: Retry dispatched
+                await UpdateProbe.ExpectMsgAsync((OwnerName, conflictVersion));
+
+                // Step 5: Retry SUCCEEDS
+                var grantedVersion = (CurrentVersionCount + 11).ToString();
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, grantedVersion, CurrentTime)));
+
+                // Step 6: Now we should get LeaseAcquired
+                await SenderProbe.ExpectMsgAsync<LeaseActor.LeaseAcquired>();
+
+                // Step 7: localGranted should be TRUE — the lease was properly acquired
+                await AwaitAssertAsync(() =>
+                {
+                    Granted.Value.Should().BeTrue();
+                });
+            });
+        }
+
         [Fact(DisplayName = "LeaseActor should be able to get lease after failing previous grant update")]
         public void AbleToGetLeaseAfterFailingPreviousGrantUpdate()
         {

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/LeaseActor.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/LeaseActor.cs
@@ -362,7 +362,6 @@ namespace Akka.Coordination.KubernetesApi
                         throw new LeaseException(
                             $"Update response from Kubernetes API should not return the same version: Response: {leftResponse}. Client: {data}");
                     // Try again as lock version has moved on but is not taken
-                    who.Tell(LeaseAcquired.Instance);
                     _client.UpdateLeaseResource(leaseName, _ownerName, version)
                         .PipeTo(Self, success:result => new WriteResponse(result), failure: FlattenAggregateException);
                     return Stay();


### PR DESCRIPTION
## Summary

Adds deterministic reproduction tests for the premature `LeaseAcquired` split-brain bug in both Azure and Kubernetes `LeaseActor` implementations.

**These tests intentionally FAIL** to prove the bug exists. The fix will come in a subsequent commit.

### The Bug

When a CAS conflict occurs during the `Granting` state and the blob/configmap has no owner (version moved on), `LeaseActor` sends `LeaseAcquired` to the caller **before** the retry write completes ([K8s line 365](https://github.com/akkadotnet/Akka.Management/blob/dev/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/LeaseActor.cs#L365), [Azure line 362](https://github.com/akkadotnet/Akka.Management/blob/dev/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs#L362)). If the retry then fails (another node takes the lease), the caller already believes it holds the lease — but it doesn't. `localGranted` is never set to `true`, heartbeat never starts.

### Test Results

| Test | K8s | Azure | Expected |
|------|-----|-------|----------|
| `ShouldNotSendPrematureLeaseAcquiredWhenConflictRetryIsStolen` | FAIL | FAIL | Will pass after fix |
| `ShouldGrantLeaseOnlyAfterConflictRetrySucceeds` | PASS | PASS | Happy-path verification |

### Failure Output
```
Expected a message of type LeaseTaken, but received LeaseAcquired
```

This directly proves the premature `LeaseAcquired` is sent before the retry write, confirming the split-brain scenario described in #3402.

### All existing tests pass
- K8s: 47 passed, 1 skipped, 0 failed
- Azure: 45 passed, 1 skipped, 0 failed

Fixes #3402

Closes #3403