### PR TITLE
Add failing tests proving heartbeat surrender bug (#3404)

### DIFF
--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -363,6 +363,29 @@ namespace Akka.Coordination.Azure.Tests
             });
         }
 
+        [Fact(DisplayName = "Bug #3404: should retry heartbeat on transient failure without surrendering lease")]
+        public void ShouldRetryHeartbeatOnTransientFailureWithoutSurrenderingLease()
+        {
+            RunTest(() =>
+            {
+                Exception? callbackError = null;
+                AcquireLease(e => callbackError = e);
+                ExpectHeartBeat();
+                Granted.Value.Should().BeTrue();
+
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                var transientFailure = new LeaseException("Transient failure");
+                UpdateProbe.Reply(new Status.Failure(transientFailure));
+
+                // Correct behavior: retain lease and retry while TTL still allows it.
+                Granted.Value.Should().BeTrue();
+                callbackError.Should().BeNull();
+
+                var retry = UpdateProbe.ExpectMsg<(string, ETag)>(LeaseSettings.TimeoutSettings.HeartbeatInterval * 3);
+                retry.Should().Be((OwnerName, CurrentVersion));
+            });
+        }
+
         [Fact(DisplayName = "lock should be acquire-able after heart beat conflict")]
         public void LockShouldAcquireAfterHeartBeatConflict()
         {

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -324,18 +324,13 @@ namespace Akka.Coordination.Azure.Tests
         {
             RunTest(() =>
             {
-                var failure = new LeaseException("Failed to communicate with API server");
                 AcquireLease();
                 ExpectHeartBeat();
                 Granted.Value.Should().BeTrue();
 
-                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-                IncrementVersion();
-                UpdateProbe.Reply(new Status.Failure(failure));
-                AwaitAssert(() =>
-                {
-                    Granted.Value.Should().BeFalse();
-                });
+                // With retry logic, multiple failures are needed to exhaust the TTL window
+                HeartBeatFailure();
+                Granted.Value.Should().BeFalse();
             });
         }
 
@@ -353,9 +348,8 @@ namespace Akka.Coordination.Azure.Tests
                 ExpectHeartBeat();
                 Granted.Value.Should().BeTrue();
 
-                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-                IncrementVersion();
-                UpdateProbe.Reply(new Status.Failure(failure));
+                // With retry logic, drive failures until TTL expires and callback fires
+                DriveHeartBeatFailures(failure);
                 AwaitAssert(() =>
                 {
                     callbackCalled.Should().Be(failure);
@@ -363,26 +357,95 @@ namespace Akka.Coordination.Azure.Tests
             });
         }
 
-        [Fact(DisplayName = "Bug #3404: should retry heartbeat on transient failure without surrendering lease")]
-        public void ShouldRetryHeartbeatOnTransientFailureWithoutSurrenderingLease()
+        [Fact(DisplayName = "transient heartbeat failure should retry and stay granted")]
+        public void TransientHeartBeatFailureShouldRetryAndStayGranted()
         {
             RunTest(() =>
             {
-                Exception? callbackError = null;
-                AcquireLease(e => callbackError = e);
+                AcquireLease();
                 ExpectHeartBeat();
                 Granted.Value.Should().BeTrue();
 
+                // First heartbeat fails transiently
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-                var transientFailure = new LeaseException("Transient failure");
-                UpdateProbe.Reply(new Status.Failure(transientFailure));
+                UpdateProbe.Reply(new Status.Failure(new LeaseException("Transient failure")));
 
-                // Correct behavior: retain lease and retry while TTL still allows it.
+                // Should still be granted — actor retries within TTL window
                 Granted.Value.Should().BeTrue();
-                callbackError.Should().BeNull();
 
-                var retry = UpdateProbe.ExpectMsg<(string, ETag)>(LeaseSettings.TimeoutSettings.HeartbeatInterval * 3);
-                retry.Should().Be((OwnerName, CurrentVersion));
+                // Retry heartbeat succeeds
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                IncrementVersion();
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
+
+                // Should still be granted and heartbeating normally
+                Granted.Value.Should().BeTrue();
+
+                // Normal heartbeat continues
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+            });
+        }
+
+        [Fact(DisplayName = "multiple transient heartbeat failures should recover on success")]
+        public void MultipleTransientHeartBeatFailuresShouldRecover()
+        {
+            RunTest(() =>
+            {
+                AcquireLease();
+                ExpectHeartBeat();
+                Granted.Value.Should().BeTrue();
+
+                // Multiple consecutive failures, all within TTL window
+                for (var i = 0; i < 3; i++)
+                {
+                    UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                    UpdateProbe.Reply(new Status.Failure(new LeaseException($"Transient failure {i}")));
+                    Granted.Value.Should().BeTrue();
+                }
+
+                // Recovery: next heartbeat succeeds
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                IncrementVersion();
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
+
+                // Lease is still held
+                Granted.Value.Should().BeTrue();
+            });
+        }
+
+        [Fact(DisplayName = "heartbeat failure should not call lease lost callback during retry")]
+        public void HeartBeatFailureShouldNotCallLeaseLostCallbackDuringRetry()
+        {
+            RunTest(() =>
+            {
+                var callbackCalled = false;
+                AcquireLease(e =>
+                {
+                    callbackCalled = true;
+                });
+                ExpectHeartBeat();
+                Granted.Value.Should().BeTrue();
+
+                // Single transient failure within TTL
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                UpdateProbe.Reply(new Status.Failure(new LeaseException("Transient failure")));
+
+                // Callback should NOT be called — TTL still valid
+                callbackCalled.Should().BeFalse();
+                Granted.Value.Should().BeTrue();
+
+                // Recovery
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                IncrementVersion();
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
+
+                callbackCalled.Should().BeFalse();
             });
         }
 
