### PR TITLE
Migrate Aspire + Redis tests from FluentAssertions to xUnit Assert (1/3)

### DIFF
--- a/src/aspire/Akka.Aspire.Hosting.Tests/AkkaServiceExtensionsSpecs.cs
+++ b/src/aspire/Akka.Aspire.Hosting.Tests/AkkaServiceExtensionsSpecs.cs
@@ -6,7 +6,6 @@
 
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -25,10 +24,10 @@ public class AkkaServiceExtensionsSpecs
 
         var akkaService = appBuilder.AddAkka(serviceName);
 
-        akkaService.Should().NotBeNull();
-        akkaService.Name.Should().Be(serviceName);
-        akkaService.Builder.Should().BeSameAs(appBuilder);
-        akkaService.Clustering.Should().BeNull();
+        Assert.NotNull(akkaService);
+        Assert.Equal(serviceName, akkaService.Name);
+        Assert.Same(appBuilder, akkaService.Builder);
+        Assert.Null(akkaService.Clustering);
     }
 
     [Fact]
@@ -38,7 +37,8 @@ public class AkkaServiceExtensionsSpecs
 
         var act = () => builder.AddAkka("test");
 
-        act.Should().Throw<ArgumentNullException>().WithParameterName("builder");
+        var ex = Assert.Throws<ArgumentNullException>(act);
+        Assert.Equal("builder", ex.ParamName);
     }
 
     [Fact]
@@ -48,7 +48,8 @@ public class AkkaServiceExtensionsSpecs
 
         var act = () => appBuilder.AddAkka(null!);
 
-        act.Should().Throw<ArgumentNullException>().WithParameterName("name");
+        var ex = Assert.Throws<ArgumentNullException>(act);
+        Assert.Equal("name", ex.ParamName);
     }
 
     [Fact]
@@ -60,8 +61,8 @@ public class AkkaServiceExtensionsSpecs
 
         var result = akkaService.WithClustering(redis);
 
-        result.Should().BeSameAs(akkaService);
-        akkaService.Clustering.Should().NotBeNull();
+        Assert.Same(akkaService, result);
+        Assert.NotNull(akkaService.Clustering);
     }
 
     [Fact]
@@ -73,7 +74,8 @@ public class AkkaServiceExtensionsSpecs
 
         var act = () => akkaService.WithClustering(redis);
 
-        act.Should().Throw<ArgumentNullException>().WithParameterName("akkaService");
+        var ex = Assert.Throws<ArgumentNullException>(act);
+        Assert.Equal("akkaService", ex.ParamName);
     }
 
     [Fact]
@@ -84,7 +86,8 @@ public class AkkaServiceExtensionsSpecs
 
         var act = () => akkaService.WithClustering(null!);
 
-        act.Should().Throw<ArgumentNullException>().WithParameterName("resource");
+        var ex = Assert.Throws<ArgumentNullException>(act);
+        Assert.Equal("resource", ex.ParamName);
     }
 
     [Fact]
@@ -99,24 +102,24 @@ public class AkkaServiceExtensionsSpecs
 
         var result = containerResource.WithReference(akkaService);
 
-        result.Should().BeSameAs(containerResource);
+        Assert.Same(containerResource, result);
 
         var endpoints = containerResource.Resource.Annotations.OfType<EndpointAnnotation>().ToList();
-        endpoints.Should().Contain(e => e.Name == "akka-remote");
-        endpoints.Should().Contain(e => e.Name == "akka-management");
+        Assert.Contains(endpoints, e => e.Name == "akka-remote");
+        Assert.Contains(endpoints, e => e.Name == "akka-management");
 
         var remoteEndpoint = endpoints.First(e => e.Name == "akka-remote");
-        remoteEndpoint.UriScheme.Should().Be("tcp");
-        remoteEndpoint.IsProxied.Should().BeTrue();
-        remoteEndpoint.IsExternal.Should().BeFalse();
+        Assert.Equal("tcp", remoteEndpoint.UriScheme);
+        Assert.True(remoteEndpoint.IsProxied);
+        Assert.False(remoteEndpoint.IsExternal);
 
         var managementEndpoint = endpoints.First(e => e.Name == "akka-management");
-        managementEndpoint.UriScheme.Should().Be("http");
-        managementEndpoint.IsProxied.Should().BeTrue();
-        managementEndpoint.IsExternal.Should().BeFalse();
+        Assert.Equal("http", managementEndpoint.UriScheme);
+        Assert.True(managementEndpoint.IsProxied);
+        Assert.False(managementEndpoint.IsExternal);
 
         var envCallbacks = containerResource.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-        envCallbacks.Should().NotBeEmpty();
+        Assert.NotEmpty(envCallbacks);
     }
 
     [Fact]
@@ -128,11 +131,11 @@ public class AkkaServiceExtensionsSpecs
 
         var result = containerResource.WithReference(akkaService);
 
-        result.Should().BeSameAs(containerResource);
+        Assert.Same(containerResource, result);
 
         var endpoints = containerResource.Resource.Annotations.OfType<EndpointAnnotation>();
-        endpoints.Should().Contain(e => e.Name == "akka-remote");
-        endpoints.Should().Contain(e => e.Name == "akka-management");
+        Assert.Contains(endpoints, e => e.Name == "akka-remote");
+        Assert.Contains(endpoints, e => e.Name == "akka-management");
     }
 
     [Fact]
@@ -144,7 +147,8 @@ public class AkkaServiceExtensionsSpecs
 
         var act = () => builder.WithReference(akkaService);
 
-        act.Should().Throw<ArgumentNullException>().WithParameterName("builder");
+        var ex = Assert.Throws<ArgumentNullException>(act);
+        Assert.Equal("builder", ex.ParamName);
     }
 
     [Fact]
@@ -155,7 +159,8 @@ public class AkkaServiceExtensionsSpecs
 
         var act = () => containerResource.WithReference(null!);
 
-        act.Should().Throw<ArgumentNullException>().WithParameterName("akkaService");
+        var ex = Assert.Throws<ArgumentNullException>(act);
+        Assert.Equal("akkaService", ex.ParamName);
     }
 
     [Fact]
@@ -180,8 +185,8 @@ public class AkkaServiceExtensionsSpecs
             callback.Callback(envContext);
         }
 
-        envContext.EnvironmentVariables.Should().ContainKey("Akka__Cluster__RequiredContactPointsNr");
-        envContext.EnvironmentVariables["Akka__Cluster__RequiredContactPointsNr"].Should().Be("3");
+        Assert.Contains("Akka__Cluster__RequiredContactPointsNr", envContext.EnvironmentVariables.Keys);
+        Assert.Equal("3", envContext.EnvironmentVariables["Akka__Cluster__RequiredContactPointsNr"]);
     }
 
     [Fact]
@@ -204,16 +209,16 @@ public class AkkaServiceExtensionsSpecs
             callback.Callback(envContext);
         }
 
