### PR TITLE
Bump AkkaVersion and AkkaHostingVersion from 1.5.67 to 1.5.68

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <AkkaHostingVersion>1.5.68</AkkaHostingVersion>
     <PbmVersion>1.4.5</PbmVersion>
     <KubernetesClientVersionNet>17.0.14</KubernetesClientVersionNet>
-    <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>9.0.0</MicrosoftExtensionsVersion>
     <AzureIdentityVersion>1.14.2</AzureIdentityVersion>
     <ProtobufVersion>3.30.2</ProtobufVersion>
     <GrpcToolsVersion>2.71.0</GrpcToolsVersion>
@@ -57,7 +57,7 @@
 
   <!-- Microsoft Extensions packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,8 @@
     <FluentAssertionVersion>7.0.0</FluentAssertionVersion>
     <TestSdkVersion>17.13.0</TestSdkVersion>
     <WireMockVersion>1.8.4</WireMockVersion>
-    <AkkaVersion>1.5.67</AkkaVersion>
-    <AkkaHostingVersion>1.5.67</AkkaHostingVersion>
+    <AkkaVersion>1.5.68</AkkaVersion>
+    <AkkaHostingVersion>1.5.68</AkkaHostingVersion>
     <PbmVersion>1.4.5</PbmVersion>
     <KubernetesClientVersionNet>17.0.14</KubernetesClientVersionNet>
     <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>


### PR DESCRIPTION
Bumps Akka.NET and Akka.Hosting to **1.5.68**.

**Changes in Akka.Hosting 1.5.68:**
- **Security Fix** - Resolves GHSA-g94r-2vxg-569j by bumping OpenTelemetry minimum to 1.10.0
- **Bug Fix** - Fix implicit-sender leak under xUnit v3 parallel execution in `Akka.Hosting.TestKit`
- **Bug Fix** - Fix `SynchronizationContext` leak and `TestActor` startup race in `Akka.Hosting.TestKit`
- **Bug Fix** - Fix cached `TestProbe` refs becoming stale after `TestActor` recovery

Related: akkadotnet/Akka.Hosting#746