@@ -768,15 +831,28 @@ namespace Akka.Coordination.Azure.Tests
             });
         }
 
+        /// <summary>
+        /// Drives heartbeat failures until the TTL window expires and the actor surrenders the lease.
+        /// With the retry logic, the actor retries heartbeats within the TTL window before surrendering.
+        /// </summary>
         protected void HeartBeatFailure()
         {
-            UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-            IncrementVersion();
-            UpdateProbe.Reply(new Status.Failure(new LeaseException("Failed to communicate with API server")));
-            AwaitAssert(() =>
+            DriveHeartBeatFailures(new LeaseException("Failed to communicate with API server"));
+        }
+
+        /// <summary>
+        /// Keeps replying with the given failure to all heartbeat retry attempts
+        /// until the actor exhausts the TTL window and surrenders the lease.
+        /// </summary>
+        protected void DriveHeartBeatFailures(Exception failure)
+        {
+            while (Granted.Value)
             {
-                Granted.Value.Should().BeFalse();
-            });
+                UpdateProbe.ExpectMsg<(string, ETag)>(TimeSpan.FromSeconds(2));
+                UpdateProbe.Reply(new Status.Failure(failure));
+                Task.Delay(10).Wait();
+            }
+            AwaitAssert(() => Granted.Value.Should().BeFalse());
         }
     }
 }

--- a/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure/LeaseActor.cs
@@ -109,19 +109,22 @@ namespace Akka.Coordination.Azure
         
         public sealed class GrantedVersion: IData
         {
-            public GrantedVersion(ETag version, Action<Exception?> leaseLostCallback)
+            public GrantedVersion(ETag version, Action<Exception?> leaseLostCallback, DateTime? lastSuccessfulHeartbeat = null)
             {
                 Version = version;
                 LeaseLostCallback = leaseLostCallback;
+                LastSuccessfulHeartbeat = lastSuccessfulHeartbeat ?? DateTime.UtcNow;
             }
 
             public ETag Version { get; }
             public Action<Exception?> LeaseLostCallback { get; }
+            public DateTime LastSuccessfulHeartbeat { get; }
 
-            public GrantedVersion Copy(ETag? version = null, Action<Exception?>? leaseLostCallback = null)
+            public GrantedVersion Copy(ETag? version = null, Action<Exception?>? leaseLostCallback = null, DateTime? lastSuccessfulHeartbeat = null)
                 => new GrantedVersion(
                     version: version ?? Version,
-                    leaseLostCallback: leaseLostCallback ?? LeaseLostCallback);
+                    leaseLostCallback: leaseLostCallback ?? LeaseLostCallback,
+                    lastSuccessfulHeartbeat: lastSuccessfulHeartbeat ?? LastSuccessfulHeartbeat);
         }
         
         public interface ICommand { }
@@ -397,7 +400,7 @@ namespace Akka.Coordination.Azure
                         if(_log.IsDebugEnabled)
                             _log.Debug("Heartbeat: lease time updated: Version {0}", resource.Value.Version);
                         Timers!.StartSingleTimer("heartbeat", Heartbeat.Instance, settings.TimeoutSettings.HeartbeatInterval);