-        envContext.EnvironmentVariables.Should().ContainKey("Akka__Cluster__Enabled");
-        envContext.EnvironmentVariables["Akka__Cluster__Enabled"].Should().Be("true");
-        envContext.EnvironmentVariables.Should().ContainKey("Akka__Cluster__PublicHostName");
-        envContext.EnvironmentVariables["Akka__Cluster__PublicHostName"].Should().Be("localhost");
-        envContext.EnvironmentVariables.Should().ContainKey("Akka__Cluster__ServiceName");
-        envContext.EnvironmentVariables["Akka__Cluster__ServiceName"].Should().Be("my-akka-cluster");
-        envContext.EnvironmentVariables.Should().ContainKey("Akka__Cluster__FilterOnFallbackPort");
-        envContext.EnvironmentVariables["Akka__Cluster__FilterOnFallbackPort"].Should().Be("false");
-        envContext.EnvironmentVariables.Should().ContainKey("Akka__Cluster__RequiredContactPointsNr");
-        envContext.EnvironmentVariables["Akka__Cluster__RequiredContactPointsNr"].Should().Be("1");
+        Assert.Contains("Akka__Cluster__Enabled", envContext.EnvironmentVariables.Keys);
+        Assert.Equal("true", envContext.EnvironmentVariables["Akka__Cluster__Enabled"]);
+        Assert.Contains("Akka__Cluster__PublicHostName", envContext.EnvironmentVariables.Keys);
+        Assert.Equal("localhost", envContext.EnvironmentVariables["Akka__Cluster__PublicHostName"]);
+        Assert.Contains("Akka__Cluster__ServiceName", envContext.EnvironmentVariables.Keys);
+        Assert.Equal("my-akka-cluster", envContext.EnvironmentVariables["Akka__Cluster__ServiceName"]);
+        Assert.Contains("Akka__Cluster__FilterOnFallbackPort", envContext.EnvironmentVariables.Keys);
+        Assert.Equal("false", envContext.EnvironmentVariables["Akka__Cluster__FilterOnFallbackPort"]);
+        Assert.Contains("Akka__Cluster__RequiredContactPointsNr", envContext.EnvironmentVariables.Keys);
+        Assert.Equal("1", envContext.EnvironmentVariables["Akka__Cluster__RequiredContactPointsNr"]);
     }
 
     [Fact]
@@ -229,7 +234,7 @@ public class AkkaServiceExtensionsSpecs
         containerResource.WithReference(akkaService);
 
         var envCallbacks = containerResource.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-        envCallbacks.Should().NotBeEmpty("because clustering provider should add environment callbacks");
+        Assert.True(envCallbacks.Any(), "because clustering provider should add environment callbacks");
     }
 
     [Fact]
@@ -259,9 +264,9 @@ public class AkkaServiceExtensionsSpecs
         });
         await Task.WhenAll(tasks);
 
-        envContext.EnvironmentVariables.Should().ContainKey("Akka__Cluster__Clustering__ProviderType");
-        envContext.EnvironmentVariables["Akka__Cluster__Clustering__ProviderType"].Should().Be("Redis");
-        envContext.EnvironmentVariables.Should().ContainKey("Akka__Cluster__Clustering__ConnectionStringName");
-        envContext.EnvironmentVariables["Akka__Cluster__Clustering__ConnectionStringName"].Should().Be("my-redis");
+        Assert.Contains("Akka__Cluster__Clustering__ProviderType", envContext.EnvironmentVariables.Keys);
+        Assert.Equal("Redis", envContext.EnvironmentVariables["Akka__Cluster__Clustering__ProviderType"]);
+        Assert.Contains("Akka__Cluster__Clustering__ConnectionStringName", envContext.EnvironmentVariables.Keys);
+        Assert.Equal("my-redis", envContext.EnvironmentVariables["Akka__Cluster__Clustering__ConnectionStringName"]);
     }
 }

--- a/src/aspire/Akka.Aspire.Hosting.Tests/AspireClusterFormationSpecs.cs
+++ b/src/aspire/Akka.Aspire.Hosting.Tests/AspireClusterFormationSpecs.cs
@@ -7,7 +7,6 @@
 using System.Net;
 using Aspire.Hosting;
 using Aspire.Hosting.Testing;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Aspire.Hosting.Tests;
@@ -87,8 +86,8 @@ public sealed class AspireClusterFormationSpecs : IAsyncLifetime
             await Task.Delay(1000, cts.Token);
         }
 
-        response.Should().NotBeNull();
-        response!.StatusCode.Should().Be(HttpStatusCode.OK,
+        Assert.NotNull(response);
+        Assert.True(response!.StatusCode == HttpStatusCode.OK,
             "health check returns 200 only once the 3-node cluster has formed and member status is Up");
     }
 
@@ -101,7 +100,7 @@ public sealed class AspireClusterFormationSpecs : IAsyncLifetime
         var endpoint = _app!.GetEndpoint("service", "http");
         using var client = new HttpClient { BaseAddress = endpoint };
         var response = await client.GetStringAsync("/");
-        response.Should().Contain("Hello from Akka.NET Aspire");
+        Assert.Contains("Hello from Akka.NET Aspire", response);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/aspire/Akka.Aspire.Tests/AkkaAspireBootstrapTestKitSpecs.cs
+++ b/src/aspire/Akka.Aspire.Tests/AkkaAspireBootstrapTestKitSpecs.cs
@@ -6,7 +6,6 @@
 
 using Akka.Cluster;
 using Akka.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Xunit;
@@ -49,8 +48,8 @@ public class ConfigProviderBootstrapSpecs : global::Akka.Hosting.TestKit.TestKit
     public void Should_configure_remote_correctly()
     {
         var config = Sys.Settings.Config;
-        config.GetString("akka.remote.dot-netty.tcp.hostname").Should().Be("0.0.0.0");
-        config.GetString("akka.remote.dot-netty.tcp.public-hostname").Should().Be("test-host");
+        Assert.Equal("0.0.0.0", config.GetString("akka.remote.dot-netty.tcp.hostname"));
+        Assert.Equal("test-host", config.GetString("akka.remote.dot-netty.tcp.public-hostname"));
     }
 
     [Fact]
@@ -58,29 +57,29 @@ public class ConfigProviderBootstrapSpecs : global::Akka.Hosting.TestKit.TestKit
     {
         // Verify cluster is available by accessing the Cluster extension
         var cluster = Cluster.Cluster.Get(Sys);
-        cluster.Should().NotBeNull();
-        cluster.SelfAddress.Protocol.Should().Be("akka.tcp");
+        Assert.NotNull(cluster);
+        Assert.Equal("akka.tcp", cluster.SelfAddress.Protocol);
     }
 
     [Fact]
     public void Should_set_discovery_method_to_config()
     {
-        Sys.Settings.Config.GetString("akka.discovery.method").Should().Be("config");
+        Assert.Equal("config", Sys.Settings.Config.GetString("akka.discovery.method"));
     }
 
     [Fact]
     public void Should_configure_cluster_bootstrap()
     {
         var config = Sys.Settings.Config;
-        config.GetInt("akka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr").Should().Be(2);
-        config.GetString("akka.management.cluster.bootstrap.contact-point-discovery.service-name").Should().Be("test-service");
+        Assert.Equal(2, config.GetInt("akka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr"));
+        Assert.Equal("test-service", config.GetString("akka.management.cluster.bootstrap.contact-point-discovery.service-name"));
     }
 
     [Fact]
     public void Should_configure_management_endpoint()
     {
         var config = Sys.Settings.Config;
-        config.GetString("akka.management.http.hostname").Should().Be("test-host");
+        Assert.Equal("test-host", config.GetString("akka.management.http.hostname"));
     }
 }
 
