### PR TITLE
Update RELEASE_NOTES.md for 1.5.68 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.59</VersionPrefix>
-    <PackageReleaseNotes>* Update to [Akka.NET v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
-* Update to [Akka.Hosting v1.5.59](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)</PackageReleaseNotes>
+    <VersionPrefix>1.5.68</VersionPrefix>
+    <PackageReleaseNotes>* Update to [Akka.NET v1.5.68](https://github.com/akkadotnet/akka.net/releases/tag/1.5.68)
+* Update to [Akka.Hosting v1.5.68](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.68)</PackageReleaseNotes>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Management</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.68 May 31st 2026 ####
+
+* Update to [Akka.NET v1.5.68](https://github.com/akkadotnet/akka.net/releases/tag/1.5.68)
+* Update to [Akka.Hosting v1.5.68](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.68)
+
 #### 1.5.67 April 28th 2026 ####
 
 * Update to [Akka.NET v1.5.67](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67)


### PR DESCRIPTION
## Release 1.5.68 — May 31st, 2026

This release bumps Akka.Management to align with Akka.NET v1.5.68 and Akka.Hosting v1.5.68.

### Changes
- Update to [Akka.NET v1.5.68](https://github.com/akkadotnet/akka.net/releases/tag/1.5.68)
- Update to [Akka.Hosting v1.5.68](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.68)

> [!NOTE]
> Version bumps were handled in PR #3434. This PR adds release notes to RELEASE_NOTES.md.

### Release Checklist
- [x] Release notes written
- [x] Version numbers updated (by #3434)
- [ ] PR merged
- [ ] Tag 1.5.68 pushed to upstream