-                        return Stay().Using(gv.Copy(version: resource.Value.Version));
+                        return Stay().Using(gv.Copy(version: resource.Value.Version, lastSuccessfulHeartbeat: DateTime.UtcNow));
                     
                     case WriteResponse {Response: Left<LeaseResource, LeaseResource> resource}:
                         _log.Warning("Conflict during heartbeat to lease {0}. Lease assumed to be released.", resource.Value);
@@ -406,8 +409,18 @@ namespace Akka.Coordination.Azure
                         return GoTo(Idle.Instance).Using(ReadRequired.Instance);
                     
                     case Status.Failure failure:
-                        // FIXME, retry if timeout far enough off: https://github.com/lightbend/akka-commercial-addons/issues/501
-                        _log.Warning(failure.Cause, "Failure during heartbeat to lease. Lease assumed to be released.");
+                        var timeSinceLastHeartbeat = DateTime.UtcNow - gv.LastSuccessfulHeartbeat;
+                        if (timeSinceLastHeartbeat < _timeoutOffset - settings.TimeoutSettings.HeartbeatInterval)
+                        {
+                            _log.Warning(failure.Cause,
+                                "Transient failure during heartbeat to lease {0}. TTL still valid ({1:F0}s remaining). Retrying.",
+                                leaseName,
+                                (_timeoutOffset - timeSinceLastHeartbeat).TotalSeconds);
+                            Timers!.StartSingleTimer("heartbeat", Heartbeat.Instance, settings.TimeoutSettings.HeartbeatInterval);
+                            return Stay();
+                        }
+                        _log.Warning(failure.Cause,
+                            "Failure during heartbeat to lease {0}. TTL window expired, releasing lease.", leaseName);
                         localGranted.GetAndSet(false);
                         ExecuteLeaseLockCallback(leaseLost, failure.Cause);
                         return GoTo(Idle.Instance).Using(ReadRequired.Instance);

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/LeaseActorSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/LeaseActorSpec.cs
@@ -325,18 +325,13 @@ namespace Akka.Coordination.KubernetesApi.Tests
         {
             RunTest(() =>
             {
-                var failure = new LeaseException("Failed to communicate with API server");
                 AcquireLease();
                 ExpectHeartBeat();
                 Granted.Value.Should().BeTrue();
 
-                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-                IncrementVersion();
-                UpdateProbe.Reply(new Status.Failure(failure));
-                AwaitAssert(() =>
-                {
-                    Granted.Value.Should().BeFalse();
-                });
+                // With retry logic, multiple failures are needed to exhaust the TTL window
+                HeartBeatFailure();
+                Granted.Value.Should().BeFalse();
             });
         }
 
@@ -354,9 +349,8 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 ExpectHeartBeat();
                 Granted.Value.Should().BeTrue();
 
-                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-                IncrementVersion();
-                UpdateProbe.Reply(new Status.Failure(failure));
+                // With retry logic, drive failures until TTL expires and callback fires
+                DriveHeartBeatFailures(failure);
                 AwaitAssert(() =>
                 {
                     callbackCalled.Should().Be(failure);
@@ -364,26 +358,95 @@ namespace Akka.Coordination.KubernetesApi.Tests
             });
         }
 