@@ -107,14 +106,14 @@ public class DisabledBootstrapSpecs : global::Akka.Hosting.TestKit.TestKit
     {
         // When disabled, the provider should not be cluster
         var provider = Sys.Settings.Config.GetString("akka.actor.provider");
-        provider.Should().NotContain("Cluster");
+        Assert.DoesNotContain("Cluster", provider);
     }
 
     [Fact]
     public void Should_not_configure_remote_when_disabled()
     {
         // Default remote port should remain 0 (random) since we didn't configure it
-        Sys.Settings.Config.GetInt("akka.remote.dot-netty.tcp.port").Should().Be(0);
+        Assert.Equal(0, Sys.Settings.Config.GetInt("akka.remote.dot-netty.tcp.port"));
     }
 }
 
@@ -150,8 +149,8 @@ public class CustomClusterOptionsSpecs : global::Akka.Hosting.TestKit.TestKit
     public void Should_apply_custom_roles()
     {
         var roles = Sys.Settings.Config.GetStringList("akka.cluster.roles");
-        roles.Should().Contain("test-role");
-        roles.Should().Contain("worker");
+        Assert.Contains("test-role", roles);
+        Assert.Contains("worker", roles);
     }
 
     [Fact]
@@ -159,7 +158,7 @@ public class CustomClusterOptionsSpecs : global::Akka.Hosting.TestKit.TestKit
     {
         // Verify cluster is available
         var cluster = Cluster.Cluster.Get(Sys);
-        cluster.Should().NotBeNull();
-        cluster.SelfAddress.Protocol.Should().Be("akka.tcp");
+        Assert.NotNull(cluster);
+        Assert.Equal("akka.tcp", cluster.SelfAddress.Protocol);
     }
 }

--- a/src/aspire/Akka.Aspire.Tests/AkkaAspireClusterSettingsSpecs.cs
+++ b/src/aspire/Akka.Aspire.Tests/AkkaAspireClusterSettingsSpecs.cs
@@ -4,7 +4,6 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -17,14 +16,14 @@ public class AkkaAspireClusterSettingsSpecs
     {
         var settings = new AkkaAspireClusterSettings();
 
-        settings.Enabled.Should().BeFalse();
-        settings.RemotePort.Should().Be(8081);
-        settings.ManagementPort.Should().Be(8558);
-        settings.PublicHostName.Should().Be("localhost");
-        settings.ServiceName.Should().Be("default");
-        settings.RequiredContactPointsNr.Should().Be(1);
-        settings.FilterOnFallbackPort.Should().BeFalse();
-        settings.Clustering.Should().BeNull();
+        Assert.False(settings.Enabled);
+        Assert.Equal(8081, settings.RemotePort);
+        Assert.Equal(8558, settings.ManagementPort);
+        Assert.Equal("localhost", settings.PublicHostName);
+        Assert.Equal("default", settings.ServiceName);
+        Assert.Equal(1, settings.RequiredContactPointsNr);
+        Assert.False(settings.FilterOnFallbackPort);
+        Assert.Null(settings.Clustering);
     }
 
     [Fact]
@@ -48,13 +47,13 @@ public class AkkaAspireClusterSettingsSpecs
         var settings = new AkkaAspireClusterSettings();
         configuration.GetSection("Akka:Cluster").Bind(settings);
 
-        settings.Enabled.Should().BeTrue();
-        settings.RemotePort.Should().Be(9999);
-        settings.ManagementPort.Should().Be(7777);
-        settings.PublicHostName.Should().Be("myhost.example.com");
-        settings.ServiceName.Should().Be("my-service");
-        settings.RequiredContactPointsNr.Should().Be(3);
-        settings.FilterOnFallbackPort.Should().BeTrue();
+        Assert.True(settings.Enabled);
+        Assert.Equal(9999, settings.RemotePort);
+        Assert.Equal(7777, settings.ManagementPort);
+        Assert.Equal("myhost.example.com", settings.PublicHostName);
+        Assert.Equal("my-service", settings.ServiceName);
+        Assert.Equal(3, settings.RequiredContactPointsNr);
+        Assert.True(settings.FilterOnFallbackPort);
     }
 
     [Fact]
@@ -73,9 +72,9 @@ public class AkkaAspireClusterSettingsSpecs
         var settings = new AkkaAspireClusterSettings();
         configuration.GetSection("Akka:Cluster").Bind(settings);
 
-        settings.Enabled.Should().BeTrue();
-        settings.Clustering.Should().NotBeNull();
-        settings.Clustering!.ProviderType.Should().Be("Redis");
+        Assert.True(settings.Enabled);
+        Assert.NotNull(settings.Clustering);
+        Assert.Equal("Redis", settings.Clustering!.ProviderType);
     }
 
     [Fact]
@@ -94,10 +93,10 @@ public class AkkaAspireClusterSettingsSpecs
         var settings = new AkkaAspireClusterSettings();
         configuration.GetSection("Akka:Cluster").Bind(settings);
 
-        settings.Enabled.Should().BeTrue();
-        settings.ServiceName.Should().Be("test-service");
-        settings.RemotePort.Should().Be(8081);
-        settings.ManagementPort.Should().Be(8558);
-        settings.PublicHostName.Should().Be("localhost");
+        Assert.True(settings.Enabled);
+        Assert.Equal("test-service", settings.ServiceName);
+        Assert.Equal(8081, settings.RemotePort);
+        Assert.Equal(8558, settings.ManagementPort);
+        Assert.Equal("localhost", settings.PublicHostName);
     }
 }

--- a/src/aspire/Akka.Aspire.Tests/AkkaAspireExtensionsSpecs.cs
+++ b/src/aspire/Akka.Aspire.Tests/AkkaAspireExtensionsSpecs.cs
@@ -6,7 +6,6 @@
 
 using Akka.Actor;
 using Akka.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -31,8 +30,8 @@ public class AkkaAspireExtensionsSpecs
 
         var result = builder.WithAspireClusterBootstrap(sp);
 
-        result.Should().NotBeNull();
-        result.Should().BeSameAs(builder);
+        Assert.NotNull(result);
+        Assert.Same(builder, result);
     }
 
     [Fact]
