### PR TITLE
Fix intermittent NRE in ServerSettings.Create due to config injection race

### DIFF
--- a/src/management/Akka.Http.Shim/Dsl/Settings/ServerSettings.cs
+++ b/src/management/Akka.Http.Shim/Dsl/Settings/ServerSettings.cs
@@ -26,7 +26,21 @@ namespace Akka.Http.Dsl.Settings
         public static ServerSettings Create(ExtendedActorSystem system)
         {
             var c = system.Settings.Config.GetConfig("akka.http.server");
-            
+
+            if (c is null)
+            {
+                // Config may not be visible yet due to a race in Settings.RebuildConfig()
+                // where a concurrent InjectTopLevelFallback can overwrite Config with a stale value.
+                // Re-inject and retry. See https://github.com/akkadotnet/akka.net/issues/XXXX
+                system.Settings.InjectTopLevelFallback(Http.DefaultConfig());
+                c = system.Settings.Config.GetConfig("akka.http.server");
+            }
+
+            if (c is null)
+                throw new ConfigurationException(
+                    "akka.http.server configuration section is missing. " +
+                    "Ensure Akka.Http default config has been loaded.");
+
             return new ServerSettings(
                  c.GetString("server-header"),
                  c.GetBoolean("remote-address-attribute"),

--- a/src/management/Akka.Management/AkkaHostingExtensions.cs
+++ b/src/management/Akka.Management/AkkaHostingExtensions.cs
@@ -138,6 +138,7 @@ namespace Akka.Management
         {
             options.Apply(builder);
             builder.AddHocon(AkkaManagementProvider.DefaultConfiguration(), HoconAddMode.Append);
+            builder.AddHocon(Akka.Http.Http.DefaultConfig(), HoconAddMode.Append);
             if (autoStart)
             {
                 builder.WithExtensions(typeof(AkkaManagementProvider));
@@ -167,6 +168,8 @@ namespace Akka.Management
             bool autoStart = false)
         {
             builder.AddSetup(setup);
+            builder.AddHocon(AkkaManagementProvider.DefaultConfiguration(), HoconAddMode.Append);
+            builder.AddHocon(Akka.Http.Http.DefaultConfig(), HoconAddMode.Append);
             if (autoStart)
             {
                 builder.WithExtensions(typeof(AkkaManagementProvider));


### PR DESCRIPTION
## Summary

Fixes an intermittent `NullReferenceException` in `ServerSettings.Create()` that occurs on Windows CI when `akka.http.server` config is not yet visible due to a race condition in Akka.NET core's `Settings.RebuildConfig()`.

**Root cause**: `Settings.InjectTopLevelFallback` uses CAS for the `_fallbackConfig` atomic reference but `RebuildConfig()` writes to the `Config` property (a plain auto-property) non-atomically. When two threads call `InjectTopLevelFallback` concurrently, one can overwrite `Config` with a stale value that's missing the other's injected config. This was partially fixed in akkadotnet/akka.net#7721 (1.5.45) but the stale-write race in `RebuildConfig` remains.

**Impact**: When the `HttpExt` extension injects `akka.http` config via `InjectTopLevelFallback` and another extension does the same concurrently, `ServerSettings.Create()` can read a `Config` snapshot that's missing `akka.http.server`, causing `GetConfig()` to return `null` and the next line to throw NRE.

**Observed on**: Windows CI only (PR #3418), due to thread pool scheduling and timer resolution differences. The lease conflict fix in #3418 is unrelated — this is a pre-existing issue.

## Changes

- **`AkkaHostingExtensions.cs`**: Pre-inject `Akka.Http.Http.DefaultConfig()` at builder time in both `WithAkkaManagement` overloads, so the config is part of the initial `ActorSystem` config before any concurrent threads can interfere
- **`ServerSettings.cs`**: Add a defensive null guard — if `GetConfig("akka.http.server")` returns null, re-inject the default config and retry before throwing a descriptive exception

## Related

- Unblocks #3418 (lease self-conflict fix) which hit this flaky test on Windows CI
- Core race condition tracked in akkadotnet/akka.net (Settings.RebuildConfig stale-write bug — incomplete fix from #7721)

## Test plan

- [x] Existing `Akka.Management.Tests.HostingSpecs` tests pass (these are the tests that were flaking)
- [x] Both projects compile cleanly