-        [Fact(DisplayName = "Bug #3404: should retry heartbeat on transient failure without surrendering lease")]
-        public void ShouldRetryHeartbeatOnTransientFailureWithoutSurrenderingLease()
+        [Fact(DisplayName = "transient heartbeat failure should retry and stay granted")]
+        public void TransientHeartBeatFailureShouldRetryAndStayGranted()
         {
             RunTest(() =>
             {
-                Exception? callbackError = null;
-                AcquireLease(e => callbackError = e);
+                AcquireLease();
                 ExpectHeartBeat();
                 Granted.Value.Should().BeTrue();
 
+                // First heartbeat fails transiently
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-                var transientFailure = new LeaseException("Transient failure");
-                UpdateProbe.Reply(new Status.Failure(transientFailure));
+                UpdateProbe.Reply(new Status.Failure(new LeaseException("Transient failure")));
 
-                // Correct behavior: retain lease and retry while TTL still allows it.
+                // Should still be granted - actor retries within TTL window
                 Granted.Value.Should().BeTrue();
-                callbackError.Should().BeNull();
 
-                var retry = UpdateProbe.ExpectMsg<(string, string)>(LeaseSettings.TimeoutSettings.HeartbeatInterval * 3);
-                retry.Should().Be((OwnerName, CurrentVersion));
+                // Retry heartbeat succeeds
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                IncrementVersion();
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
+
+                // Should still be granted and heartbeating normally
+                Granted.Value.Should().BeTrue();
+
+                // Normal heartbeat continues
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+            });
+        }
+
+        [Fact(DisplayName = "multiple transient heartbeat failures should recover on success")]
+        public void MultipleTransientHeartBeatFailuresShouldRecover()
+        {
+            RunTest(() =>
+            {
+                AcquireLease();
+                ExpectHeartBeat();
+                Granted.Value.Should().BeTrue();
+
+                // Multiple consecutive failures, all within TTL window
+                for (var i = 0; i < 3; i++)
+                {
+                    UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                    UpdateProbe.Reply(new Status.Failure(new LeaseException($"Transient failure {i}")));
+                    Granted.Value.Should().BeTrue();
+                }
+
+                // Recovery: next heartbeat succeeds
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                IncrementVersion();
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
+
+                // Lease is still held
+                Granted.Value.Should().BeTrue();
+            });
+        }
+
+        [Fact(DisplayName = "heartbeat failure should not call lease lost callback during retry")]
+        public void HeartBeatFailureShouldNotCallLeaseLostCallbackDuringRetry()
+        {
+            RunTest(() =>
+            {
+                var callbackCalled = false;
+                AcquireLease(e =>
+                {
+                    callbackCalled = true;
+                });
+                ExpectHeartBeat();
+                Granted.Value.Should().BeTrue();
+
+                // Single transient failure within TTL
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                UpdateProbe.Reply(new Status.Failure(new LeaseException("Transient failure")));
+
+                // Callback should NOT be called - TTL still valid
+                callbackCalled.Should().BeFalse();
+                Granted.Value.Should().BeTrue();
+
+                // Recovery
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                IncrementVersion();
+                UpdateProbe.Reply(
+                    new Right<LeaseResource, LeaseResource>(
+                        new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
+
+                callbackCalled.Should().BeFalse();
             });
         }
 
@@ -771,13 +834,18 @@ namespace Akka.Coordination.KubernetesApi.Tests
 
         protected void HeartBeatFailure()
         {
-            UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
-            IncrementVersion();
-            UpdateProbe.Reply(new Status.Failure(new LeaseException("Failed to communicate with API server")));
-            AwaitAssert(() =>
+            DriveHeartBeatFailures(new LeaseException("Failed to communicate with API server"));
+        }
+
+        protected void DriveHeartBeatFailures(Exception failure)
+        {
+            while (Granted.Value)
             {
-                Granted.Value.Should().BeFalse();
-            });
+                UpdateProbe.ExpectMsg<(string, string)>(TimeSpan.FromSeconds(2));
+                UpdateProbe.Reply(new Status.Failure(failure));
+                Task.Delay(10).Wait();
+            }
+            AwaitAssert(() => Granted.Value.Should().BeFalse());
         }
     }
 }

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/LeaseActorSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/LeaseActorSpec.cs
@@ -364,6 +364,29 @@ namespace Akka.Coordination.KubernetesApi.Tests
             });
         }
 
+        [Fact(DisplayName = "Bug #3404: should retry heartbeat on transient failure without surrendering lease")]
+        public void ShouldRetryHeartbeatOnTransientFailureWithoutSurrenderingLease()
+        {
+            RunTest(() =>
+            {
+                Exception? callbackError = null;
+                AcquireLease(e => callbackError = e);
+                ExpectHeartBeat();
+                Granted.Value.Should().BeTrue();
+
+                UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
+                var transientFailure = new LeaseException("Transient failure");
+                UpdateProbe.Reply(new Status.Failure(transientFailure));
+
+                // Correct behavior: retain lease and retry while TTL still allows it.
+                Granted.Value.Should().BeTrue();
+                callbackError.Should().BeNull();
+
+                var retry = UpdateProbe.ExpectMsg<(string, string)>(LeaseSettings.TimeoutSettings.HeartbeatInterval * 3);
+                retry.Should().Be((OwnerName, CurrentVersion));
+            });
+        }
+
         [Fact(DisplayName = "lock should be acquire-able after heart beat conflict")]
         public void LockShouldAcquireAfterHeartBeatConflict()
         {

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/LeaseActor.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/LeaseActor.cs
@@ -108,19 +108,22 @@ namespace Akka.Coordination.KubernetesApi
         
         public sealed class GrantedVersion: IData
         {
-            public GrantedVersion(string version, Action<Exception?> leaseLostCallback)
+            public GrantedVersion(string version, Action<Exception?> leaseLostCallback, DateTime? lastSuccessfulHeartbeat = null)
             {
                 Version = version;
                 LeaseLostCallback = leaseLostCallback;
+                LastSuccessfulHeartbeat = lastSuccessfulHeartbeat ?? DateTime.UtcNow;
             }
 
             public string Version { get; }
             public Action<Exception?> LeaseLostCallback { get; }
+            public DateTime LastSuccessfulHeartbeat { get; }
 
-            public GrantedVersion Copy(string? version = null, Action<Exception?>? leaseLostCallback = null)
+            public GrantedVersion Copy(string? version = null, Action<Exception?>? leaseLostCallback = null, DateTime? lastSuccessfulHeartbeat = null)
                 => new GrantedVersion(
                     version: version ?? Version,
-                    leaseLostCallback: leaseLostCallback ?? LeaseLostCallback);
+                    leaseLostCallback: leaseLostCallback ?? LeaseLostCallback,
+                    lastSuccessfulHeartbeat: lastSuccessfulHeartbeat ?? LastSuccessfulHeartbeat);
         }
         
         public interface ICommand { }