@@ -66,22 +65,22 @@ public class AkkaAspireExtensionsSpecs
         var actorSystem = host.Services.GetRequiredService<ActorSystem>();
         var config = actorSystem.Settings.Config;
 
-        config.GetString("akka.discovery.method").Should().Be("redis");
+        Assert.Equal("redis", config.GetString("akka.discovery.method"));
 
-        config.GetString("akka.remote.dot-netty.tcp.hostname").Should().Be("0.0.0.0");
-        config.GetInt("akka.remote.dot-netty.tcp.port").Should().Be(8081);
-        config.GetString("akka.remote.dot-netty.tcp.public-hostname").Should().Be("localhost");
-        config.GetInt("akka.remote.dot-netty.tcp.public-port").Should().Be(8081);
+        Assert.Equal("0.0.0.0", config.GetString("akka.remote.dot-netty.tcp.hostname"));
+        Assert.Equal(8081, config.GetInt("akka.remote.dot-netty.tcp.port"));
+        Assert.Equal("localhost", config.GetString("akka.remote.dot-netty.tcp.public-hostname"));
+        Assert.Equal(8081, config.GetInt("akka.remote.dot-netty.tcp.public-port"));
 
-        config.GetString("akka.management.http.hostname").Should().Be("localhost");
-        config.GetInt("akka.management.http.port").Should().Be(8558);
+        Assert.Equal("localhost", config.GetString("akka.management.http.hostname"));
+        Assert.Equal(8558, config.GetInt("akka.management.http.port"));
 
-        config.GetInt("akka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr").Should().Be(2);
-        config.GetString("akka.management.cluster.bootstrap.contact-point-discovery.service-name").Should().Be("test-service");
-        config.GetBoolean("akka.management.cluster.bootstrap.contact-point.filter-on-fallback-port").Should().BeFalse();
+        Assert.Equal(2, config.GetInt("akka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr"));
+        Assert.Equal("test-service", config.GetString("akka.management.cluster.bootstrap.contact-point-discovery.service-name"));
+        Assert.False(config.GetBoolean("akka.management.cluster.bootstrap.contact-point.filter-on-fallback-port"));
 
-        config.GetString("akka.discovery.redis.public-hostname").Should().Be("localhost");
-        config.GetInt("akka.discovery.redis.public-port").Should().Be(8558);
+        Assert.Equal("localhost", config.GetString("akka.discovery.redis.public-hostname"));
+        Assert.Equal(8558, config.GetInt("akka.discovery.redis.public-port"));
     }
 
     [Fact]
@@ -120,7 +119,7 @@ public class AkkaAspireExtensionsSpecs
             .Build();
 
         var actorSystem = host.Services.GetRequiredService<ActorSystem>();
-        actorSystem.Settings.Config.GetString("akka.discovery.method").Should().Be(expectedMethod);
+        Assert.Equal(expectedMethod, actorSystem.Settings.Config.GetString("akka.discovery.method"));
     }
 
     [Fact]
@@ -144,7 +143,7 @@ public class AkkaAspireExtensionsSpecs
             clusterOptions.Roles = ["test-role"];
         });
 
-        callbackInvoked.Should().BeTrue();
+        Assert.True(callbackInvoked);
     }
 
     [Fact]
@@ -175,9 +174,9 @@ public class AkkaAspireExtensionsSpecs
                 receivedConfig = config;
             });
 
-        callbackInvoked.Should().BeTrue();
-        receivedConfig.Should().NotBeNull();
-        receivedConfig!.GetConnectionString("akka-discovery").Should().Be("localhost:6379");
+        Assert.True(callbackInvoked);
+        Assert.NotNull(receivedConfig);
+        Assert.Equal("localhost:6379", receivedConfig!.GetConnectionString("akka-discovery"));
     }
 
     [Fact]
@@ -198,6 +197,6 @@ public class AkkaAspireExtensionsSpecs
         builder.WithAspireClusterBootstrap(sp,
             configureDiscovery: (b, config) => { callbackInvoked = true; });
 
-        callbackInvoked.Should().BeFalse();
+        Assert.False(callbackInvoked);
     }
 }

--- a/src/discovery/redis/Akka.Discovery.Redis.Tests/ClusterMemberSpec.cs
+++ b/src/discovery/redis/Akka.Discovery.Redis.Tests/ClusterMemberSpec.cs
@@ -7,7 +7,6 @@
 #nullable enable
 using System;
 using System.Linq;
-using FluentAssertions;
 using Google.Protobuf;
 using Xunit;
 
@@ -30,11 +29,11 @@ namespace Akka.Discovery.Redis.Tests
 
             var restored = ClusterMember.FromBytes(member.ToBytes());
 
-            restored.ServiceName.Should().Be(member.ServiceName);
-            restored.Host.Should().Be(member.Host);
-            restored.Port.Should().Be(member.Port);
-            restored.Created.Should().Be(member.Created);
-            restored.LastUpdate.Should().Be(member.LastUpdate);
+            Assert.Equal(member.ServiceName, restored.ServiceName);
+            Assert.Equal(member.Host, restored.Host);
+            Assert.Equal(member.Port, restored.Port);
+            Assert.Equal(member.Created, restored.Created);
+            Assert.Equal(member.LastUpdate, restored.LastUpdate);
         }
 
         [Fact]
@@ -48,11 +47,12 @@ namespace Akka.Discovery.Redis.Tests
 
             var act = () => ClusterMember.FromBytes(withUnknownField);
 
-            act.Should().NotThrow();
+            var ex = Record.Exception(act);
+            Assert.Null(ex);
             var restored = act();
-            restored.ServiceName.Should().Be("svc");
-            restored.Host.Should().Be("host");
-            restored.Port.Should().Be(42);
+            Assert.Equal("svc", restored.ServiceName);
+            Assert.Equal("host", restored.Host);
+            Assert.Equal(42, restored.Port);
         }
 
         [Fact]
@@ -64,15 +64,15 @@ namespace Akka.Discovery.Redis.Tests
 
             var restored = ClusterMember.FromBytes(proto.ToByteArray());
 
-            restored.Created.Should().Be(Epoch);
-            restored.LastUpdate.Should().Be(Epoch);
+            Assert.Equal(Epoch, restored.Created);
+            Assert.Equal(Epoch, restored.LastUpdate);
         }
 
         [Fact]
         public void CreateKey_should_be_stable_and_namespaced()
         {
             var key = ClusterMember.CreateKey("akka:discovery", "svc", "10.0.0.5", 8558);
-            key.Should().Be("akka:discovery:svc:10.0.0.5:8558");
+            Assert.Equal("akka:discovery:svc:10.0.0.5:8558", key);
         }
     }
 }

--- a/src/discovery/redis/Akka.Discovery.Redis.Tests/HostingSpecs.cs
+++ b/src/discovery/redis/Akka.Discovery.Redis.Tests/HostingSpecs.cs
@@ -9,7 +9,6 @@ using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -32,9 +31,9 @@ namespace Akka.Discovery.Redis.Tests
                 builder.WithRedisDiscovery("localhost:6379", "test-service"));
 
             var config = system.Settings.Config;
-            config.GetString("akka.discovery.method").Should().Be("redis");
-            config.GetString("akka.discovery.redis.connection-string").Should().Be("localhost:6379");
-            config.GetString("akka.discovery.redis.service-name").Should().Be("test-service");
+            Assert.Equal("redis", config.GetString("akka.discovery.method"));
+            Assert.Equal("localhost:6379", config.GetString("akka.discovery.redis.connection-string"));
+            Assert.Equal("test-service", config.GetString("akka.discovery.redis.service-name"));
 
             await system.Terminate();
         }
@@ -54,14 +53,14 @@ namespace Akka.Discovery.Redis.Tests
             }));
 
             var config = system.Settings.Config;
-            config.GetString("akka.discovery.method").Should().Be("redis");
-            config.GetString("akka.discovery.redis.connection-string").Should().Be("redis-server:6379");
-            config.GetString("akka.discovery.redis.service-name").Should().Be("my-cluster");
-            config.GetInt("akka.discovery.redis.public-port").Should().Be(9999);
-            config.GetTimeSpan("akka.discovery.redis.ttl").Should().Be(TimeSpan.FromMinutes(5));
-            config.GetBoolean("akka.discovery.redis.read-only").Should().BeTrue();
-            config.GetTimeSpan("akka.discovery.redis.stale-ttl-threshold").Should().Be(TimeSpan.FromSeconds(90));
-            config.GetTimeSpan("akka.discovery.redis.operation-timeout").Should().Be(TimeSpan.FromSeconds(7));
+            Assert.Equal("redis", config.GetString("akka.discovery.method"));
+            Assert.Equal("redis-server:6379", config.GetString("akka.discovery.redis.connection-string"));
+            Assert.Equal("my-cluster", config.GetString("akka.discovery.redis.service-name"));
+            Assert.Equal(9999, config.GetInt("akka.discovery.redis.public-port"));
+            Assert.Equal(TimeSpan.FromMinutes(5), config.GetTimeSpan("akka.discovery.redis.ttl"));
+            Assert.True(config.GetBoolean("akka.discovery.redis.read-only"));
+            Assert.Equal(TimeSpan.FromSeconds(90), config.GetTimeSpan("akka.discovery.redis.stale-ttl-threshold"));
+            Assert.Equal(TimeSpan.FromSeconds(7), config.GetTimeSpan("akka.discovery.redis.operation-timeout"));
 
             await system.Terminate();
         }
@@ -70,7 +69,7 @@ namespace Akka.Discovery.Redis.Tests
         public async Task WithRedisDiscovery_should_set_default_discovery_method()
         {
             var system = await StartSystem(builder => builder.WithRedisDiscovery("localhost:6379"));
-            system.Settings.Config.GetString("akka.discovery.method").Should().Be("redis");
+            Assert.Equal("redis", system.Settings.Config.GetString("akka.discovery.method"));
             await system.Terminate();
         }
 
@@ -83,7 +82,7 @@ namespace Akka.Discovery.Redis.Tests
                 options.IsDefaultPlugin = false;
             }));
 
-            system.Settings.Config.HasPath("akka.discovery.method").Should().BeFalse();
+            Assert.False(system.Settings.Config.HasPath("akka.discovery.method"));
             await system.Terminate();
         }
     }

--- a/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisClusterMemberClientSpec.cs
+++ b/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisClusterMemberClientSpec.cs
@@ -8,8 +8,6 @@
 using System;
 using System.Threading.Tasks;
 using Akka.Event;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using StackExchange.Redis;
@@ -75,22 +73,22 @@ namespace Akka.Discovery.Redis.Tests
         {
             var entity = await _client.GetOrCreateAsync();
 
-            entity.ServiceName.Should().Be(ServiceName);
-            entity.Host.Should().Be(Host);
-            entity.Port.Should().Be(SelfPort);
+            Assert.Equal(ServiceName, entity.ServiceName);
+            Assert.Equal(Host, entity.Host);
+            Assert.Equal(SelfPort, entity.Port);
 
             var raw = await _database.StringGetAsync(ClusterMember.CreateKey(KeyPrefix, ServiceName, Host, SelfPort));
-            raw.HasValue.Should().BeTrue();
+            Assert.True(raw.HasValue);
         }
 
         [Fact(DisplayName = "GetOrCreateAsync should fetch existing entry and refresh LastUpdate")]
         public async Task GetOrCreateShouldFetchAndRefresh()
         {
-            await SeedAsync(Host, SelfPort, DateTime.UtcNow - 1.Hours());
+            await SeedAsync(Host, SelfPort, DateTime.UtcNow - TimeSpan.FromHours(1));
 
             var entity = await _client.GetOrCreateAsync();
 
-            entity.LastUpdate.Should().BeAfter(DateTime.UtcNow - 5.Seconds());
+            Assert.True(entity.LastUpdate > DateTime.UtcNow - TimeSpan.FromSeconds(5));
         }
 
         [Fact(DisplayName = "GetAllAsync should return live members and exclude stale ones")]
@@ -98,25 +96,25 @@ namespace Akka.Discovery.Redis.Tests
         {
             // self (fresh) + one fresh peer + one stale peer
             await _client.GetOrCreateAsync();
-            await SeedAsync("10.0.0.2", 8558, DateTime.UtcNow - 2.Seconds());
-            await SeedAsync("10.0.0.3", 8558, DateTime.UtcNow - 10.Minutes());
+            await SeedAsync("10.0.0.2", 8558, DateTime.UtcNow - TimeSpan.FromSeconds(2));
+            await SeedAsync("10.0.0.3", 8558, DateTime.UtcNow - TimeSpan.FromMinutes(10));
 
-            var members = await _client.GetAllAsync(30.Seconds());
+            var members = await _client.GetAllAsync(TimeSpan.FromSeconds(30));
 
-            members.Count.Should().Be(2);
-            members.Should().NotContain(m => m.Host == "10.0.0.3");
+            Assert.Equal(2, members.Count);
+            Assert.DoesNotContain(members, m => m.Host == "10.0.0.3");
         }
 
         [Fact(DisplayName = "UpdateAsync should refresh LastUpdate")]
         public async Task UpdateShouldRefresh()
         {
             var first = await _client.GetOrCreateAsync();
-            await Task.Delay(50.Milliseconds());
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
             await _client.UpdateAsync();
 
             var members = await _client.GetAllAsync(TimeSpan.FromMinutes(5));
-            members.Should().ContainSingle();
-            members[0].LastUpdate.Should().BeAfter(first.LastUpdate);
+            Assert.Single(members);
+            Assert.True(members[0].LastUpdate > first.LastUpdate);
         }
 
         [Fact(DisplayName = "RemoveSelfAsync should delete the entry")]