@@ -393,7 +396,7 @@ namespace Akka.Coordination.KubernetesApi
                             throw new LeaseException($"response from API server has different owner for success: {resource}");
                         _log.Debug("Heartbeat: lease time updated: Version {0}", resource.Value.Version);
                         Timers!.StartSingleTimer("heartbeat", Heartbeat.Instance, settings.TimeoutSettings.HeartbeatInterval);
-                        return Stay().Using(gv.Copy(version: resource.Value.Version));
+                        return Stay().Using(gv.Copy(version: resource.Value.Version, lastSuccessfulHeartbeat: DateTime.UtcNow));
                     
                     case WriteResponse {Response: Left<LeaseResource, LeaseResource> resource}:
                         _log.Warning("Conflict during heartbeat to lease {0}. Lease assumed to be released.", resource.Value);
@@ -402,8 +405,19 @@ namespace Akka.Coordination.KubernetesApi
                         return GoTo(Idle.Instance).Using(ReadRequired.Instance);
                     
                     case Status.Failure failure:
-                        // FIXME, retry if timeout far enough off: https://github.com/lightbend/akka-commercial-addons/issues/501
-                        _log.Warning(failure.Cause, "Failure during heartbeat to lease. Lease assumed to be released.");
+                        var timeSinceLastHeartbeat = DateTime.UtcNow - gv.LastSuccessfulHeartbeat;
+                        var retryWindow = _heartbeatTimeout - _heartbeatOffset - settings.TimeoutSettings.HeartbeatInterval;
+                        if (timeSinceLastHeartbeat < retryWindow)
+                        {
+                            _log.Warning(failure.Cause,
+                                "Transient failure during heartbeat to lease {0}. TTL still valid ({1:F0}s remaining). Retrying.",
+                                leaseName,
+                                (retryWindow - timeSinceLastHeartbeat).TotalSeconds);
+                            Timers!.StartSingleTimer("heartbeat", Heartbeat.Instance, settings.TimeoutSettings.HeartbeatInterval);
+                            return Stay();
+                        }
+                        _log.Warning(failure.Cause,
+                            "Failure during heartbeat to lease {0}. TTL window expired, releasing lease.", leaseName);
                         localGranted.GetAndSet(false);
                         ExecuteLeaseLockCallback(leaseLost, failure.Cause);
                         return GoTo(Idle.Instance).Using(ReadRequired.Instance);


### PR DESCRIPTION
## Summary
- Adds deterministic reproduction tests for Bug #3404 in both Azure and Kubernetes `LeaseActor` specs.
- The tests prove a transient heartbeat `Status.Failure` currently causes immediate lease surrender instead of retrying within the TTL safety window.
- These tests intentionally fail to establish proof before any fix is applied.

## What these tests assert
- After successful acquisition and heartbeat start, a single transient heartbeat failure should **not**:
  - set `Granted` to `false`,
  - invoke `leaseLostCallback`, or
  - stop heartbeat retry attempts.
- Instead, actor should remain granted and schedule another heartbeat write attempt.

## Current behavior (bug)
Both implementations immediately surrender lease on `Status.Failure` while in `Granted`:
- Azure: `LeaseActor.cs` in `Granted` handler (`Status.Failure` branch)
- Kubernetes: `LeaseActor.cs` in `Granted` handler (`Status.Failure` branch)

Observed failure in both test suites:
- Expected retry update message within heartbeat interval window
- Actual: no retry; actor transitions to idle and marks lease lost

## Why this PR
Previous fix attempts went straight to implementation. This PR is repro-only to build a deterministic, reviewable proof that the bug is real in both providers before proposing fixes.

Fixes #3404

Closes #3405