@@ -126,7 +124,7 @@ namespace Akka.Discovery.Redis.Tests
             await _client.RemoveSelfAsync();
 
             var raw = await _database.StringGetAsync(ClusterMember.CreateKey(KeyPrefix, ServiceName, Host, SelfPort));
-            raw.HasValue.Should().BeFalse();
+            Assert.False(raw.HasValue);
         }
 
         [Fact(DisplayName = "Entries should physically expire after their TTL")]
@@ -137,18 +135,18 @@ namespace Akka.Discovery.Redis.Tests
                 .WithHostName(Host)
                 .WithPort(SelfPort)
                 .WithKeyPrefix(KeyPrefix)
-                .WithTtlHeartbeatInterval(1.Seconds())
-                .WithTtl(2.Seconds());
+                .WithTtlHeartbeatInterval(TimeSpan.FromSeconds(1))
+                .WithTtl(TimeSpan.FromSeconds(2));
 
             var shortClient = new ClusterMemberRedisClient(_connection, shortTtl, Logging.GetLogger(Sys, "short-ttl"));
             await shortClient.GetOrCreateAsync();
 
             var key = ClusterMember.CreateKey(KeyPrefix, ServiceName, Host, SelfPort);
-            (await _database.StringGetAsync(key)).HasValue.Should().BeTrue();
+            Assert.True((await _database.StringGetAsync(key)).HasValue);
 
-            await Task.Delay(3.Seconds());
+            await Task.Delay(TimeSpan.FromSeconds(3));
 
-            (await _database.StringGetAsync(key)).HasValue.Should().BeFalse();
+            Assert.False((await _database.StringGetAsync(key)).HasValue);
         }
     }
 }

--- a/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisDiscoveryActorSpec.cs
+++ b/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisDiscoveryActorSpec.cs
@@ -11,8 +11,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Discovery;
 using Akka.Discovery.Redis.Actors;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using StackExchange.Redis;
 using Xunit;
 
@@ -53,7 +51,7 @@ namespace Akka.Discovery.Redis.Tests
                 .WithPort(SelfPort)
                 .WithKeyPrefix(_keyPrefix)
                 .WithConnectionString(_fixture.ConnectionString)
-                .WithTtlHeartbeatInterval(1.Seconds());
+                .WithTtlHeartbeatInterval(TimeSpan.FromSeconds(1));
         }
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
@@ -65,11 +63,11 @@ namespace Akka.Discovery.Redis.Tests
 
             await AwaitAssertAsync(async () =>
             {
-                var members = await guardian.Ask<ImmutableList<ClusterMember>>(new Lookup(ServiceName), 3.Seconds());
-                members.Count.Should().Be(1);
-                members[0].Host.Should().Be(Host);
-                members[0].Port.Should().Be(SelfPort);
-            }, 20.Seconds(), 500.Milliseconds());
+                var members = await guardian.Ask<ImmutableList<ClusterMember>>(new Lookup(ServiceName), TimeSpan.FromSeconds(3));
+                Assert.Single(members);
+                Assert.Equal(Host, members[0].Host);
+                Assert.Equal(SelfPort, members[0].Port);
+            }, TimeSpan.FromSeconds(20), TimeSpan.FromMilliseconds(500));
         }
 
         [Fact(DisplayName = "Guardian should return empty on a service-name mismatch")]
@@ -80,12 +78,12 @@ namespace Akka.Discovery.Redis.Tests
             // wait until initialized (self resolvable)
             await AwaitAssertAsync(async () =>
             {
-                var members = await guardian.Ask<ImmutableList<ClusterMember>>(new Lookup(ServiceName), 3.Seconds());
-                members.Count.Should().Be(1);
-            }, 20.Seconds(), 500.Milliseconds());
+                var members = await guardian.Ask<ImmutableList<ClusterMember>>(new Lookup(ServiceName), TimeSpan.FromSeconds(3));
+                Assert.Single(members);
+            }, TimeSpan.FromSeconds(20), TimeSpan.FromMilliseconds(500));
 
-            var mismatch = await guardian.Ask<ImmutableList<ClusterMember>>(new Lookup("some-other-service"), 3.Seconds());
-            mismatch.Should().BeEmpty();
+            var mismatch = await guardian.Ask<ImmutableList<ClusterMember>>(new Lookup("some-other-service"), TimeSpan.FromSeconds(3));
+            Assert.Empty(mismatch);
         }
 
         [Fact(DisplayName = "Heartbeat child should keep refreshing the self entry")]
@@ -100,7 +98,7 @@ namespace Akka.Discovery.Redis.Tests
             async Task<DateTime> ReadLastUpdate()
             {
                 var value = await database.StringGetAsync(key);
-                value.HasValue.Should().BeTrue();
+                Assert.True(value.HasValue);
                 return ClusterMember.FromBytes((byte[])value!).LastUpdate;
             }
 
@@ -108,16 +106,16 @@ namespace Akka.Discovery.Redis.Tests
             DateTime first = default;
             await AwaitAssertAsync(async () =>
             {
-                (await database.KeyExistsAsync(key)).Should().BeTrue();
+                Assert.True(await database.KeyExistsAsync(key));
                 first = await ReadLastUpdate();
-            }, 20.Seconds(), 500.Milliseconds());
+            }, TimeSpan.FromSeconds(20), TimeSpan.FromMilliseconds(500));
 
             // The 1s heartbeat must advance LastUpdate over time.
             await AwaitAssertAsync(async () =>
             {
                 var current = await ReadLastUpdate();
-                current.Should().BeAfter(first);
-            }, 10.Seconds(), 500.Milliseconds());
+                Assert.True(current > first);
+            }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(500));
         }
 
         [Fact(DisplayName = "StopDiscovery should remove the self entry from Redis")]
@@ -131,15 +129,15 @@ namespace Akka.Discovery.Redis.Tests
 
             await AwaitAssertAsync(async () =>
             {
-                var members = await guardian.Ask<ImmutableList<ClusterMember>>(new Lookup(ServiceName), 3.Seconds());
-                members.Count.Should().Be(1);
-            }, 20.Seconds(), 500.Milliseconds());
+                var members = await guardian.Ask<ImmutableList<ClusterMember>>(new Lookup(ServiceName), TimeSpan.FromSeconds(3));
+                Assert.Single(members);
+            }, TimeSpan.FromSeconds(20), TimeSpan.FromMilliseconds(500));
 
-            await guardian.Ask<Done>(StopDiscovery.Instance, 5.Seconds());
+            await guardian.Ask<Done>(StopDiscovery.Instance, TimeSpan.FromSeconds(5));
 
             await using var connection = await ConnectionMultiplexer.ConnectAsync(_fixture.ConnectionString);
             var key = ClusterMember.CreateKey(_keyPrefix, ServiceName, Host, SelfPort);
-            (await connection.GetDatabase().StringGetAsync(key)).HasValue.Should().BeFalse();
+            Assert.False((await connection.GetDatabase().StringGetAsync(key)).HasValue);
         }
     }
 }

--- a/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisDiscoveryLoadSpecs.cs
+++ b/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisDiscoveryLoadSpecs.cs
@@ -8,7 +8,6 @@
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Discovery.Redis.Tests
@@ -34,7 +33,7 @@ namespace Akka.Discovery.Redis.Tests
             using var system = ActorSystem.Create("redis-load-spec", config);
 
             var discovery = Discovery.Get(system).LoadServiceDiscovery("redis");
-            discovery.Should().BeOfType<RedisServiceDiscovery>();
+            Assert.IsType<RedisServiceDiscovery>(discovery);
 
             await system.Terminate();
         }

--- a/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisDiscoverySettingsSpecs.cs
+++ b/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisDiscoverySettingsSpecs.cs
@@ -7,7 +7,6 @@
 #nullable enable
 using System;
 using Akka.Configuration;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Discovery.Redis.Tests
@@ -40,18 +39,18 @@ namespace Akka.Discovery.Redis.Tests
                 max-retry-backoff = 3s
             ");
 
-            settings.ReadOnly.Should().BeTrue();
-            settings.ServiceName.Should().Be("my-service");
-            settings.HostName.Should().Be("localhost");
-            settings.Port.Should().Be(9999);
-            settings.ConnectionString.Should().Be("redis:6379");
-            settings.Ttl.Should().Be(TimeSpan.FromMinutes(5));
-            settings.TtlHeartbeatInterval.Should().Be(TimeSpan.FromSeconds(45));
-            settings.StaleTtlThreshold.Should().Be(TimeSpan.FromSeconds(90));
-            settings.KeyPrefix.Should().Be("test:prefix");
-            settings.OperationTimeout.Should().Be(TimeSpan.FromSeconds(7));
-            settings.RetryBackoff.Should().Be(TimeSpan.FromMilliseconds(250));
-            settings.MaximumRetryBackoff.Should().Be(TimeSpan.FromSeconds(3));
+            Assert.True(settings.ReadOnly);
+            Assert.Equal("my-service", settings.ServiceName);
+            Assert.Equal("localhost", settings.HostName);
+            Assert.Equal(9999, settings.Port);
+            Assert.Equal("redis:6379", settings.ConnectionString);
+            Assert.Equal(TimeSpan.FromMinutes(5), settings.Ttl);
+            Assert.Equal(TimeSpan.FromSeconds(45), settings.TtlHeartbeatInterval);
+            Assert.Equal(TimeSpan.FromSeconds(90), settings.StaleTtlThreshold);
+            Assert.Equal("test:prefix", settings.KeyPrefix);
+            Assert.Equal(TimeSpan.FromSeconds(7), settings.OperationTimeout);
+            Assert.Equal(TimeSpan.FromMilliseconds(250), settings.RetryBackoff);
+            Assert.Equal(TimeSpan.FromSeconds(3), settings.MaximumRetryBackoff);
         }
 
         [Fact]
@@ -59,16 +58,16 @@ namespace Akka.Discovery.Redis.Tests
         {
             var settings = ParseSettings(@"connection-string = ""localhost""");
 
-            settings.ReadOnly.Should().BeFalse();
-            settings.ServiceName.Should().Be("default");
-            settings.Port.Should().Be(8558);
-            settings.Ttl.Should().Be(TimeSpan.FromMinutes(2));
-            settings.TtlHeartbeatInterval.Should().Be(TimeSpan.FromSeconds(30));
-            settings.StaleTtlThreshold.Should().Be(TimeSpan.Zero);
-            settings.KeyPrefix.Should().Be("akka:discovery");
-            settings.OperationTimeout.Should().Be(TimeSpan.FromSeconds(10));
-            settings.RetryBackoff.Should().Be(TimeSpan.FromMilliseconds(500));
-            settings.MaximumRetryBackoff.Should().Be(TimeSpan.FromSeconds(5));
+            Assert.False(settings.ReadOnly);
+            Assert.Equal("default", settings.ServiceName);
+            Assert.Equal(8558, settings.Port);
+            Assert.Equal(TimeSpan.FromMinutes(2), settings.Ttl);
+            Assert.Equal(TimeSpan.FromSeconds(30), settings.TtlHeartbeatInterval);
+            Assert.Equal(TimeSpan.Zero, settings.StaleTtlThreshold);
+            Assert.Equal("akka:discovery", settings.KeyPrefix);
+            Assert.Equal(TimeSpan.FromSeconds(10), settings.OperationTimeout);
+            Assert.Equal(TimeSpan.FromMilliseconds(500), settings.RetryBackoff);
+            Assert.Equal(TimeSpan.FromSeconds(5), settings.MaximumRetryBackoff);
         }
 
         [Fact]
@@ -79,7 +78,7 @@ namespace Akka.Discovery.Redis.Tests
                               public-hostname = """"",
                 extraSystemHocon: @"akka.remote.dot-netty.tcp.public-hostname = ""my-remote-host""");
 
-            settings.HostName.Should().Be("my-remote-host");
+            Assert.Equal("my-remote-host", settings.HostName);
         }
 
         [Fact]
@@ -87,7 +86,7 @@ namespace Akka.Discovery.Redis.Tests
         {
             // heartbeat 30s, ttl 2m => min(90s, 120s) == 90s
             var settings = ParseSettings(@"connection-string = ""localhost""");
-            settings.EffectiveStaleTtlThreshold.Should().Be(TimeSpan.FromSeconds(90));
+            Assert.Equal(TimeSpan.FromSeconds(90), settings.EffectiveStaleTtlThreshold);
         }
 
         [Fact]
@@ -97,7 +96,7 @@ namespace Akka.Discovery.Redis.Tests
                 connection-string = ""localhost""
                 stale-ttl-threshold = 50s
             ");
-            settings.EffectiveStaleTtlThreshold.Should().Be(TimeSpan.FromSeconds(50));
+            Assert.Equal(TimeSpan.FromSeconds(50), settings.EffectiveStaleTtlThreshold);
         }
 
         [Fact]
@@ -106,10 +105,10 @@ namespace Akka.Discovery.Redis.Tests
             var original = RedisDiscoverySettings.Empty;
             var modified = original.WithServiceName("new-service");
 
-            modified.ServiceName.Should().Be("new-service");
-            modified.HostName.Should().Be(original.HostName);
-            modified.Port.Should().Be(original.Port);
-            original.ServiceName.Should().Be("default");
+            Assert.Equal("new-service", modified.ServiceName);
+            Assert.Equal(original.HostName, modified.HostName);
+            Assert.Equal(original.Port, modified.Port);
+            Assert.Equal("default", original.ServiceName);
         }
 
         [Fact]
@@ -118,8 +117,8 @@ namespace Akka.Discovery.Redis.Tests
             var original = RedisDiscoverySettings.Empty;
             var modified = original.WithReadOnlyMode(true);
 
-            modified.ReadOnly.Should().BeTrue();
-            original.ReadOnly.Should().BeFalse();
+            Assert.True(modified.ReadOnly);
+            Assert.False(original.ReadOnly);
         }
 
         [Theory]
@@ -128,7 +127,7 @@ namespace Akka.Discovery.Redis.Tests
         public void Constructor_should_throw_when_port_is_invalid(int port)
         {
             var act = () => RedisDiscoverySettings.Empty.WithPort(port);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [Fact]
@@ -138,7 +137,7 @@ namespace Akka.Discovery.Redis.Tests
                 .WithTtl(TimeSpan.FromSeconds(30))
                 .WithTtlHeartbeatInterval(TimeSpan.FromSeconds(45));
 
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [Fact]
@@ -146,14 +145,14 @@ namespace Akka.Discovery.Redis.Tests
         {
             // heartbeat is 30s by default; 10s <= 30s must throw
             var act = () => RedisDiscoverySettings.Empty.WithStaleTtlThreshold(TimeSpan.FromSeconds(10));
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [Fact]
         public void Constructor_should_throw_when_operation_timeout_is_not_positive()
         {
             var act = () => RedisDiscoverySettings.Empty.WithOperationTimeout(TimeSpan.Zero);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [Fact]
@@ -161,21 +160,21 @@ namespace Akka.Discovery.Redis.Tests
         {
             var act = () => RedisDiscoverySettings.Empty
                 .WithRetryBackoff(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1));
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [Fact]
         public void Constructor_should_throw_on_empty_connection_string()
         {
             var act = () => RedisDiscoverySettings.Empty.WithConnectionString("  ");
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [Fact]
         public void Constructor_should_throw_on_empty_key_prefix()
         {
             var act = () => RedisDiscoverySettings.Empty.WithKeyPrefix("");
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
     }
 }

--- a/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisMultiNodeDiscoverySpec.cs
+++ b/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisMultiNodeDiscoverySpec.cs
@@ -11,8 +11,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Discovery;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Akka.Discovery.Redis.Tests
@@ -85,10 +83,10 @@ namespace Akka.Discovery.Redis.Tests
             {
                 foreach (var discovery in _discoveries)
                 {
-                    var resolved = await discovery.Lookup(new Lookup(ServiceName), 5.Seconds());
-                    resolved.Addresses.Count.Should().Be(NodeCount);
+                    var resolved = await discovery.Lookup(new Lookup(ServiceName), TimeSpan.FromSeconds(5));
+                    Assert.Equal(NodeCount, resolved.Addresses.Count);
                 }
-            }, 30.Seconds(), 1.Seconds());
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
         }
     }
 }

--- a/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisResilienceSpec.cs
+++ b/src/discovery/redis/Akka.Discovery.Redis.Tests/RedisResilienceSpec.cs
@@ -12,8 +12,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Discovery;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Testcontainers.Redis;
 using Xunit;
 
@@ -62,10 +60,11 @@ namespace Akka.Discovery.Redis.Tests
 
             ServiceDiscovery? discovery = null;
             var load = () => discovery = Discovery.Get(system).LoadServiceDiscovery("redis");
-            load.Should().NotThrow("the connection must be established lazily, not in the discovery constructor");
+            var loadException = Record.Exception(load);
+            Assert.True(loadException is null, "the connection must be established lazily, not in the discovery constructor");
 
-            var resolved = await discovery!.Lookup(new Lookup("svc"), 2.Seconds());
-            resolved.Addresses.Should().BeEmpty();
+            var resolved = await discovery!.Lookup(new Lookup("svc"), TimeSpan.FromSeconds(2));
+            Assert.Empty(resolved.Addresses);
 
             await system.Terminate();
         }
@@ -98,8 +97,8 @@ namespace Akka.Discovery.Redis.Tests
                 var discovery = Discovery.Get(system).LoadServiceDiscovery("redis");
 
                 // Redis is not up yet: startup survived and lookup is empty.
-                var initial = await discovery.Lookup(new Lookup("recovery"), 2.Seconds());
-                initial.Addresses.Should().BeEmpty();
+                var initial = await discovery.Lookup(new Lookup("recovery"), TimeSpan.FromSeconds(2));
+                Assert.Empty(initial.Addresses);
 
                 // Bring Redis up; the guardian's retry loop should now register self and resolve it.
                 try
@@ -116,9 +115,9 @@ namespace Akka.Discovery.Redis.Tests
 
                 await AwaitAssertAsync(async () =>
                 {
-                    var resolved = await discovery.Lookup(new Lookup("recovery"), 3.Seconds());
-                    resolved.Addresses.Count.Should().Be(1);
-                }, 30.Seconds(), 1.Seconds());
+                    var resolved = await discovery.Lookup(new Lookup("recovery"), TimeSpan.FromSeconds(3));
+                    Assert.Single(resolved.Addresses);
+                }, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
             }
             finally
             {


### PR DESCRIPTION
**Part 1 of 3** of removing FluentAssertions from the repo (it went commercial at v8; we're on the last MIT version, 7.0.0). This PR migrates the **Aspire + Redis** test projects to native xUnit `Assert.*`.

### Scope — 13 files
- `src/aspire/Akka.Aspire.Hosting.Tests/**` (2), `src/aspire/Akka.Aspire.Tests/**` (3)
- `src/discovery/redis/Akka.Discovery.Redis.Tests/**` (8)

Only assertion calls changed — arrange/act, test data, names, and `[Fact]`/`[Theory]` structure are untouched. `FluentAssertions.Extensions` timing helpers (`1.Seconds()` etc., which are TimeSpan sugar, not assertions) are replaced with `TimeSpan.FromX`. Reason strings and exception message/param-name checks are preserved.

### Semantic equivalence — independently verified
The conversion and the review were done by **separate agents**. An adversarial reviewer audited every old→new assertion pair with a "not equivalent until proven" stance:

- **0 blocking findings.**
- **Dropped-assertion audit:** none. 193 removed `.Should()` lines map to 199 `Assert.*` + 2 `Record.Exception`; the +6 delta is exactly 6 `WithParameterName` chains, each expanded to a throw-check plus a `ParamName` check.
- **Exact-type `Throw<T>`** (FA matches derived types; `Assert.Throws<T>` is exact): verified safe by reading each throwing path — all throw exactly `ArgumentException`/`ArgumentNullException`.
- **`Assert.Equal` argument order** (expected-first): all ~150 call sites checked, none flipped.
- String-vs-collection `Contains`, `Count==1 → Assert.Single`, strict `BeAfter`, boxed dictionary-value equality, and `NotThrow` single-invocation/side-effects all verified.

### Tests — green on net10.0
- `Akka.Discovery.Redis.Tests`: **37/37**
- `Akka.Aspire.Tests`: **22/22**
- `Akka.Aspire.Hosting.Tests`: **16/16** (including the real 3-node Aspire cluster-formation test)

FluentAssertions stays in `Directory.Packages.props` until part 3, when the last project is migrated and the package is removed.
