### PR TITLE
Migrate Discovery + Coordination tests from FluentAssertions to xUnit Assert (2/3)

### DIFF
--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/AkkaHostingSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/AkkaHostingSpec.cs
@@ -6,7 +6,6 @@
 
 using System.Linq;
 using Akka.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -21,9 +20,8 @@ namespace Akka.Coordination.Azure.Tests
             
             builder.WithAzureLease("");
             
-            builder.Configuration.HasValue.Should().BeTrue();
-            builder.Configuration.Value.GetConfig("akka.coordination.lease.azure")
-                .Should().NotBeNull();
+            Assert.True(builder.Configuration.HasValue);
+            Assert.NotNull(builder.Configuration.Value.GetConfig("akka.coordination.lease.azure"));
         }
         
         [Fact(DisplayName = "Hosting Action<Options> extension should add default hocon settings")]
@@ -36,10 +34,10 @@ namespace Akka.Coordination.Azure.Tests
                 lease.ContainerName = "underTest";
             });
                         
-            builder.Configuration.HasValue.Should().BeTrue();
+            Assert.True(builder.Configuration.HasValue);
             var config = builder.Configuration.Value.GetConfig("akka.coordination.lease.azure");
-            config.Should().NotBeNull();
-            config.GetString("container-name").Should().Be("underTest");
+            Assert.NotNull(config);
+            Assert.Equal("underTest", config.GetString("container-name"));
         }
         
         [Fact(DisplayName = "Hosting options extension should add default hocon settings")]
@@ -52,10 +50,10 @@ namespace Akka.Coordination.Azure.Tests
                 ContainerName = "underTest"
             });
                         
-            builder.Configuration.HasValue.Should().BeTrue();
+            Assert.True(builder.Configuration.HasValue);
             var config = builder.Configuration.Value.GetConfig("akka.coordination.lease.azure");
-            config.Should().NotBeNull();
-            config.GetString("container-name").Should().Be("underTest");
+            Assert.NotNull(config);
+            Assert.Equal("underTest", config.GetString("container-name"));
         }
     }
 }

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureApiSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureApiSpec.cs
@@ -11,8 +11,6 @@ using Akka.Configuration;
 using Akka.Coordination.Azure.Internal;
 using Akka.Discovery.Azure.Tests;
 using Akka.Util;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Akka.Coordination.Azure.Tests
@@ -37,7 +35,7 @@ namespace Akka.Coordination.Azure.Tests
             _connectionString = _fixture.ConnectionString;
             _settings = AzureLeaseSettings.Empty
                 .WithConnectionString(_connectionString)
-                .WithApiServiceRequestTimeout(800.Milliseconds());
+                .WithApiServiceRequestTimeout(TimeSpan.FromMilliseconds(800));
                 
             _underTest = new AzureApiImpl(Sys, _settings);
         }
@@ -55,10 +53,11 @@ namespace Akka.Coordination.Azure.Tests
         [Fact(DisplayName = "Azure lease resource should be able to be created")]
         public async Task AbleToCreateLeaseResource()
         {
-            (await _underTest.RemoveLease(LeaseName)).Should().Be(Done.Instance);
+            Assert.Equal(Done.Instance, (await _underTest.RemoveLease(LeaseName)));
             var leaseRecord = await _underTest.ReadOrCreateLeaseResource(LeaseName);
-            leaseRecord.Owner.Should().BeNull();
-            leaseRecord.Version.Should().NotBeNull();
+            Assert.Null(leaseRecord.Owner);
+            // Version is a non-nullable ETag struct; FA's boxed NotBeNull() was vacuously true — preserved via boxing
+            Assert.NotNull((object)leaseRecord.Version);
         }
 
         [Fact(DisplayName = "Azure lease resource should update a lease successfully")]
@@ -69,11 +68,11 @@ namespace Akka.Coordination.Azure.Tests
             var created = await _underTest.ReadOrCreateLeaseResource(LeaseName);
             
             var response = await _underTest.UpdateLeaseResource(LeaseName, owner, created.Version, DateTimeOffset.UtcNow);
-            response.Should().BeOfType<Right<LeaseResource, LeaseResource>>();
+            Assert.IsType<Right<LeaseResource, LeaseResource>>(response);
             var right = ((Right<LeaseResource, LeaseResource>)response).Value;
-            right.Owner.Should().Be(owner);
-            right.Version.Should().NotBe(created.Version);
-            right.Time.Should().BeAfter(created.Time);
+            Assert.Equal(owner, right.Owner);
+            Assert.NotEqual(created.Version, right.Version);
+            Assert.True(right.Time > created.Time);
         }
 
         [Fact(DisplayName = "Azure lease resource should update a lease conflict")]
@@ -87,11 +86,11 @@ namespace Akka.Coordination.Azure.Tests
             var updated = ((Right<LeaseResource, LeaseResource>)updateResponse).Value;
 
             var response = await _underTest.UpdateLeaseResource(LeaseName, owner, created.Version, DateTimeOffset.UtcNow);
-            response.Should().BeOfType<Left<LeaseResource, LeaseResource>>();
+            Assert.IsType<Left<LeaseResource, LeaseResource>>(response);
             var left = ((Left<LeaseResource, LeaseResource>)response).Value;
-            left.Owner.Should().Be(conflictOwner);
-            left.Version.Should().Be(updated.Version);
-            left.Time.Should().Be(updated.Time);
+            Assert.Equal(conflictOwner, left.Owner);
+            Assert.Equal(updated.Version, left.Version);
+            Assert.Equal(updated.Time, left.Time);
 
         }
 
@@ -101,7 +100,7 @@ namespace Akka.Coordination.Azure.Tests
             var created = await _underTest.ReadOrCreateLeaseResource(LeaseName);
 
             var response = await _underTest.RemoveLease(LeaseName);
-            response.Should().Be(Done.Instance);
+            Assert.Equal(Done.Instance, response);
         }
 
         // Regression test for https://github.com/akkadotnet/Akka.Management/issues/3397
@@ -113,15 +112,16 @@ namespace Akka.Coordination.Azure.Tests
         {
             // First instance creates the container and lease blob
             var firstLease = await _underTest.ReadOrCreateLeaseResource(LeaseName);
-            firstLease.Owner.Should().BeNull();
+            Assert.Null(firstLease.Owner);
 
             // Second instance has _initialized = false, so ContainerClient() will call
             // CreateAsync() and receive a 409 ContainerAlreadyExists from Azure.
             // Before the fix, this threw LeaseException and crashed the lease actor.
             var secondInstance = new AzureApiImpl(Sys, _settings);
             var secondLease = await secondInstance.ReadOrCreateLeaseResource(LeaseName);
-            secondLease.Owner.Should().BeNull();
-            secondLease.Version.Should().NotBeNull();
+            Assert.Null(secondLease.Owner);
+            // Version is a non-nullable ETag struct; FA's boxed NotBeNull() was vacuously true — preserved via boxing
+            Assert.NotNull((object)secondLease.Version);
         }
 
         // Verifies that multiple independent AzureApiImpl instances can operate concurrently
@@ -143,15 +143,15 @@ namespace Akka.Coordination.Azure.Tests
             var lease2 = await instance2.ReadOrCreateLeaseResource(leaseName2);
 
             // Both should succeed — one creates the container, the other gets 409 and handles it
-            lease1.Owner.Should().BeNull();
-            lease2.Owner.Should().BeNull();
+            Assert.Null(lease1.Owner);
+            Assert.Null(lease2.Owner);
 
             // Both instances should be able to update their respective leases
             var update1 = await instance1.UpdateLeaseResource(leaseName1, owner1, lease1.Version, DateTimeOffset.UtcNow);
-            update1.Should().BeOfType<Right<LeaseResource, LeaseResource>>();
+            Assert.IsType<Right<LeaseResource, LeaseResource>>(update1);
 
             var update2 = await instance2.UpdateLeaseResource(leaseName2, owner2, lease2.Version, DateTimeOffset.UtcNow);
-            update2.Should().BeOfType<Right<LeaseResource, LeaseResource>>();
+            Assert.IsType<Right<LeaseResource, LeaseResource>>(update2);
         }
     }
 }

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureLeaseSettingsSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureLeaseSettingsSpec.cs
@@ -9,7 +9,6 @@ using System;
 using Akka.Configuration;
 using Azure.Identity;
 using Azure.Storage.Blobs;
-using FluentAssertions;
 using Humanizer;
 using Xunit;
 
@@ -31,41 +30,43 @@ namespace Akka.Coordination.Azure.Tests
         [Fact(DisplayName = "default request-timeout should be 2/5 of the lease-operation-timeout")]
         public void RequestTimeoutIsTwoFifthOfLeaseOperationTimeout()
         {
-            Conf($"{AzureLease.ConfigPath}.lease-operation-timeout=10s")
-                .ApiServiceRequestTimeout.Should().Be(TimeSpan.FromSeconds(4));
+            Assert.Equal(TimeSpan.FromSeconds(4),
+                Conf($"{AzureLease.ConfigPath}.lease-operation-timeout=10s")
+                    .ApiServiceRequestTimeout);
         }
 
         [Fact(DisplayName = "Azure settings should allow api server request timeout override")]
         public void ShouldAllowServerRequestTimeoutOverride()
         {
-            Conf(@$"
+            Assert.Equal(TimeSpan.FromSeconds(4),
+                Conf(@$"
             {AzureLease.ConfigPath}.lease-operation-timeout=5s
-            {AzureLease.ConfigPath}.api-service-request-timeout=4s").ApiServiceRequestTimeout
-                .Should().Be(TimeSpan.FromSeconds(4));
+            {AzureLease.ConfigPath}.api-service-request-timeout=4s").ApiServiceRequestTimeout);
         }
 
         [Fact(DisplayName =
             "Azure settings should not allow server request timeout greater than operation timeout")]
         public void InvalidServerRequestTimeout()
         {
-            Assert.Throws<ConfigurationException>(() =>
+            var ex = Assert.Throws<ConfigurationException>(() =>
             {
                 Conf(@$"
                     {AzureLease.ConfigPath}.lease-operation-timeout=5s
                     {AzureLease.ConfigPath}.api-service-request-timeout=6s");
-            }).Message.Should().Be("'api-service-request-timeout can not be less than 'akka.coordination.azure.lease-operation-timeout'");
+            });
+            Assert.Equal("'api-service-request-timeout can not be less than 'akka.coordination.azure.lease-operation-timeout'", ex.Message);
         }
 
         [Fact(DisplayName = "AzureLeaseSettings should contain default values")]
         public void DefaultAzureLeaseSettingsTest()
         {
             var settings = Conf(null);
-            settings.ConnectionString.Should().Be("");
-            settings.ContainerName.Should().Be("akka-coordination-lease");
-            settings.ApiServiceRequestTimeout.Should().Be(6.Seconds());
-            settings.ServiceEndpoint.Should().BeNull();
-            settings.AzureCredential.Should().BeNull();
-            settings.BlobClientOptions.Should().BeNull();
+            Assert.Equal("", settings.ConnectionString);
+            Assert.Equal("akka-coordination-lease", settings.ContainerName);
+            Assert.Equal(6.Seconds(), settings.ApiServiceRequestTimeout);
+            Assert.Null(settings.ServiceEndpoint);
+            Assert.Null(settings.AzureCredential);
+            Assert.Null(settings.BlobClientOptions);
         }
 
         [Fact(DisplayName = "Empty AzureLeaseSettings should contain default values")]
@@ -73,12 +74,12 @@ namespace Akka.Coordination.Azure.Tests
         {
             var settings = Conf(null);
             var empty = AzureLeaseSettings.Empty;
-            empty.ConnectionString.Should().Be(settings.ConnectionString);
-            empty.ContainerName.Should().Be(settings.ContainerName);
-            empty.ApiServiceRequestTimeout.Should().Be(settings.ApiServiceRequestTimeout);
-            empty.ServiceEndpoint.Should().Be(settings.ServiceEndpoint);
-            empty.AzureCredential.Should().Be(settings.AzureCredential); 
-            empty.BlobClientOptions.Should().Be(settings.BlobClientOptions);
+            Assert.Equal(settings.ConnectionString, empty.ConnectionString);
+            Assert.Equal(settings.ContainerName, empty.ContainerName);
+            Assert.Equal(settings.ApiServiceRequestTimeout, empty.ApiServiceRequestTimeout);
+            Assert.Equal(settings.ServiceEndpoint, empty.ServiceEndpoint);
+            Assert.Equal(settings.AzureCredential, empty.AzureCredential);
+            Assert.Equal(settings.BlobClientOptions, empty.BlobClientOptions);
         }
 
         [Fact(DisplayName = "AzureLeaseSettings overrides should work")]
@@ -95,12 +96,12 @@ namespace Akka.Coordination.Azure.Tests
                 .WithAzureCredential(cred, uri)
                 .WithBlobClientOption(opt);
             
-            settings.ConnectionString.Should().Be("a");
-            settings.ContainerName.Should().Be("b");
-            settings.ApiServiceRequestTimeout.Should().Be(11.Seconds());
-            settings.ServiceEndpoint.Should().Be(uri);
-            settings.AzureCredential.Should().Be(cred); 
-            settings.BlobClientOptions.Should().Be(opt);
+            Assert.Equal("a", settings.ConnectionString);
+            Assert.Equal("b", settings.ContainerName);
+            Assert.Equal(11.Seconds(), settings.ApiServiceRequestTimeout);
+            Assert.Equal(uri, settings.ServiceEndpoint);
+            Assert.Equal(cred, settings.AzureCredential);
+            Assert.Equal(opt, settings.BlobClientOptions);
         }
         
         [Fact(DisplayName = "AzureLeaseSetup overrides should work")]
@@ -121,12 +122,12 @@ namespace Akka.Coordination.Azure.Tests
             };
             
             var settings = setup.Apply(AzureLeaseSettings.Empty, null!);
-            settings.ConnectionString.Should().Be("a");
-            settings.ContainerName.Should().Be("b");
-            settings.ApiServiceRequestTimeout.Should().Be(11.Seconds());
-            settings.ServiceEndpoint.Should().Be(uri);
-            settings.AzureCredential.Should().Be(cred); 
-            settings.BlobClientOptions.Should().Be(opt);
+            Assert.Equal("a", settings.ConnectionString);
+            Assert.Equal("b", settings.ContainerName);
+            Assert.Equal(11.Seconds(), settings.ApiServiceRequestTimeout);
+            Assert.Equal(uri, settings.ServiceEndpoint);
+            Assert.Equal(cred, settings.AzureCredential);
+            Assert.Equal(opt, settings.BlobClientOptions);
         }
     }
 }

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureLeaseSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureLeaseSpec.cs
@@ -10,8 +10,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Discovery.Azure.Tests;
 using Xunit;
-using FluentAssertions;
-using static FluentAssertions.FluentActions;
 
 namespace Akka.Coordination.Azure.Tests;
 
@@ -43,11 +41,12 @@ public class AzureLeaseSpec: TestKit.Xunit.TestKit, IAsyncLifetime
     [Fact(DisplayName = "Releasing non-acquired lease should not throw an exception")]
     public async Task NonAcquiredReleaseTest()
     {
-        await Awaiting(async () =>
+        var ex = await Record.ExceptionAsync(async () =>
         {
             var result = await _lease.Release();
-            result.Should().BeTrue();
-        }).Should().NotThrowAsync();
+            Assert.True(result);
+        });
+        Assert.Null(ex);
     }
 
     [Fact(DisplayName = "Acquire should be idempotent and returns the same task while acquire is in progress")]
@@ -57,8 +56,9 @@ public class AzureLeaseSpec: TestKit.Xunit.TestKit, IAsyncLifetime
         var task2 = _lease.Acquire();
         var task3 = _lease.Acquire();
 
-        task1.Should().Be(task2).And.Be(task3);
-        (await task1).Should().BeTrue();
+        Assert.Equal(task2, task1);
+        Assert.Equal(task3, task1);
+        Assert.True((await task1));
     }
 
     public async ValueTask InitializeAsync()

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/ClusterSingletonSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/ClusterSingletonSpec.cs
@@ -12,8 +12,6 @@ using Akka.Discovery.Azure.Tests;
 using Akka.Event;
 using Akka.Hosting;
 using Akka.Remote.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Akka.Coordination.Azure.Tests
@@ -80,10 +78,10 @@ namespace Akka.Coordination.Azure.Tests
             {
                 tcs.SetResult(Done.Instance);
             });
-            await tcs.Task.WaitAsync(30.Seconds());
+            await tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
             
             var singleton = ActorRegistry.Get<SingletonKey>();
-            (await singleton.Ask("test")).Should().Be("test");
+            Assert.Equal("test", (await singleton.Ask("test")));
 
             await probe.FishForMessageAsync(evt => evt is Info i && (i.Message?.ToString()?.StartsWith("Acquire lease result") ?? false));
         }

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -15,7 +15,6 @@ using Akka.Configuration;
 using Akka.TestKit;
 using Akka.Util;
 using Azure;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Coordination.Azure.Tests
@@ -57,7 +56,7 @@ namespace Akka.Coordination.Azure.Tests
                 UnderTest.Tell(new LeaseActor.Acquire(), Sender);
                 LeaseProbe.ExpectMsg(LeaseName);
                 LeaseProbe.Reply(new Status.Failure(failure));
-                SenderProbe.ExpectMsg<Status.Failure>().Cause.Should().Be(failure);
+                Assert.Equal(failure, SenderProbe.ExpectMsg<Status.Failure>().Cause);
             });
         }
 
@@ -100,9 +99,8 @@ namespace Akka.Coordination.Azure.Tests
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
             
                 // not granted
-                SenderProbe.ExpectMsg<Status.Failure>().Cause.Message
-                    .Should().StartWith("API server took too long to respond");
-                Granted.Value.Should().BeFalse();
+                Assert.StartsWith("API server took too long to respond", SenderProbe.ExpectMsg<Status.Failure>().Cause.Message);
+                Assert.False(Granted.Value);
             
                 // should allow retry
                 AcquireLease();
@@ -201,7 +199,7 @@ namespace Akka.Coordination.Azure.Tests
                 UpdateProbe.ExpectMsg(("", CurrentVersion));
                 IncrementVersion();
                 UpdateProbe.Reply(new Status.Failure(failure));
-                SenderProbe.ExpectMsg<Status.Failure>().Cause.Should().Be(failure);
+                Assert.Equal(failure, SenderProbe.ExpectMsg<Status.Failure>().Cause);
             });
         }
 
@@ -210,11 +208,11 @@ namespace Akka.Coordination.Azure.Tests
         {
             RunTest(() =>
             {
-                Granted.Value.Should().BeFalse();
+                Assert.False(Granted.Value);
                 AcquireLease();
                 AwaitAssert(() =>
                 {
-                    Granted.Value.Should().BeTrue();
+                    Assert.True(Granted.Value);
                 });
             });
         }
@@ -224,16 +222,16 @@ namespace Akka.Coordination.Azure.Tests
         {
             RunTest(() =>
             {
-                Granted.Value.Should().BeFalse();
+                Assert.False(Granted.Value);
                 AcquireLease();
                 AwaitAssert(() =>
                 {
-                    Granted.Value.Should().BeTrue();
+                    Assert.True(Granted.Value);
                 });
                 ReleaseLease();
                 AwaitAssert(() =>
                 {
-                    Granted.Value.Should().BeFalse();
+                    Assert.False(Granted.Value);
                 });
             });
         }
@@ -282,7 +280,7 @@ namespace Akka.Coordination.Azure.Tests
             {
                 AcquireLease();
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
                 IncrementVersion();
@@ -291,7 +289,7 @@ namespace Akka.Coordination.Azure.Tests
                         new LeaseResource("I stole your lock", CurrentVersion, CurrentTime)));
                 AwaitAssert(() =>
                 {
-                    Granted.Value.Should().BeFalse();
+                    Assert.False(Granted.Value);
                 });
             });
         }
@@ -307,7 +305,7 @@ namespace Akka.Coordination.Azure.Tests
                     callbackCalled = true;
                 });
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
                 IncrementVersion();
@@ -316,7 +314,7 @@ namespace Akka.Coordination.Azure.Tests
                         new LeaseResource("I stole your lock", CurrentVersion, CurrentTime)));
                 AwaitAssert(() =>
                 {
-                    callbackCalled.Should().BeTrue();
+                    Assert.True(callbackCalled);
                 });
             });
         }
@@ -328,11 +326,11 @@ namespace Akka.Coordination.Azure.Tests
             {
                 AcquireLease();
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // With retry logic, multiple failures are needed to exhaust the TTL window
                 HeartBeatFailure();
-                Granted.Value.Should().BeFalse();
+                Assert.False(Granted.Value);
             });
         }
 
@@ -348,13 +346,13 @@ namespace Akka.Coordination.Azure.Tests
                     callbackCalled = e;
                 });
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // With retry logic, drive failures until TTL expires and callback fires
                 DriveHeartBeatFailures(failure);
                 AwaitAssert(() =>
                 {
-                    callbackCalled.Should().Be(failure);
+                    Assert.Equal(failure, callbackCalled);
                 });
             });
         }
@@ -366,14 +364,14 @@ namespace Akka.Coordination.Azure.Tests
             {
                 AcquireLease();
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // First heartbeat fails transiently
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
                 UpdateProbe.Reply(new Status.Failure(new LeaseException("Transient failure")));
 
                 // Should still be granted — actor retries within TTL window
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Retry heartbeat succeeds
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
@@ -383,7 +381,7 @@ namespace Akka.Coordination.Azure.Tests
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
 
                 // Should still be granted and heartbeating normally
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Normal heartbeat continues
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
@@ -397,14 +395,14 @@ namespace Akka.Coordination.Azure.Tests
             {
                 AcquireLease();
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Multiple consecutive failures, all within TTL window
                 for (var i = 0; i < 3; i++)
                 {
                     UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
                     UpdateProbe.Reply(new Status.Failure(new LeaseException($"Transient failure {i}")));
-                    Granted.Value.Should().BeTrue();
+                    Assert.True(Granted.Value);
                 }
 
                 // Recovery: next heartbeat succeeds
@@ -415,7 +413,7 @@ namespace Akka.Coordination.Azure.Tests
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
 
                 // Lease is still held
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
             });
         }
 
@@ -430,15 +428,15 @@ namespace Akka.Coordination.Azure.Tests
                     callbackCalled = true;
                 });
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Single transient failure within TTL
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
                 UpdateProbe.Reply(new Status.Failure(new LeaseException("Transient failure")));
 
                 // Callback should NOT be called — TTL still valid
-                callbackCalled.Should().BeFalse();
-                Granted.Value.Should().BeTrue();
+                Assert.False(callbackCalled);
+                Assert.True(Granted.Value);
 
                 // Recovery
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
@@ -447,7 +445,7 @@ namespace Akka.Coordination.Azure.Tests
                     new Right<LeaseResource, LeaseResource>(
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
 
-                callbackCalled.Should().BeFalse();
+                Assert.False(callbackCalled);
             });
         }
 
@@ -468,7 +466,7 @@ namespace Akka.Coordination.Azure.Tests
             {
                 await AcquireLeaseAsync();
                 await ExpectHeartBeatAsync();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Step 1: Heartbeat fires, but PUT times out on client (server succeeded and bumped version)
                 await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
@@ -476,7 +474,7 @@ namespace Akka.Coordination.Azure.Tests
                     new LeaseException("API server request timed out")));
 
                 // Should still be granted — within TTL retry window (#3404 fix)
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Step 2: Actor retries heartbeat with stale version (server already moved to next version)
                 await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
@@ -490,7 +488,7 @@ namespace Akka.Coordination.Azure.Tests
 
                 // BUG: Actor currently releases the lease here (lines 400-404)
                 // EXPECTED: Actor should recognize it's still the owner and stay Granted
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Step 4: Heartbeat should continue normally with the updated version
                 await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
@@ -499,7 +497,7 @@ namespace Akka.Coordination.Azure.Tests
                     new Right<LeaseResource, LeaseResource>(
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
 
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
             });
         }
 
@@ -519,7 +517,7 @@ namespace Akka.Coordination.Azure.Tests
                     callbackCalled = true;
                 });
                 await ExpectHeartBeatAsync();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Heartbeat times out on client
                 await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
@@ -534,8 +532,8 @@ namespace Akka.Coordination.Azure.Tests
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
 
                 // Callback should NOT be called — we still own the lease
-                callbackCalled.Should().BeFalse();
-                Granted.Value.Should().BeTrue();
+                Assert.False(callbackCalled);
+                Assert.True(Granted.Value);
             });
         }
 
@@ -551,7 +549,7 @@ namespace Akka.Coordination.Azure.Tests
             {
                 await AcquireLeaseAsync();
                 await ExpectHeartBeatAsync();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Heartbeat times out on client
                 await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
@@ -568,7 +566,7 @@ namespace Akka.Coordination.Azure.Tests
                 // Should release — this is a genuine conflict
                 await AwaitAssertAsync(() =>
                 {
-                    Granted.Value.Should().BeFalse();
+                    Assert.False(Granted.Value);
                 });
             });
         }
@@ -664,7 +662,7 @@ namespace Akka.Coordination.Azure.Tests
                 await SenderProbe.ExpectMsgAsync<LeaseActor.LeaseTaken>();
 
                 // Step 7: localGranted should be false — the lease was never actually acquired
-                Granted.Value.Should().BeFalse();
+                Assert.False(Granted.Value);
             });
         }
 
@@ -707,7 +705,7 @@ namespace Akka.Coordination.Azure.Tests
                 // Step 7: localGranted should be TRUE — the lease was properly acquired
                 await AwaitAssertAsync(() =>
                 {
-                    Granted.Value.Should().BeTrue();
+                    Assert.True(Granted.Value);
                 });
             });
         }
@@ -1053,7 +1051,7 @@ namespace Akka.Coordination.Azure.Tests
             LeaseProbe.ExpectMsg(LeaseName);
             LeaseProbe.Reply(new Status.Failure(failure));
             var receivedFailure = SenderProbe.ExpectMsg<Status.Failure>();
-            receivedFailure.Cause.Should().Be(failure);
+            Assert.Equal(failure, receivedFailure.Cause);
         }
 
         protected void HeartBeatConflict()
@@ -1065,7 +1063,7 @@ namespace Akka.Coordination.Azure.Tests
                     new LeaseResource("I stole your lock", CurrentVersion, CurrentTime)));
             AwaitAssert(() =>
             {
-                Granted.Value.Should().BeFalse();
+                Assert.False(Granted.Value);
             });
         }
 
@@ -1090,7 +1088,7 @@ namespace Akka.Coordination.Azure.Tests
                 UpdateProbe.Reply(new Status.Failure(failure));
                 Task.Delay(10).Wait();
             }
-            AwaitAssert(() => Granted.Value.Should().BeFalse());
+            AwaitAssert(() => Assert.False(Granted.Value));
         }
     }
 }

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/AkkaHostingSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/AkkaHostingSpec.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Hosting;
-using FluentAssertions;
 using Humanizer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -29,25 +28,25 @@ namespace Akka.Coordination.KubernetesApi.Tests
             
             builder.WithKubernetesLease();
             
-            builder.Configuration.HasValue.Should().BeTrue();
-            builder.Configuration.Value.GetConfig(KubernetesLease.ConfigPath).Should().NotBeNull();
+            Assert.True(builder.Configuration.HasValue);
+            Assert.NotNull(builder.Configuration.Value.GetConfig(KubernetesLease.ConfigPath));
             
             var leaseSettings = GetSettings(builder);
             var settings = KubernetesSettings.Create(leaseSettings);
-            settings.ApiCaPath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt");
-            settings.ApiTokenPath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/token");
-            settings.ApiServiceHostEnvName.Should().Be("KUBERNETES_SERVICE_HOST");
-            settings.ApiServicePortEnvName.Should().Be("KUBERNETES_SERVICE_PORT");
-            settings.Namespace.Should().BeNull(); 
-            settings.NamespacePath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); 
-            settings.ApiServiceRequestTimeout.Should().Be(2.Seconds());
-            settings.Secure.Should().BeTrue(); 
-            settings.BodyReadTimeout.Should().Be(1.Seconds()); 
+            Assert.Equal("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt", settings.ApiCaPath);
+            Assert.Equal("/var/run/secrets/kubernetes.io/serviceaccount/token", settings.ApiTokenPath);
+            Assert.Equal("KUBERNETES_SERVICE_HOST", settings.ApiServiceHostEnvName);
+            Assert.Equal("KUBERNETES_SERVICE_PORT", settings.ApiServicePortEnvName);
+            Assert.Null(settings.Namespace);
+            Assert.Equal("/var/run/secrets/kubernetes.io/serviceaccount/namespace", settings.NamespacePath);
+            Assert.Equal(2.Seconds(), settings.ApiServiceRequestTimeout);
+            Assert.True(settings.Secure);
+            Assert.Equal(1.Seconds(), settings.BodyReadTimeout);
 
             var timeSettings = TimeoutSettings.Create(leaseSettings.LeaseConfig);
-            timeSettings.HeartbeatInterval.Should().Be(12.Seconds());
-            timeSettings.HeartbeatTimeout.Should().Be(120.Seconds());
-            timeSettings.OperationTimeout.Should().Be(5.Seconds());
+            Assert.Equal(12.Seconds(), timeSettings.HeartbeatInterval);
+            Assert.Equal(120.Seconds(), timeSettings.HeartbeatTimeout);
+            Assert.Equal(5.Seconds(), timeSettings.OperationTimeout);
         }
         
         [Fact(DisplayName = "Hosting Action<KubernetesLeaseOption> extension should override hocon settings")]
@@ -70,25 +69,25 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 lease.LeaseOperationTimeout = 4.Seconds();
             });
                         
-            builder.Configuration.HasValue.Should().BeTrue();
-            builder.Configuration.Value.GetConfig(KubernetesLease.ConfigPath).Should().NotBeNull();
+            Assert.True(builder.Configuration.HasValue);
+            Assert.NotNull(builder.Configuration.Value.GetConfig(KubernetesLease.ConfigPath));
             
             var leaseSettings = GetSettings(builder);
             var settings = KubernetesSettings.Create(leaseSettings);
-            settings.ApiCaPath.Should().Be("a");
-            settings.ApiTokenPath.Should().Be("b");
-            settings.ApiServiceHostEnvName.Should().Be("c");
-            settings.ApiServicePortEnvName.Should().Be("d");
-            settings.Namespace.Should().Be("e"); 
-            settings.NamespacePath.Should().Be("f"); 
-            settings.ApiServiceRequestTimeout.Should().Be(3.Seconds());
-            settings.Secure.Should().BeFalse(); 
-            settings.BodyReadTimeout.Should().Be(1.5.Seconds());
+            Assert.Equal("a", settings.ApiCaPath);
+            Assert.Equal("b", settings.ApiTokenPath);
+            Assert.Equal("c", settings.ApiServiceHostEnvName);
+            Assert.Equal("d", settings.ApiServicePortEnvName);
+            Assert.Equal("e", settings.Namespace);
+            Assert.Equal("f", settings.NamespacePath);
+            Assert.Equal(3.Seconds(), settings.ApiServiceRequestTimeout);
+            Assert.False(settings.Secure);
+            Assert.Equal(1.5.Seconds(), settings.BodyReadTimeout);
 
             var timeSettings = TimeoutSettings.Create(leaseSettings.LeaseConfig);
-            timeSettings.HeartbeatInterval.Should().Be(4.Seconds());
-            timeSettings.HeartbeatTimeout.Should().Be(10.Seconds());
-            timeSettings.OperationTimeout.Should().Be(4.Seconds());
+            Assert.Equal(4.Seconds(), timeSettings.HeartbeatInterval);
+            Assert.Equal(10.Seconds(), timeSettings.HeartbeatTimeout);
+            Assert.Equal(4.Seconds(), timeSettings.OperationTimeout);
         }
         
         [Fact(DisplayName = "Hosting Setup extension should override hocon settings")]
@@ -111,25 +110,25 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 LeaseOperationTimeout = 4.Seconds()
             });
                         
-            builder.Configuration.HasValue.Should().BeTrue();
-            builder.Configuration.Value.GetConfig(KubernetesLease.ConfigPath).Should().NotBeNull();
+            Assert.True(builder.Configuration.HasValue);
+            Assert.NotNull(builder.Configuration.Value.GetConfig(KubernetesLease.ConfigPath));
             
             var leaseSettings = GetSettings(builder);
             var settings = KubernetesSettings.Create(leaseSettings);
-            settings.ApiCaPath.Should().Be("a");
-            settings.ApiTokenPath.Should().Be("b");
-            settings.ApiServiceHostEnvName.Should().Be("c");
-            settings.ApiServicePortEnvName.Should().Be("d");
-            settings.Namespace.Should().Be("e"); 
-            settings.NamespacePath.Should().Be("f"); 
-            settings.ApiServiceRequestTimeout.Should().Be(3.Seconds());
-            settings.Secure.Should().BeFalse(); 
-            settings.BodyReadTimeout.Should().Be(1.5.Seconds());
+            Assert.Equal("a", settings.ApiCaPath);
+            Assert.Equal("b", settings.ApiTokenPath);
+            Assert.Equal("c", settings.ApiServiceHostEnvName);
+            Assert.Equal("d", settings.ApiServicePortEnvName);
+            Assert.Equal("e", settings.Namespace);
+            Assert.Equal("f", settings.NamespacePath);
+            Assert.Equal(3.Seconds(), settings.ApiServiceRequestTimeout);
+            Assert.False(settings.Secure);
+            Assert.Equal(1.5.Seconds(), settings.BodyReadTimeout);
 
             var timeSettings = TimeoutSettings.Create(leaseSettings.LeaseConfig);
-            timeSettings.HeartbeatInterval.Should().Be(4.Seconds());
-            timeSettings.HeartbeatTimeout.Should().Be(10.Seconds());
-            timeSettings.OperationTimeout.Should().Be(4.Seconds());
+            Assert.Equal(4.Seconds(), timeSettings.HeartbeatInterval);
+            Assert.Equal(10.Seconds(), timeSettings.HeartbeatTimeout);
+            Assert.Equal(4.Seconds(), timeSettings.OperationTimeout);
         }
 
         private static LeaseSettings GetSettings(AkkaConfigurationBuilder builder)

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/KubernetesApiSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/KubernetesApiSpec.cs
@@ -14,7 +14,6 @@ using Akka.Coordination.KubernetesApi.Internal;
 using Akka.Coordination.KubernetesApi.Models;
 using Akka.Event;
 using Akka.Util;
-using FluentAssertions;
 using k8s.Models;
 using WireMock;
 using WireMock.RequestBuilders;
@@ -23,7 +22,6 @@ using WireMock.Server;
 using WireMock.Types;
 using WireMock.Util;
 using Xunit;
-using static FluentAssertions.FluentActions;
 
 #if !NET6_0_OR_GREATER
 using Microsoft.Rest.Serialization;
@@ -116,11 +114,11 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         .WithHeader("Content-Type", "application/json")
                         .WithBodyAsJson(json));
 
-                (await _underTest.RemoveLease(LeaseName)).Should().Be(Done.Instance);
+                Assert.Equal(Done.Instance, (await _underTest.RemoveLease(LeaseName)));
                 var leaseRecord = await _underTest.ReadOrCreateLeaseResource(LeaseName);
-                leaseRecord.Owner.Should().Be(null);
-                leaseRecord.Version.Should().NotBeNullOrEmpty();
-                leaseRecord.Version.Should().Be(version);
+                Assert.Null(leaseRecord.Owner);
+                Assert.False(string.IsNullOrEmpty(leaseRecord.Version));
+                Assert.Equal(version, leaseRecord.Version);
             }
             finally
             {
@@ -180,11 +178,11 @@ namespace Akka.Coordination.KubernetesApi.Tests
                             };
                         }));
                 var response = await _underTest.UpdateLeaseResource(LeaseName, owner, "2", timestamp);
-                response.Should().BeOfType<Right<LeaseResource, LeaseResource>>();
+                Assert.IsType<Right<LeaseResource, LeaseResource>>(response);
                 var right = ((Right<LeaseResource, LeaseResource>)response).Value;
-                right.Owner.Should().Be(owner);
-                right.Version.Should().Be("3");
-                right.Time.Should().Be(timestamp);
+                Assert.Equal(owner, right.Owner);
+                Assert.Equal("3", right.Version);
+                Assert.Equal(timestamp, right.Time);
             }
             finally
             {
@@ -232,11 +230,11 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         .WithBodyAsJson(json));
 
                 var response = await _underTest.UpdateLeaseResource(LeaseName, owner, version, timestamp);
-                response.Should().BeOfType<Left<LeaseResource, LeaseResource>>();
+                Assert.IsType<Left<LeaseResource, LeaseResource>>(response);
                 var left = ((Left<LeaseResource, LeaseResource>)response).Value;
-                left.Owner.Should().Be(conflictOwner);
-                left.Version.Should().Be(updatedVersion);
-                left.Time.Should().Be(timestamp);
+                Assert.Equal(conflictOwner, left.Owner);
+                Assert.Equal(updatedVersion, left.Version);
+                Assert.Equal(timestamp, left.Time);
             }
             finally
             {
@@ -256,7 +254,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         .WithStatusCode(HttpStatusCode.OK));
 
                 var response = await _underTest.RemoveLease(LeaseName);
-                response.Should().Be(Done.Instance);
+                Assert.Equal(Done.Instance, response);
             }
             finally
             {
@@ -296,9 +294,9 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         .WithStatusCode(HttpStatusCode.OK)
                         .WithHeader("Content-Type", "application/json")
                         .WithBodyAsJson(json));
-                await Awaiting(() => _underTest.ReadOrCreateLeaseResource(LeaseName)).Should()
-                    .ThrowAsync<LeaseTimeoutException>()
-                    .WithMessage($"Timed out reading lease {LeaseName}.*");
+                var ex = await Assert.ThrowsAsync<LeaseTimeoutException>(() => _underTest.ReadOrCreateLeaseResource(LeaseName));
+                // converted from WithMessage glob "Timed out reading lease {LeaseName}.*"
+                Assert.StartsWith($"Timed out reading lease {LeaseName}.", ex.Message);
             }
             finally
             {
@@ -340,9 +338,9 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         .WithStatusCode(HttpStatusCode.OK)
                         .WithHeader("Content-Type", "application/json")
                         .WithBodyAsJson(json));
-                await Awaiting(() => _underTest.ReadOrCreateLeaseResource(LeaseName)).Should()
-                    .ThrowAsync<LeaseTimeoutException>()
-                    .WithMessage($"Timed out creating lease {LeaseName}.*");
+                var ex = await Assert.ThrowsAsync<LeaseTimeoutException>(() => _underTest.ReadOrCreateLeaseResource(LeaseName));
+                // converted from WithMessage glob "Timed out creating lease {LeaseName}.*"
+                Assert.StartsWith($"Timed out creating lease {LeaseName}.", ex.Message);
             }
             finally
             {
@@ -382,9 +380,9 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         .WithStatusCode(HttpStatusCode.OK)
                         .WithHeader("Content-Type", "application/json")
                         .WithBodyAsJson(json));
-                await Awaiting(() => _underTest.UpdateLeaseResource(LeaseName, owner, version)).Should()
-                    .ThrowAsync<LeaseTimeoutException>()
-                    .WithMessage($"Timed out updating lease {LeaseName} to owner {owner}. It is not known if the update happened.*");
+                var ex = await Assert.ThrowsAsync<LeaseTimeoutException>(() => _underTest.UpdateLeaseResource(LeaseName, owner, version));
+                // converted from WithMessage glob "Timed out updating lease {LeaseName} to owner {owner}. It is not known if the update happened.*"
+                Assert.StartsWith($"Timed out updating lease {LeaseName} to owner {owner}. It is not known if the update happened.", ex.Message);
             }
             finally
             {
@@ -402,9 +400,9 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         .WithDelay((int)(_settings.ApiServiceRequestTimeout.TotalMilliseconds * 2)) // time out
                         .WithStatusCode(HttpStatusCode.OK));
 
-                await Awaiting(() => _underTest.RemoveLease(LeaseName)).Should()
-                    .ThrowAsync<LeaseTimeoutException>()
-                    .WithMessage($"Timed out removing lease {LeaseName}. It is not known if the remove happened.*");
+                var ex = await Assert.ThrowsAsync<LeaseTimeoutException>(() => _underTest.RemoveLease(LeaseName));
+                // converted from WithMessage glob "Timed out removing lease {LeaseName}. It is not known if the remove happened.*"
+                Assert.StartsWith($"Timed out removing lease {LeaseName}. It is not known if the remove happened.", ex.Message);
             }
             finally
             {

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/KubernetesSettingsSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/KubernetesSettingsSpec.cs
@@ -7,7 +7,6 @@
 
 using System;
 using Akka.Configuration;
-using FluentAssertions;
 using Humanizer;
 using Xunit;
 
@@ -38,51 +37,54 @@ namespace Akka.Coordination.KubernetesApi.Tests
         [Fact(DisplayName = "default request-timeout should be 2/5 of the lease-operation-timeout")]
         public void RequestTimeoutIsTwoFifthOfLeaseOperationTimeout()
         {
-            Conf("akka.coordination.lease.lease-operation-timeout=10s")
-                .ApiServiceRequestTimeout.Should().Be(TimeSpan.FromSeconds(4));
+            Assert.Equal(TimeSpan.FromSeconds(4),
+                Conf("akka.coordination.lease.lease-operation-timeout=10s")
+                    .ApiServiceRequestTimeout);
         }
 
         [Fact(DisplayName = "default body-read timeout should be 1/2 of api request timeout")]
         public void BodyReadTimeoutIsHalfOfApiRequestTimeout()
         {
-            Conf("akka.coordination.lease.lease-operation-timeout=10s")
-                .BodyReadTimeout.Should().Be(TimeSpan.FromSeconds(2));
+            Assert.Equal(TimeSpan.FromSeconds(2),
+                Conf("akka.coordination.lease.lease-operation-timeout=10s")
+                    .BodyReadTimeout);
         }
 
         [Fact(DisplayName = "Kubernetes settings should allow api server request timeout override")]
         public void ShouldAllowServerRequestTimeoutOverride()
         {
-            Conf(@"
+            Assert.Equal(TimeSpan.FromSeconds(4),
+                Conf(@"
             akka.coordination.lease.lease-operation-timeout=5s
-            akka.coordination.lease.kubernetes.api-service-request-timeout=4s").ApiServiceRequestTimeout
-                .Should().Be(TimeSpan.FromSeconds(4));
+            akka.coordination.lease.kubernetes.api-service-request-timeout=4s").ApiServiceRequestTimeout);
         }
 
         [Fact(DisplayName =
             "Kubernetes settings should not allow service request timeout greater than operation timeout")]
         public void InvalidServerRequestTimeout()
         {
-            Assert.Throws<ConfigurationException>(() =>
+            var ex = Assert.Throws<ConfigurationException>(() =>
             {
                 Conf(@"
                     akka.coordination.lease.lease-operation-timeout=5s
                     akka.coordination.lease.kubernetes.api-service-request-timeout=6s");
-            }).Message.Should().Be("'api-service-request-timeout can not be greater than 'lease-operation-timeout'");
+            });
+            Assert.Equal("'api-service-request-timeout can not be greater than 'lease-operation-timeout'", ex.Message);
         }
 
         [Fact(DisplayName = "KubernetesSettings should contain default values")]
         public void DefaultKubernetesSettingsTest()
         {
             var settings = Conf(null);
-            settings.ApiCaPath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt");
-            settings.ApiTokenPath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/token");
-            settings.ApiServiceHostEnvName.Should().Be("KUBERNETES_SERVICE_HOST");
-            settings.ApiServicePortEnvName.Should().Be("KUBERNETES_SERVICE_PORT");
-            settings.Namespace.Should().BeNull(); 
-            settings.NamespacePath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); 
-            settings.ApiServiceRequestTimeout.Should().Be(2.Seconds());
-            settings.Secure.Should().BeTrue(); 
-            settings.BodyReadTimeout.Should().Be(1.Seconds()); 
+            Assert.Equal("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt", settings.ApiCaPath);
+            Assert.Equal("/var/run/secrets/kubernetes.io/serviceaccount/token", settings.ApiTokenPath);
+            Assert.Equal("KUBERNETES_SERVICE_HOST", settings.ApiServiceHostEnvName);
+            Assert.Equal("KUBERNETES_SERVICE_PORT", settings.ApiServicePortEnvName);
+            Assert.Null(settings.Namespace);
+            Assert.Equal("/var/run/secrets/kubernetes.io/serviceaccount/namespace", settings.NamespacePath);
+            Assert.Equal(2.Seconds(), settings.ApiServiceRequestTimeout);
+            Assert.True(settings.Secure);
+            Assert.Equal(1.Seconds(), settings.BodyReadTimeout);
         }
 
         [Fact(DisplayName = "Empty KubernetesSettings should contain default values")]
@@ -90,15 +92,15 @@ namespace Akka.Coordination.KubernetesApi.Tests
         {
             var settings = Conf(null);
             var empty = KubernetesSettings.Empty;
-            empty.ApiCaPath.Should().Be(settings.ApiCaPath);
-            empty.ApiTokenPath.Should().Be(settings.ApiTokenPath);
-            empty.ApiServiceHostEnvName.Should().Be(settings.ApiServiceHostEnvName);
-            empty.ApiServicePortEnvName.Should().Be(settings.ApiServicePortEnvName);
-            empty.Namespace.Should().Be(settings.Namespace);
-            empty.NamespacePath.Should().Be(settings.NamespacePath); 
-            empty.ApiServiceRequestTimeout.Should().Be(settings.ApiServiceRequestTimeout);
-            empty.Secure.Should().Be(settings.Secure); 
-            empty.BodyReadTimeout.Should().Be(settings.BodyReadTimeout); 
+            Assert.Equal(settings.ApiCaPath, empty.ApiCaPath);
+            Assert.Equal(settings.ApiTokenPath, empty.ApiTokenPath);
+            Assert.Equal(settings.ApiServiceHostEnvName, empty.ApiServiceHostEnvName);
+            Assert.Equal(settings.ApiServicePortEnvName, empty.ApiServicePortEnvName);
+            Assert.Equal(settings.Namespace, empty.Namespace);
+            Assert.Equal(settings.NamespacePath, empty.NamespacePath);
+            Assert.Equal(settings.ApiServiceRequestTimeout, empty.ApiServiceRequestTimeout);
+            Assert.Equal(settings.Secure, empty.Secure);
+            Assert.Equal(settings.BodyReadTimeout, empty.BodyReadTimeout);
         }
 
         [Fact(DisplayName = "KubernetesSettings overrides should work")]
@@ -115,15 +117,15 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 .WithSecure(false)
                 .WithBodyReadTimeout(12.Seconds());
             
-            settings.ApiCaPath.Should().Be("a");
-            settings.ApiTokenPath.Should().Be("b");
-            settings.ApiServiceHostEnvName.Should().Be("c");
-            settings.ApiServicePortEnvName.Should().Be("d");
-            settings.Namespace.Should().Be("e"); 
-            settings.NamespacePath.Should().Be("f"); 
-            settings.ApiServiceRequestTimeout.Should().Be(11.Seconds());
-            settings.Secure.Should().BeFalse(); 
-            settings.BodyReadTimeout.Should().Be(12.Seconds()); 
+            Assert.Equal("a", settings.ApiCaPath);
+            Assert.Equal("b", settings.ApiTokenPath);
+            Assert.Equal("c", settings.ApiServiceHostEnvName);
+            Assert.Equal("d", settings.ApiServicePortEnvName);
+            Assert.Equal("e", settings.Namespace);
+            Assert.Equal("f", settings.NamespacePath);
+            Assert.Equal(11.Seconds(), settings.ApiServiceRequestTimeout);
+            Assert.False(settings.Secure);
+            Assert.Equal(12.Seconds(), settings.BodyReadTimeout);
         }
         
         [Fact(DisplayName = "KubernetesLeaseSetup overrides should work")]
@@ -143,15 +145,15 @@ namespace Akka.Coordination.KubernetesApi.Tests
             };
             
             var settings = setup.Apply(KubernetesSettings.Empty);
-            settings.ApiCaPath.Should().Be("a");
-            settings.ApiTokenPath.Should().Be("b");
-            settings.ApiServiceHostEnvName.Should().Be("c");
-            settings.ApiServicePortEnvName.Should().Be("d");
-            settings.Namespace.Should().Be("e"); 
-            settings.NamespacePath.Should().Be("f"); 
-            settings.ApiServiceRequestTimeout.Should().Be(11.Seconds());
-            settings.Secure.Should().BeFalse(); 
-            settings.BodyReadTimeout.Should().Be(12.Seconds()); 
+            Assert.Equal("a", settings.ApiCaPath);
+            Assert.Equal("b", settings.ApiTokenPath);
+            Assert.Equal("c", settings.ApiServiceHostEnvName);
+            Assert.Equal("d", settings.ApiServicePortEnvName);
+            Assert.Equal("e", settings.Namespace);
+            Assert.Equal("f", settings.NamespacePath);
+            Assert.Equal(11.Seconds(), settings.ApiServiceRequestTimeout);
+            Assert.False(settings.Secure);
+            Assert.Equal(12.Seconds(), settings.BodyReadTimeout);
         }
     }
 }

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/LeaseActorSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/LeaseActorSpec.cs
@@ -11,8 +11,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Akka.Util;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 #nullable enable
@@ -55,7 +53,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 UnderTest.Tell(new LeaseActor.Acquire(), Sender);
                 LeaseProbe.ExpectMsg(LeaseName);
                 LeaseProbe.Reply(new Status.Failure(failure));
-                SenderProbe.ExpectMsg<Status.Failure>().Cause.Should().Be(failure);
+                Assert.Equal(failure, SenderProbe.ExpectMsg<Status.Failure>().Cause);
             });
         }
 
@@ -98,9 +96,8 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
             
                 // not granted
-                SenderProbe.ExpectMsg<Status.Failure>().Cause.Message
-                    .Should().StartWith("API server took too long to respond");
-                Granted.Value.Should().BeFalse();
+                Assert.StartsWith("API server took too long to respond", SenderProbe.ExpectMsg<Status.Failure>().Cause.Message);
+                Assert.False(Granted.Value);
             
                 // should allow retry
                 AcquireLease();
@@ -199,7 +196,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 UpdateProbe.ExpectMsg(("", CurrentVersion));
                 IncrementVersion();
                 UpdateProbe.Reply(new Status.Failure(failure));
-                SenderProbe.ExpectMsg<Status.Failure>().Cause.Should().Be(failure);
+                Assert.Equal(failure, SenderProbe.ExpectMsg<Status.Failure>().Cause);
             });
         }
 
@@ -208,11 +205,11 @@ namespace Akka.Coordination.KubernetesApi.Tests
         {
             RunTest(() =>
             {
-                Granted.Value.Should().BeFalse();
+                Assert.False(Granted.Value);
                 AcquireLease();
                 AwaitAssert(() =>
                 {
-                    Granted.Value.Should().BeTrue();
+                    Assert.True(Granted.Value);
                 });
             });
         }
@@ -222,16 +219,16 @@ namespace Akka.Coordination.KubernetesApi.Tests
         {
             RunTest(() =>
             {
-                Granted.Value.Should().BeFalse();
+                Assert.False(Granted.Value);
                 AcquireLease();
                 AwaitAssert(() =>
                 {
-                    Granted.Value.Should().BeTrue();
+                    Assert.True(Granted.Value);
                 });
                 ReleaseLease();
                 AwaitAssert(() =>
                 {
-                    Granted.Value.Should().BeFalse();
+                    Assert.False(Granted.Value);
                 });
             });
         }
@@ -280,7 +277,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
             {
                 AcquireLease();
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
                 IncrementVersion();
@@ -289,7 +286,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         new LeaseResource("I stole your lock", CurrentVersion, CurrentTime)));
                 AwaitAssert(() =>
                 {
-                    Granted.Value.Should().BeFalse();
+                    Assert.False(Granted.Value);
                 });
             });
         }
@@ -305,7 +302,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     callbackCalled = true;
                 });
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
                 IncrementVersion();
@@ -314,7 +311,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         new LeaseResource("I stole your lock", CurrentVersion, CurrentTime)));
                 AwaitAssert(() =>
                 {
-                    callbackCalled.Should().BeTrue();
+                    Assert.True(callbackCalled);
                 });
             });
         }
@@ -326,11 +323,11 @@ namespace Akka.Coordination.KubernetesApi.Tests
             {
                 AcquireLease();
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // With retry logic, multiple failures are needed to exhaust the TTL window
                 HeartBeatFailure();
-                Granted.Value.Should().BeFalse();
+                Assert.False(Granted.Value);
             });
         }
 
@@ -346,13 +343,13 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     callbackCalled = e;
                 });
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // With retry logic, drive failures until TTL expires and callback fires
                 DriveHeartBeatFailures(failure);
                 AwaitAssert(() =>
                 {
-                    callbackCalled.Should().Be(failure);
+                    Assert.Equal(failure, callbackCalled);
                 });
             });
         }
@@ -364,14 +361,14 @@ namespace Akka.Coordination.KubernetesApi.Tests
             {
                 AcquireLease();
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // First heartbeat fails transiently
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
                 UpdateProbe.Reply(new Status.Failure(new LeaseException("Transient failure")));
 
                 // Should still be granted - actor retries within TTL window
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Retry heartbeat succeeds
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
@@ -381,7 +378,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
 
                 // Should still be granted and heartbeating normally
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Normal heartbeat continues
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
@@ -395,14 +392,14 @@ namespace Akka.Coordination.KubernetesApi.Tests
             {
                 AcquireLease();
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Multiple consecutive failures, all within TTL window
                 for (var i = 0; i < 3; i++)
                 {
                     UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
                     UpdateProbe.Reply(new Status.Failure(new LeaseException($"Transient failure {i}")));
-                    Granted.Value.Should().BeTrue();
+                    Assert.True(Granted.Value);
                 }
 
                 // Recovery: next heartbeat succeeds
@@ -413,7 +410,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
 
                 // Lease is still held
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
             });
         }
 
@@ -428,15 +425,15 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     callbackCalled = true;
                 });
                 ExpectHeartBeat();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Single transient failure within TTL
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
                 UpdateProbe.Reply(new Status.Failure(new LeaseException("Transient failure")));
 
                 // Callback should NOT be called - TTL still valid
-                callbackCalled.Should().BeFalse();
-                Granted.Value.Should().BeTrue();
+                Assert.False(callbackCalled);
+                Assert.True(Granted.Value);
 
                 // Recovery
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
@@ -445,7 +442,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     new Right<LeaseResource, LeaseResource>(
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
 
-                callbackCalled.Should().BeFalse();
+                Assert.False(callbackCalled);
             });
         }
 
@@ -466,7 +463,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
             {
                 await AcquireLeaseAsync();
                 await ExpectHeartBeatAsync();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Step 1: Heartbeat fires, but PUT times out on client (server succeeded and bumped version)
                 await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
@@ -474,7 +471,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     new LeaseException("API server request timed out")));
 
                 // Should still be granted — within TTL retry window (#3404 fix)
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Step 2: Actor retries heartbeat with stale version (server already moved to next version)
                 await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
@@ -488,7 +485,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
 
                 // BUG: Actor currently releases the lease here (lines 400-404)
                 // EXPECTED: Actor should recognize it's still the owner and stay Granted
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Step 4: Heartbeat should continue normally with the updated version
                 await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
@@ -497,7 +494,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     new Right<LeaseResource, LeaseResource>(
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
 
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
             });
         }
 
@@ -517,7 +514,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     callbackCalled = true;
                 });
                 await ExpectHeartBeatAsync();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Heartbeat times out on client
                 await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
@@ -532,8 +529,8 @@ namespace Akka.Coordination.KubernetesApi.Tests
                         new LeaseResource(OwnerName, CurrentVersion, CurrentTime)));
 
                 // Callback should NOT be called — we still own the lease
-                callbackCalled.Should().BeFalse();
-                Granted.Value.Should().BeTrue();
+                Assert.False(callbackCalled);
+                Assert.True(Granted.Value);
             });
         }
 
@@ -549,7 +546,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
             {
                 await AcquireLeaseAsync();
                 await ExpectHeartBeatAsync();
-                Granted.Value.Should().BeTrue();
+                Assert.True(Granted.Value);
 
                 // Heartbeat times out on client
                 await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
@@ -566,7 +563,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 // Should release — this is a genuine conflict
                 await AwaitAssertAsync(() =>
                 {
-                    Granted.Value.Should().BeFalse();
+                    Assert.False(Granted.Value);
                 });
             });
         }
@@ -662,7 +659,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 await SenderProbe.ExpectMsgAsync<LeaseActor.LeaseTaken>();
 
                 // Step 7: localGranted should be false — the lease was never actually acquired
-                Granted.Value.Should().BeFalse();
+                Assert.False(Granted.Value);
             });
         }
 
@@ -705,7 +702,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 // Step 7: localGranted should be TRUE — the lease was properly acquired
                 await AwaitAssertAsync(() =>
                 {
-                    Granted.Value.Should().BeTrue();
+                    Assert.True(Granted.Value);
                 });
             });
         }
@@ -970,7 +967,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
         {
             UnderTest.Tell(new LeaseActor.Acquire(callback), Sender);
             await LeaseProbe.ExpectMsgAsync(LeaseName);
-            LeaseProbe.Reply(new LeaseResource(null, CurrentVersion, CurrentTime.Date + 1.Milliseconds()));
+            LeaseProbe.Reply(new LeaseResource(null, CurrentVersion, CurrentTime.Date + TimeSpan.FromMilliseconds(1)));
             await UpdateProbe.ExpectMsgAsync((OwnerName, CurrentVersion));
             IncrementVersion();
             UpdateProbe.Reply(
@@ -991,7 +988,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
         {
             UnderTest.Tell(new LeaseActor.Acquire(callback), Sender);
             LeaseProbe.ExpectMsg(LeaseName);
-            LeaseProbe.Reply(new LeaseResource(null, CurrentVersion, CurrentTime.Date + 1.Milliseconds()));
+            LeaseProbe.Reply(new LeaseResource(null, CurrentVersion, CurrentTime.Date + TimeSpan.FromMilliseconds(1)));
             UpdateProbe.ExpectMsg((OwnerName, CurrentVersion));
             IncrementVersion();
             UpdateProbe.Reply(
@@ -1051,7 +1048,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
             LeaseProbe.ExpectMsg(LeaseName);
             LeaseProbe.Reply(new Status.Failure(failure));
             var receivedFailure = SenderProbe.ExpectMsg<Status.Failure>();
-            receivedFailure.Cause.Should().Be(failure);
+            Assert.Equal(failure, receivedFailure.Cause);
         }
 
         protected void HeartBeatConflict()
@@ -1063,7 +1060,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     new LeaseResource("I stole your lock", CurrentVersion, CurrentTime)));
             AwaitAssert(() =>
             {
-                Granted.Value.Should().BeFalse();
+                Assert.False(Granted.Value);
             });
         }
 
@@ -1080,7 +1077,7 @@ namespace Akka.Coordination.KubernetesApi.Tests
                 UpdateProbe.Reply(new Status.Failure(failure));
                 Task.Delay(10).Wait();
             }
-            AwaitAssert(() => Granted.Value.Should().BeFalse());
+            AwaitAssert(() => Assert.False(Granted.Value));
         }
     }
 }

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/AwsIntegrationSpec.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/AwsIntegrationSpec.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Discovery.AwsApi.Ec2;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Discovery.AwsApi.Integration.Tests
@@ -53,8 +52,11 @@ akka {{
             var discovery = new Ec2TagBasedServiceDiscovery((ExtendedActorSystem)Sys);
             var lookup = new Lookup("fake-api");
             var resolved = await discovery.Lookup(lookup, TimeSpan.FromSeconds(5));
-            resolved.Addresses.Count.Should().Be(4);
-            resolved.Addresses.Select(a => a.Address.ToString()).Should().BeEquivalentTo(_fixture.IpAddresses);
+            Assert.Equal(4, resolved.Addresses.Count);
+            // converted from BeEquivalentTo (order-insensitive collection equivalence)
+            Assert.Equal(
+                _fixture.IpAddresses.OrderBy(x => x),
+                resolved.Addresses.Select(a => a.Address.ToString()).OrderBy(x => x));
         }
     }
 }

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Ec2ServiceDiscoverySettingsSpec.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Ec2ServiceDiscoverySettingsSpec.cs
@@ -14,9 +14,7 @@ using Akka.Discovery.AwsApi.Ec2;
 using Amazon.EC2;
 using Amazon.EC2.Model;
 using Amazon.Runtime;
-using FluentAssertions;
 using Xunit;
-using static FluentAssertions.FluentActions;
 
 namespace Akka.Discovery.AwsApi.Tests
 {
@@ -28,13 +26,13 @@ namespace Akka.Discovery.AwsApi.Tests
             var settings = Ec2ServiceDiscoverySettings.Create(
                 AwsEc2Discovery.DefaultConfiguration().GetConfig("akka.discovery.aws-api-ec2-tag-based"));
 
-            settings.ClientConfig.Should().BeNull();
-            settings.CredentialsProvider.Should().Be(typeof(Ec2InstanceMetadataCredentialProvider));
-            settings.TagKey.Should().Be("service");
-            settings.Filters.Should().BeEmpty();
-            settings.Ports.Should().BeEmpty();
-            settings.Endpoint.Should().BeNull();
-            settings.Region.Should().BeNull();
+            Assert.Null(settings.ClientConfig);
+            Assert.Equal(typeof(Ec2InstanceMetadataCredentialProvider), settings.CredentialsProvider);
+            Assert.Equal("service", settings.TagKey);
+            Assert.Empty(settings.Filters);
+            Assert.Empty(settings.Ports);
+            Assert.Null(settings.Endpoint);
+            Assert.Null(settings.Region);
         }
 
         [Fact(DisplayName = "Empty settings should be equal to default")]
@@ -44,13 +42,17 @@ namespace Akka.Discovery.AwsApi.Tests
             var settings = Ec2ServiceDiscoverySettings.Create(AwsEc2Discovery.DefaultConfiguration()
                 .GetConfig("akka.discovery.aws-api-ec2-tag-based"));
 
-            empty.ClientConfig.Should().Be(settings.ClientConfig);
-            empty.CredentialsProvider.Should().Be(settings.CredentialsProvider);
-            empty.TagKey.Should().Be(settings.TagKey);
-            empty.Filters.Should().BeEquivalentTo(settings.Filters);
-            empty.Ports.Should().BeEquivalentTo(settings.Ports);
-            empty.Endpoint.Should().Be(settings.Endpoint);
-            empty.Region.Should().Be(settings.Region);
+            Assert.Equal(settings.ClientConfig, empty.ClientConfig);
+            Assert.Equal(settings.CredentialsProvider, empty.CredentialsProvider);
+            Assert.Equal(settings.TagKey, empty.TagKey);
+            // converted from BeEquivalentTo (structural, order-insensitive)
+            Assert.Equal(
+                settings.Filters.Select(f => (f.Name, Values: string.Join(",", f.Values.OrderBy(v => v)))).OrderBy(t => t.Name),
+                empty.Filters.Select(f => (f.Name, Values: string.Join(",", f.Values.OrderBy(v => v)))).OrderBy(t => t.Name));
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(settings.Ports.OrderBy(p => p), empty.Ports.OrderBy(p => p));
+            Assert.Equal(settings.Endpoint, empty.Endpoint);
+            Assert.Equal(settings.Region, empty.Region);
         }
 
         [Fact(DisplayName = "Ec2ServiceDiscoverySettings With override should work")]
@@ -67,13 +69,17 @@ namespace Akka.Discovery.AwsApi.Tests
                 .WithEndpoint("e")
                 .WithRegion("f");
             
-            settings.ClientConfig.Should().Be(typeof(FakeClientConfig));
-            settings.CredentialsProvider.Should().Be(typeof(FakeCredProvider));
-            settings.TagKey.Should().Be("b");
-            settings.Filters.Should().BeEquivalentTo(filters);
-            settings.Ports.Should().BeEquivalentTo(ports);
-            settings.Endpoint.Should().Be("e");
-            settings.Region.Should().Be("f");
+            Assert.Equal(typeof(FakeClientConfig), settings.ClientConfig);
+            Assert.Equal(typeof(FakeCredProvider), settings.CredentialsProvider);
+            Assert.Equal("b", settings.TagKey);
+            // converted from BeEquivalentTo (structural, order-insensitive)
+            Assert.Equal(
+                filters.Select(f => (f.Name, Values: string.Join(",", f.Values.OrderBy(v => v)))).OrderBy(t => t.Name),
+                settings.Filters.Select(f => (f.Name, Values: string.Join(",", f.Values.OrderBy(v => v)))).OrderBy(t => t.Name));
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(ports.OrderBy(p => p), settings.Ports.OrderBy(p => p));
+            Assert.Equal("e", settings.Endpoint);
+            Assert.Equal("f", settings.Region);
         }
 
         [Fact(DisplayName = "Ec2ServiceDiscoverySetup override should work")]
@@ -93,13 +99,17 @@ namespace Akka.Discovery.AwsApi.Tests
                 .WithCredentialProvider<FakeCredProvider>();
             
             var settings = setup.Apply(Ec2ServiceDiscoverySettings.Empty);
-            settings.ClientConfig.Should().Be(typeof(FakeClientConfig));
-            settings.CredentialsProvider.Should().Be(typeof(FakeCredProvider));
-            settings.TagKey.Should().Be("b");
-            settings.Filters.Should().BeEquivalentTo(filters);
-            settings.Ports.Should().BeEquivalentTo(ports);
-            settings.Endpoint.Should().Be("e");
-            settings.Region.Should().Be("f");
+            Assert.Equal(typeof(FakeClientConfig), settings.ClientConfig);
+            Assert.Equal(typeof(FakeCredProvider), settings.CredentialsProvider);
+            Assert.Equal("b", settings.TagKey);
+            // converted from BeEquivalentTo (structural, order-insensitive)
+            Assert.Equal(
+                filters.Select(f => (f.Name, Values: string.Join(",", f.Values.OrderBy(v => v)))).OrderBy(t => t.Name),
+                settings.Filters.Select(f => (f.Name, Values: string.Join(",", f.Values.OrderBy(v => v)))).OrderBy(t => t.Name));
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(ports.OrderBy(p => p), settings.Ports.OrderBy(p => p));
+            Assert.Equal("e", settings.Endpoint);
+            Assert.Equal("f", settings.Region);
         }
 
         [Fact(DisplayName = "Ec2ServiceDiscoverySetup Type based properties should validate values")]
@@ -107,37 +117,31 @@ namespace Akka.Discovery.AwsApi.Tests
         {
             var setup = new Ec2ServiceDiscoverySetup();
 
-            Invoking(() => setup.ClientConfig = typeof(FakeClientConfig))
-                .Should().NotThrow();
-            Invoking(() => setup.ClientConfig = typeof(FakeClientConfig2))
-                .Should().NotThrow();
-            Invoking(() => setup.ClientConfig = typeof(FakeCredProvider))
-                .Should().ThrowExactly<ConfigurationException>().WithMessage("*Type value need to extend*");
-            Invoking(() => setup.ClientConfig = typeof(IllegalClientConfig))
-                .Should().ThrowExactly<ConfigurationException>().WithMessage("*need to have a parameterless constructor*");
-            
-            Invoking(() => setup.WithClientConfig<FakeClientConfig>())
-                .Should().NotThrow();
-            Invoking(() => setup.WithClientConfig<FakeClientConfig2>())
-                .Should().NotThrow();
-            Invoking(() => setup.WithClientConfig<IllegalClientConfig>())
-                .Should().ThrowExactly<ConfigurationException>().WithMessage("*need to have a parameterless constructor*");
-            
-            Invoking(() => setup.CredentialsProvider = typeof(FakeCredProvider))
-                .Should().NotThrow();
-            Invoking(() => setup.CredentialsProvider = typeof(FakeCredProvider2))
-                .Should().NotThrow();
-            Invoking(() => setup.CredentialsProvider = typeof(FakeClientConfig))
-                .Should().ThrowExactly<ConfigurationException>().WithMessage("*Type value need to extend*");
-            Invoking(() => setup.CredentialsProvider = typeof(IllegalCredProvider))
-                .Should().ThrowExactly<ConfigurationException>().WithMessage("*need to have a parameterless constructor*");
-            
-            Invoking(() => setup.WithCredentialProvider<FakeCredProvider>())
-                .Should().NotThrow();
-            Invoking(() => setup.WithCredentialProvider<FakeCredProvider2>())
-                .Should().NotThrow();
-            Invoking(() => setup.WithCredentialProvider<IllegalCredProvider>())
-                .Should().ThrowExactly<ConfigurationException>().WithMessage("*need to have a parameterless constructor*");
+            Assert.Null(Record.Exception(() => { setup.ClientConfig = typeof(FakeClientConfig); }));
+            Assert.Null(Record.Exception(() => { setup.ClientConfig = typeof(FakeClientConfig2); }));
+            // converted from ThrowExactly + WithMessage glob "*Type value need to extend*"
+            Assert.Contains("Type value need to extend",
+                Assert.Throws<ConfigurationException>(() => { setup.ClientConfig = typeof(FakeCredProvider); }).Message);
+            // converted from ThrowExactly + WithMessage glob "*need to have a parameterless constructor*"
+            Assert.Contains("need to have a parameterless constructor",
+                Assert.Throws<ConfigurationException>(() => { setup.ClientConfig = typeof(IllegalClientConfig); }).Message);
+
+            Assert.Null(Record.Exception(() => { setup.WithClientConfig<FakeClientConfig>(); }));
+            Assert.Null(Record.Exception(() => { setup.WithClientConfig<FakeClientConfig2>(); }));
+            Assert.Contains("need to have a parameterless constructor",
+                Assert.Throws<ConfigurationException>(() => { setup.WithClientConfig<IllegalClientConfig>(); }).Message);
+
+            Assert.Null(Record.Exception(() => { setup.CredentialsProvider = typeof(FakeCredProvider); }));
+            Assert.Null(Record.Exception(() => { setup.CredentialsProvider = typeof(FakeCredProvider2); }));
+            Assert.Contains("Type value need to extend",
+                Assert.Throws<ConfigurationException>(() => { setup.CredentialsProvider = typeof(FakeClientConfig); }).Message);
+            Assert.Contains("need to have a parameterless constructor",
+                Assert.Throws<ConfigurationException>(() => { setup.CredentialsProvider = typeof(IllegalCredProvider); }).Message);
+
+            Assert.Null(Record.Exception(() => { setup.WithCredentialProvider<FakeCredProvider>(); }));
+            Assert.Null(Record.Exception(() => { setup.WithCredentialProvider<FakeCredProvider2>(); }));
+            Assert.Contains("need to have a parameterless constructor",
+                Assert.Throws<ConfigurationException>(() => { setup.WithCredentialProvider<IllegalCredProvider>(); }).Message);
         }
         
         private class FakeClientConfig: AmazonEC2Config

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Ec2TagBasedServiceDiscoverySpec.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Ec2TagBasedServiceDiscoverySpec.cs
@@ -6,8 +6,8 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using Akka.Discovery.AwsApi.Ec2;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Discovery.AwsApi.Tests
@@ -18,7 +18,7 @@ namespace Akka.Discovery.AwsApi.Tests
         public void ParseEmptyString()
         {
             var result = Ec2TagBasedServiceDiscovery.ParseFiltersString("");
-            result.Count.Should().Be(0);
+            Assert.Equal(0, result.Count);
         }
         
         [Fact(DisplayName = "Can parse simple filter")]
@@ -26,10 +26,10 @@ namespace Akka.Discovery.AwsApi.Tests
         {
             var filters = "tag:purpose=demo";
             var result = Ec2TagBasedServiceDiscovery.ParseFiltersString(filters);
-            result.Count.Should().Be(1);
-            result[0].Name.Should().Be("tag:purpose");
-            result[0].Values.Count.Should().Be(1);
-            result[0].Values[0].Should().Be("demo");
+            Assert.Equal(1, result.Count);
+            Assert.Equal("tag:purpose", result[0].Name);
+            Assert.Equal(1, result[0].Values.Count);
+            Assert.Equal("demo", result[0].Values[0]);
         }
 
         [Fact(DisplayName = "Can parse complex filter")]
@@ -37,19 +37,23 @@ namespace Akka.Discovery.AwsApi.Tests
         {
             var filters = "tag:purpose=production;tag:department=engineering;tag:critical=no;tag:numbers=one,two,three";
             var result = Ec2TagBasedServiceDiscovery.ParseFiltersString(filters);
-            result.Count.Should().Be(4);
+            Assert.Equal(4, result.Count);
 
-            result[0].Name.Should().Be("tag:purpose");
-            result[0].Values.Should().BeEquivalentTo(new List<string> {"production"});
-            
-            result[1].Name.Should().Be("tag:department");
-            result[1].Values.Should().BeEquivalentTo(new List<string> {"engineering"});
-            
-            result[2].Name.Should().Be("tag:critical");
-            result[2].Values.Should().BeEquivalentTo(new List<string> {"no"});
-            
-            result[3].Name.Should().Be("tag:numbers");
-            result[3].Values.Should().BeEquivalentTo(new List<string> {"one", "two", "three"});
+            Assert.Equal("tag:purpose", result[0].Name);
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(new List<string> {"production"}.OrderBy(x => x), result[0].Values.OrderBy(x => x));
+
+            Assert.Equal("tag:department", result[1].Name);
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(new List<string> {"engineering"}.OrderBy(x => x), result[1].Values.OrderBy(x => x));
+
+            Assert.Equal("tag:critical", result[2].Name);
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(new List<string> {"no"}.OrderBy(x => x), result[2].Values.OrderBy(x => x));
+
+            Assert.Equal("tag:numbers", result[3].Name);
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(new List<string> {"one", "two", "three"}.OrderBy(x => x), result[3].Values.OrderBy(x => x));
         }
     }
 }

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Tests/UtilsSpec.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Tests/UtilsSpec.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Net;
 using Akka.Discovery.AwsApi.Ecs;
 using Amazon.ECS.Model;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Discovery.AwsApi.Tests
@@ -22,8 +21,9 @@ namespace Akka.Discovery.AwsApi.Tests
         {
             var list = Enumerable.Range(0, 10).Select(i => i.ToString());
             var chunked = list.ChunkBy(20).ToList();
-            chunked.Count.Should().Be(1);
-            chunked[0].Should().BeEquivalentTo(Enumerable.Range(0, 10).Select(i => i.ToString()));
+            Assert.Equal(1, chunked.Count);
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(Enumerable.Range(0, 10).Select(i => i.ToString()).OrderBy(x => x), chunked[0].OrderBy(x => x));
         }
         
         [Fact(DisplayName = "ChunkBy with items more than chunk count should work")]
@@ -31,10 +31,11 @@ namespace Akka.Discovery.AwsApi.Tests
         {
             var list = Enumerable.Range(0, 50).Select(i => i.ToString());
             var chunked = list.ChunkBy(20).ToList();
-            chunked.Count.Should().Be(3);
-            chunked[0].Should().BeEquivalentTo(Enumerable.Range(0, 20).Select(i => i.ToString()));
-            chunked[1].Should().BeEquivalentTo(Enumerable.Range(20, 20).Select(i => i.ToString()));
-            chunked[2].Should().BeEquivalentTo(Enumerable.Range(40, 10).Select(i => i.ToString()));
+            Assert.Equal(3, chunked.Count);
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(Enumerable.Range(0, 20).Select(i => i.ToString()).OrderBy(x => x), chunked[0].OrderBy(x => x));
+            Assert.Equal(Enumerable.Range(20, 20).Select(i => i.ToString()).OrderBy(x => x), chunked[1].OrderBy(x => x));
+            Assert.Equal(Enumerable.Range(40, 10).Select(i => i.ToString()).OrderBy(x => x), chunked[2].OrderBy(x => x));
         }
         
         [Theory(DisplayName = "Diff should return appropriate List emulating Scala list.diff()")]
@@ -42,10 +43,10 @@ namespace Akka.Discovery.AwsApi.Tests
         public void DiffTest(List<AwsTag> listA, List<AwsTag> listB, List<AwsTag> listDiff)
         {
             var result = listA.Diff(listB);
-            result.Count.Should().Be(listDiff.Count);
+            Assert.Equal(listDiff.Count, result.Count);
             foreach (var tag in listDiff)
             {
-                result.Should().Contain(tag);
+                Assert.Contains(tag, result);
             }
         }
         
@@ -252,14 +253,14 @@ namespace Akka.Discovery.AwsApi.Tests
         [MemberData(nameof(LocalhostIpAddressDataSource))]
         public void IsLocalhostAddress(IPAddress address, bool isLocal)
         {
-            address.IsLoopbackAddress().Should().Be(isLocal);
+            Assert.Equal(isLocal, address.IsLoopbackAddress());
         }
 
         [Theory(DisplayName = "IPAddress.IsSiteLocalAddress() extension method should work properly")]
         [MemberData(nameof(SiteLocalIpAddressDataSource))]
         public void IsSiteLocalAddress(IPAddress address, bool isLocal)
         {
-            address.IsSiteLocalAddress().Should().Be(isLocal);
+            Assert.Equal(isLocal, address.IsSiteLocalAddress());
         }
 
         public static IEnumerable<object[]> LocalhostIpAddressDataSource()

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/ActorSpec.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/ActorSpec.cs
@@ -16,8 +16,6 @@ using Akka.Discovery.Azure.Model;
 using Akka.Discovery.Azure.Tests.Utils;
 using Akka.Event;
 using Azure.Data.Tables;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Akka.Discovery.Azure.Tests
@@ -81,7 +79,7 @@ akka.remote.dot-netty.tcp.port = 0
             var firstEntry = await _client.GetOrCreateAsync(Host, _address, FirstPort);
             var actor = Sys.ActorOf(HeartbeatActor.Props(settings, _client));
 
-            await WithinAsync(3.Seconds(), async () =>
+            await WithinAsync(TimeSpan.FromSeconds(3), async () =>
             {
                 await EventFilter.Debug(contains: "LastUpdate successfully updated from")
                     .ExpectOneAsync(() =>
@@ -92,9 +90,9 @@ akka.remote.dot-netty.tcp.port = 0
             });
 
             var members = await GetEntriesAsync();
-            members.Count.Should().Be(1);
+            Assert.Equal(1, members.Count);
 
-            members[0].LastUpdate.Should().BeAfter(firstEntry.LastUpdate);
+            Assert.True(members[0].LastUpdate > firstEntry.LastUpdate);
         }
 
         [Fact(DisplayName = "PruneActor should prune ClusterMember entries")]
@@ -111,7 +109,7 @@ akka.remote.dot-netty.tcp.port = 0
             await PopulateTable();
 
             var members = await GetEntriesAsync();
-            members.Count.Should().Be(9);
+            Assert.Equal(9, members.Count);
             
             // Initialize client
             await _client.GetOrCreateAsync(Host, _address, FirstPort);
@@ -120,7 +118,7 @@ akka.remote.dot-netty.tcp.port = 0
             // Simulate leadership acquisition 
             actor.Tell(new ClusterEvent.LeaderChanged(selfAddress), Nobody.Instance);
             
-            await WithinAsync(3.Seconds(), async () =>
+            await WithinAsync(TimeSpan.FromSeconds(3), async () =>
             {
                 await EventFilter.Debug(contains: "row entries pruned:")
                     .ExpectOneAsync(() =>
@@ -131,7 +129,7 @@ akka.remote.dot-netty.tcp.port = 0
             });
 
             members = await GetEntriesAsync();
-            members.Count.Should().Be(4);
+            Assert.Equal(4, members.Count);
         }
 
         private async Task<List<ClusterMember>> GetEntriesAsync()
@@ -153,16 +151,16 @@ akka.remote.dot-netty.tcp.port = 0
             var add = TableTransactionActionType.Add;
             
             // add 6 entries in the past
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 9.Hours())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 8.Hours())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 7.Hours())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 6.Hours())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 5.Hours())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 4.Hours())));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromHours(9))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromHours(8))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromHours(7))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromHours(6))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromHours(5))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromHours(4))));
             
             // add 3 valid entries 
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 5.Seconds())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 3.Seconds())));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromSeconds(5))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromSeconds(3))));
             batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now)));
             
             await _rawClient.CreateIfNotExistsAsync();

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/AzureDiscoverySettingsSpecs.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/AzureDiscoverySettingsSpecs.cs
@@ -8,10 +8,7 @@
 using System;
 using System.Net;
 using Azure.Identity;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
-using static FluentAssertions.FluentActions;
 
 namespace Akka.Discovery.Azure.Tests
 {
@@ -24,21 +21,21 @@ namespace Akka.Discovery.Azure.Tests
 
             var assemblyName = typeof(AzureServiceDiscovery).Assembly.FullName!.Split(',')[0].Trim();
             var config = AzureDiscovery.DefaultConfiguration().GetConfig(AzureServiceDiscovery.DefaultConfigPath);
-            config.GetString("class").Should().Be($"{typeof(AzureServiceDiscovery).Namespace}.{nameof(AzureServiceDiscovery)}, {assemblyName}");
+            Assert.Equal($"{typeof(AzureServiceDiscovery).Namespace}.{nameof(AzureServiceDiscovery)}, {assemblyName}", config.GetString("class"));
 
-            settings.ReadOnly.Should().BeFalse();
-            settings.ServiceName.Should().Be("default");
-            settings.HostName.Should().Be(Dns.GetHostName());
-            settings.Port.Should().Be(8558);
-            settings.ConnectionString.Should().Be("<connection-string>");
-            settings.TableName.Should().Be("akkaclustermembers");
-            settings.TtlHeartbeatInterval.Should().Be(1.Minutes());
-            settings.StaleTtlThreshold.Should().Be(TimeSpan.Zero);
-            settings.PruneInterval.Should().Be(1.Hours());
-            settings.OperationTimeout.Should().Be(10.Seconds());
-            settings.EffectiveStaleTtlThreshold.Should().Be(new TimeSpan(settings.TtlHeartbeatInterval.Ticks * 5));
-            settings.AzureTableEndpoint.Should().BeNull();
-            settings.AzureAzureCredential.Should().BeNull();
+            Assert.False(settings.ReadOnly);
+            Assert.Equal("default", settings.ServiceName);
+            Assert.Equal(Dns.GetHostName(), settings.HostName);
+            Assert.Equal(8558, settings.Port);
+            Assert.Equal("<connection-string>", settings.ConnectionString);
+            Assert.Equal("akkaclustermembers", settings.TableName);
+            Assert.Equal(TimeSpan.FromMinutes(1), settings.TtlHeartbeatInterval);
+            Assert.Equal(TimeSpan.Zero, settings.StaleTtlThreshold);
+            Assert.Equal(TimeSpan.FromHours(1), settings.PruneInterval);
+            Assert.Equal(TimeSpan.FromSeconds(10), settings.OperationTimeout);
+            Assert.Equal(new TimeSpan(settings.TtlHeartbeatInterval.Ticks * 5), settings.EffectiveStaleTtlThreshold);
+            Assert.Null(settings.AzureTableEndpoint);
+            Assert.Null(settings.AzureAzureCredential);
         }
 
         [Fact(DisplayName = "Empty settings variable and default settings should match")]
@@ -47,19 +44,19 @@ namespace Akka.Discovery.Azure.Tests
             var settings = AzureDiscoverySettings.Create(AzureDiscovery.DefaultConfiguration());
             var empty = AzureDiscoverySettings.Empty;
 
-            empty.ReadOnly.Should().Be(settings.ReadOnly);
-            empty.ServiceName.Should().Be(settings.ServiceName);
-            empty.HostName.Should().Be(settings.HostName);
-            empty.Port.Should().Be(settings.Port);
-            empty.ConnectionString.Should().Be(settings.ConnectionString);
-            empty.TableName.Should().Be(settings.TableName);
-            empty.TtlHeartbeatInterval.Should().Be(settings.TtlHeartbeatInterval);
-            empty.StaleTtlThreshold.Should().Be(settings.StaleTtlThreshold);
-            empty.PruneInterval.Should().Be(settings.PruneInterval);
-            empty.OperationTimeout.Should().Be(settings.OperationTimeout);
-            empty.EffectiveStaleTtlThreshold.Should().Be(settings.EffectiveStaleTtlThreshold);
-            settings.AzureTableEndpoint.Should().Be(settings.AzureTableEndpoint);
-            settings.AzureAzureCredential.Should().Be(settings.AzureAzureCredential);
+            Assert.Equal(settings.ReadOnly, empty.ReadOnly);
+            Assert.Equal(settings.ServiceName, empty.ServiceName);
+            Assert.Equal(settings.HostName, empty.HostName);
+            Assert.Equal(settings.Port, empty.Port);
+            Assert.Equal(settings.ConnectionString, empty.ConnectionString);
+            Assert.Equal(settings.TableName, empty.TableName);
+            Assert.Equal(settings.TtlHeartbeatInterval, empty.TtlHeartbeatInterval);
+            Assert.Equal(settings.StaleTtlThreshold, empty.StaleTtlThreshold);
+            Assert.Equal(settings.PruneInterval, empty.PruneInterval);
+            Assert.Equal(settings.OperationTimeout, empty.OperationTimeout);
+            Assert.Equal(settings.EffectiveStaleTtlThreshold, empty.EffectiveStaleTtlThreshold);
+            Assert.Equal(settings.AzureTableEndpoint, settings.AzureTableEndpoint);
+            Assert.Equal(settings.AzureAzureCredential, settings.AzureAzureCredential);
         }
 
         [Fact(DisplayName = "Settings override should work properly")]
@@ -74,25 +71,25 @@ namespace Akka.Discovery.Azure.Tests
                 .WithPublicPort(1234)
                 .WithConnectionString("b")
                 .WithTableName("c")
-                .WithTtlHeartbeatInterval(1.Seconds())
-                .WithStaleTtlThreshold(2.Seconds())
-                .WithPruneInterval(3.Seconds())
-                .WithOperationTimeout(4.Seconds())
+                .WithTtlHeartbeatInterval(TimeSpan.FromSeconds(1))
+                .WithStaleTtlThreshold(TimeSpan.FromSeconds(2))
+                .WithPruneInterval(TimeSpan.FromSeconds(3))
+                .WithOperationTimeout(TimeSpan.FromSeconds(4))
                 .WithAzureCredential(uri, credential);
 
-            settings.ReadOnly.Should().BeTrue();
-            settings.ServiceName.Should().Be("a");
-            settings.HostName.Should().Be("host");
-            settings.Port.Should().Be(1234);
-            settings.ConnectionString.Should().Be("b");
-            settings.TableName.Should().Be("c");
-            settings.TtlHeartbeatInterval.Should().Be(1.Seconds());
-            settings.StaleTtlThreshold.Should().Be(2.Seconds());
-            settings.PruneInterval.Should().Be(3.Seconds());
-            settings.OperationTimeout.Should().Be(4.Seconds());
-            settings.EffectiveStaleTtlThreshold.Should().Be(settings.StaleTtlThreshold);
-            settings.AzureTableEndpoint.Should().Be(uri);
-            settings.AzureAzureCredential.Should().Be(credential);
+            Assert.True(settings.ReadOnly);
+            Assert.Equal("a", settings.ServiceName);
+            Assert.Equal("host", settings.HostName);
+            Assert.Equal(1234, settings.Port);
+            Assert.Equal("b", settings.ConnectionString);
+            Assert.Equal("c", settings.TableName);
+            Assert.Equal(TimeSpan.FromSeconds(1), settings.TtlHeartbeatInterval);
+            Assert.Equal(TimeSpan.FromSeconds(2), settings.StaleTtlThreshold);
+            Assert.Equal(TimeSpan.FromSeconds(3), settings.PruneInterval);
+            Assert.Equal(TimeSpan.FromSeconds(4), settings.OperationTimeout);
+            Assert.Equal(settings.StaleTtlThreshold, settings.EffectiveStaleTtlThreshold);
+            Assert.Equal(uri, settings.AzureTableEndpoint);
+            Assert.Equal(credential, settings.AzureAzureCredential);
         }
 
         [Fact(DisplayName = "Setup override should work properly")]
@@ -107,27 +104,27 @@ namespace Akka.Discovery.Azure.Tests
                 .WithPublicPort(1234)
                 .WithConnectionString("b")
                 .WithTableName("c")
-                .WithTtlHeartbeatInterval(1.Seconds())
-                .WithStaleTtlThreshold(2.Seconds())
-                .WithPruneInterval(3.Seconds())
-                .WithOperationTimeout(4.Seconds())
+                .WithTtlHeartbeatInterval(TimeSpan.FromSeconds(1))
+                .WithStaleTtlThreshold(TimeSpan.FromSeconds(2))
+                .WithPruneInterval(TimeSpan.FromSeconds(3))
+                .WithOperationTimeout(TimeSpan.FromSeconds(4))
                 .WithAzureCredential(uri, credential);
             
             var settings = setup.Apply(AzureDiscoverySettings.Empty);
 
-            settings.ReadOnly.Should().BeTrue();
-            settings.ServiceName.Should().Be("a");
-            settings.HostName.Should().Be("host");
-            settings.Port.Should().Be(1234);
-            settings.ConnectionString.Should().Be("b");
-            settings.TableName.Should().Be("c");
-            settings.TtlHeartbeatInterval.Should().Be(1.Seconds());
-            settings.StaleTtlThreshold.Should().Be(2.Seconds());
-            settings.PruneInterval.Should().Be(3.Seconds());
-            settings.OperationTimeout.Should().Be(4.Seconds());
-            settings.EffectiveStaleTtlThreshold.Should().Be(settings.StaleTtlThreshold);
-            settings.AzureTableEndpoint.Should().Be(uri);
-            settings.AzureAzureCredential.Should().Be(credential);
+            Assert.True(settings.ReadOnly);
+            Assert.Equal("a", settings.ServiceName);
+            Assert.Equal("host", settings.HostName);
+            Assert.Equal(1234, settings.Port);
+            Assert.Equal("b", settings.ConnectionString);
+            Assert.Equal("c", settings.TableName);
+            Assert.Equal(TimeSpan.FromSeconds(1), settings.TtlHeartbeatInterval);
+            Assert.Equal(TimeSpan.FromSeconds(2), settings.StaleTtlThreshold);
+            Assert.Equal(TimeSpan.FromSeconds(3), settings.PruneInterval);
+            Assert.Equal(TimeSpan.FromSeconds(4), settings.OperationTimeout);
+            Assert.Equal(settings.StaleTtlThreshold, settings.EffectiveStaleTtlThreshold);
+            Assert.Equal(uri, settings.AzureTableEndpoint);
+            Assert.Equal(credential, settings.AzureAzureCredential);
         }
 
         [Fact(DisplayName = "Settings constructor should throw on invalid values")]
@@ -135,29 +132,30 @@ namespace Akka.Discovery.Azure.Tests
         {
             var settings = AzureDiscoverySettings.Empty;
 
-            Invoking(() => settings.WithTtlHeartbeatInterval(TimeSpan.Zero))
-                .Should().ThrowExactly<ArgumentException>().WithMessage("Must be greater than zero*");
+            // converted from ThrowExactly + WithMessage glob "Must be greater than zero*"
+            Assert.StartsWith("Must be greater than zero",
+                Assert.Throws<ArgumentException>(() => { settings.WithTtlHeartbeatInterval(TimeSpan.Zero); }).Message);
 
-            Invoking(() => settings.WithPruneInterval(TimeSpan.Zero))
-                .Should().ThrowExactly<ArgumentException>().WithMessage("Must be greater than zero*");
+            Assert.StartsWith("Must be greater than zero",
+                Assert.Throws<ArgumentException>(() => { settings.WithPruneInterval(TimeSpan.Zero); }).Message);
 
-            Invoking(() => settings.WithStaleTtlThreshold(1.Seconds()))
-                .Should().ThrowExactly<ArgumentException>().WithMessage("Must be greater than*");
-            
-            Invoking(() => settings.WithPublicHostName(""))
-                .Should().ThrowExactly<ArgumentException>().WithMessage("Must not be empty or whitespace*");
-            
-            Invoking(() => settings.WithPublicPort(0))
-                .Should().ThrowExactly<ArgumentException>().WithMessage("Must be greater than zero and less than or equal to 65535*");
-            
-            Invoking(() => settings.WithPublicPort(65536))
-                .Should().ThrowExactly<ArgumentException>().WithMessage("Must be greater than zero and less than or equal to 65535*");
-            
-            Invoking(() => settings.WithRetryBackoff(TimeSpan.Zero, TimeSpan.FromSeconds(1)))
-                .Should().ThrowExactly<ArgumentException>().WithMessage("Must be greater than zero*");
-            
-            Invoking(() => settings.WithRetryBackoff(TimeSpan.FromSeconds(1), TimeSpan.Zero))
-                .Should().ThrowExactly<ArgumentException>().WithMessage("Must be greater than retryBackoff*");
+            Assert.StartsWith("Must be greater than",
+                Assert.Throws<ArgumentException>(() => { settings.WithStaleTtlThreshold(TimeSpan.FromSeconds(1)); }).Message);
+
+            Assert.StartsWith("Must not be empty or whitespace",
+                Assert.Throws<ArgumentException>(() => { settings.WithPublicHostName(""); }).Message);
+
+            Assert.StartsWith("Must be greater than zero and less than or equal to 65535",
+                Assert.Throws<ArgumentException>(() => { settings.WithPublicPort(0); }).Message);
+
+            Assert.StartsWith("Must be greater than zero and less than or equal to 65535",
+                Assert.Throws<ArgumentException>(() => { settings.WithPublicPort(65536); }).Message);
+
+            Assert.StartsWith("Must be greater than zero",
+                Assert.Throws<ArgumentException>(() => { settings.WithRetryBackoff(TimeSpan.Zero, TimeSpan.FromSeconds(1)); }).Message);
+
+            Assert.StartsWith("Must be greater than retryBackoff",
+                Assert.Throws<ArgumentException>(() => { settings.WithRetryBackoff(TimeSpan.FromSeconds(1), TimeSpan.Zero); }).Message);
         }
     }
 }

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/ClusterMemberEntitySpec.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/ClusterMemberEntitySpec.cs
@@ -8,8 +8,6 @@ using System;
 using System.Net;
 using Akka.Discovery.Azure.Model;
 using Akka.Discovery.Azure.Tests.Utils;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 // If anything throws InvalidOperationException, then the test failed anyway.
@@ -32,17 +30,17 @@ namespace Akka.Discovery.Azure.Tests
             var proto = ClusterMemberProto.Parser.ParseFrom(entity.GetBinary(ClusterMember.PayloadName));
             
             var created = proto.Created.ToDateTime();
-            created.Should().BeApproximately(DateTime.UtcNow, 200.Milliseconds());
-            entity.GetInt64(ClusterMember.LastUpdateName).Should().Be(created.Ticks);
+            created.BeApproximately(DateTime.UtcNow, TimeSpan.FromMilliseconds(200));
+            Assert.Equal(created.Ticks, entity.GetInt64(ClusterMember.LastUpdateName));
             
-            IPAddress.Parse(proto.Address).Should().Be(_address);
-            proto.Port.Should().Be(Port);
-            proto.Host.Should().Be(Host);
+            Assert.Equal(_address, IPAddress.Parse(proto.Address));
+            Assert.Equal(Port, proto.Port);
+            Assert.Equal(Host, proto.Host);
             
             
-            entity.PartitionKey.Should().Be(ServiceName);
-            entity.RowKey.Should().NotBeNullOrWhiteSpace();
-            entity.RowKey.Should().Be(ClusterMember.CreateRowKey(Host, _address, Port));
+            Assert.Equal(ServiceName, entity.PartitionKey);
+            Assert.False(string.IsNullOrWhiteSpace(entity.RowKey));
+            Assert.Equal(ClusterMember.CreateRowKey(Host, _address, Port), entity.RowKey);
         }
 
         [Fact(DisplayName = "Should be able to create ClusterMemberEntity from TableEntity")]
@@ -50,15 +48,15 @@ namespace Akka.Discovery.Azure.Tests
         {
             var entity = ClusterMember.FromEntity(ClusterMember.CreateEntity(ServiceName, Host, _address, Port));
             
-            entity.Created.Should().BeApproximately(DateTime.UtcNow, 200.Milliseconds());
-            entity.Created.Should().Be(entity.LastUpdate);
+            entity.Created.BeApproximately(DateTime.UtcNow, TimeSpan.FromMilliseconds(200));
+            Assert.Equal(entity.LastUpdate, entity.Created);
             
-            entity.PartitionKey.Should().Be(ServiceName);
-            entity.RowKey.Should().NotBeNullOrWhiteSpace();
-            entity.RowKey.Should().Be(ClusterMember.CreateRowKey(Host, _address, Port));
-            entity.Host.Should().Be(Host);
-            entity.Address.Should().Be(_address);
-            entity.Port.Should().Be(Port);
+            Assert.Equal(ServiceName, entity.PartitionKey);
+            Assert.False(string.IsNullOrWhiteSpace(entity.RowKey));
+            Assert.Equal(ClusterMember.CreateRowKey(Host, _address, Port), entity.RowKey);
+            Assert.Equal(Host, entity.Host);
+            Assert.Equal(_address, entity.Address);
+            Assert.Equal(Port, entity.Port);
         }
 
         [Fact(DisplayName = "Should create and parse RowKey properly")]
@@ -67,9 +65,9 @@ namespace Akka.Discovery.Azure.Tests
             var rowKey = ClusterMember.CreateRowKey(Host, _address, Port);
             var (host, address, port) = ClusterMember.ParseRowKey(rowKey);
 
-            host.Should().Be(Host);
-            address.Should().Be(_address);
-            port.Should().Be(Port);
+            Assert.Equal(Host, host);
+            Assert.Equal(_address, address);
+            Assert.Equal(Port, port);
         }
     }
 }

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/ClusterMemberTableClientSpec.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/ClusterMemberTableClientSpec.cs
@@ -13,10 +13,7 @@ using Akka.Discovery.Azure.Model;
 using Akka.Discovery.Azure.Tests.Utils;
 using Akka.Event;
 using Azure.Data.Tables;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
-using static FluentAssertions.FluentActions;
 
 namespace Akka.Discovery.Azure.Tests
 {
@@ -74,10 +71,10 @@ namespace Akka.Discovery.Azure.Tests
             {
                 entries.Add(entry);
             }
-            entries.Count.Should().Be(1);
+            Assert.Equal(1, entries.Count);
 
             var tableEntity = ClusterMember.FromEntity(entries[0]);
-            entity.Should().Be(tableEntity);
+            Assert.Equal(tableEntity, entity);
         }
 
         [Fact(DisplayName = "GetOrCreateAsync should fetch existing entry and updates LastUpdate")]
@@ -89,7 +86,7 @@ namespace Akka.Discovery.Azure.Tests
             // GetOrCreateAsync SHOULD update this value during fetch.
             var entity = await _client.GetOrCreateAsync(Host, _address, FirstPort);
             var now = DateTime.UtcNow;
-            entity.LastUpdate.Should().BeApproximately(now, 1.Seconds());
+            entity.LastUpdate.BeApproximately(now, TimeSpan.FromSeconds(1));
         }
 
         
@@ -101,15 +98,15 @@ namespace Akka.Discovery.Azure.Tests
             // initialize internal cache, this also updates the entry
             await _client.GetOrCreateAsync(Host, _address, FirstPort);
             
-            var lastUpdate = DateTime.UtcNow - 20.Seconds();
+            var lastUpdate = DateTime.UtcNow - TimeSpan.FromSeconds(20);
             // Grab all entries from the correct service
             var entries = await _client.GetAllAsync(lastUpdate.Ticks);
             
-            entries.Count.Should().Be(4);
+            Assert.Equal(4, entries.Count);
             foreach (var entry in entries)
             {
-                entry.ServiceName.Should().Be(ServiceName);
-                entry.LastUpdate.Should().BeAfter(lastUpdate);
+                Assert.Equal(ServiceName, entry.ServiceName);
+                Assert.True(entry.LastUpdate > lastUpdate);
             }
         }
 
@@ -122,13 +119,13 @@ namespace Akka.Discovery.Azure.Tests
             await _client.GetOrCreateAsync(Host, _address, FirstPort);
 
             // update should also update the table entry
-            await Awaiting(async () => await _client.UpdateAsync())
-                .Should().NotThrowAsync();
+            var updateException = await Record.ExceptionAsync(async () => await _client.UpdateAsync());
+            Assert.Null(updateException);
 
             // Retrieve the entry directly from the table and check LastUpdate value
             var entry = await _client.GetEntityAsync(ClusterMember.CreateRowKey(Host, _address, FirstPort), default);
-            entry.Should().NotBeNull();
-            entry!.LastUpdate.Should().BeApproximately(DateTime.UtcNow, 500.Milliseconds());
+            Assert.NotNull(entry);
+            entry!.LastUpdate.BeApproximately(DateTime.UtcNow, TimeSpan.FromMilliseconds(500));
         }
 
         [Fact(DisplayName = "PruneAsync should prunes entries and only on proper service name")]
@@ -139,9 +136,9 @@ namespace Akka.Discovery.Azure.Tests
             // populate the internal cache, this also updates the entry
             await _client.GetOrCreateAsync(Host, _address, FirstPort);
 
-            var lastUpdate = DateTime.UtcNow - 10.Minutes();
-            await Awaiting(async () => await _client.PruneAsync(lastUpdate.Ticks))
-                .Should().NotThrowAsync();
+            var lastUpdate = DateTime.UtcNow - TimeSpan.FromMinutes(10);
+            var pruneException = await Record.ExceptionAsync(async () => await _client.PruneAsync(lastUpdate.Ticks));
+            Assert.Null(pruneException);
 
             // Grab all entries via the raw client
             var entries = new List<TableEntity>();
@@ -151,15 +148,15 @@ namespace Akka.Discovery.Azure.Tests
             }
             
             // entries should contain 10 items, 4 valid entries and 6 entries from other service
-            entries.Count.Should().Be(10);
-            entries.Count(e => e.PartitionKey == ServiceName).Should().Be(4);
-            entries.Count(e => e.PartitionKey != ServiceName).Should().Be(6);
+            Assert.Equal(10, entries.Count);
+            Assert.Equal(4, entries.Count(e => e.PartitionKey == ServiceName));
+            Assert.Equal(6, entries.Count(e => e.PartitionKey != ServiceName));
             
             // entries with correct service name should have its LastUpdate correctly pruned
             foreach (var entry in entries.Where(e => e.PartitionKey == ServiceName))
             {
                 var entity = ClusterMember.FromEntity(entry);
-                entity.LastUpdate.Should().BeAfter(lastUpdate);
+                Assert.True(entity.LastUpdate > lastUpdate);
             }
         }
         
@@ -170,23 +167,23 @@ namespace Akka.Discovery.Azure.Tests
             var add = TableTransactionActionType.Add;
             
             // add 3 entries in the past
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 4.Hours()))); // This is the test actual entry
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 3.Hours())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 2.Hours())));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromHours(4)))); // This is the test actual entry
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromHours(3))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromHours(2))));
             
             // add 3 valid entries 
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 5.Seconds())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - 3.Seconds())));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromSeconds(5))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now - TimeSpan.FromSeconds(3))));
             batch.Add(new TableTransactionAction(add, CreateEntity(ServiceName, now)));
             
             // add 3 entries from different service name in the past
-            batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now - 4.Hours())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now - 3.Hours())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now - 2.Hours())));
+            batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now - TimeSpan.FromHours(4))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now - TimeSpan.FromHours(3))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now - TimeSpan.FromHours(2))));
             
             // add 3 valid entries from different service name
-            batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now - 5.Seconds())));
-            batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now - 3.Seconds())));
+            batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now - TimeSpan.FromSeconds(5))));
+            batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now - TimeSpan.FromSeconds(3))));
             batch.Add(new TableTransactionAction(add, CreateEntity(WrongService, now)));
 
             await _rawClient.CreateIfNotExistsAsync();

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/HostingSpecs.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/HostingSpecs.cs
@@ -14,8 +14,6 @@ using Akka.Hosting;
 using Akka.Management;
 using Akka.Management.Cluster.Bootstrap;
 using Akka.Remote.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -93,7 +91,7 @@ namespace Akka.Discovery.Azure.Tests
             var cluster = Cluster.Cluster.Get(system);
             cluster.RegisterOnMemberUp(() => { tcs.SetResult(Done.Instance); });
 
-            await tcs.Task.WaitAsync(30.Seconds());
+            await tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         public static readonly TheoryData<Func<string, AkkaConfigurationBuilder, AkkaConfigurationBuilder>> Startups =

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/Utils/XunitExtensions.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/Utils/XunitExtensions.cs
@@ -1,24 +1,24 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="XunitExtensions.cs" company="Akka.NET Project">
 //      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
 //  </copyright>
 // -----------------------------------------------------------------------
 
 using System;
-using FluentAssertions;
-using FluentAssertions.Primitives;
+using Xunit;
 
 namespace Akka.Discovery.Azure.Tests.Utils
 {
     public static class XunitExtensions
     {
-        public static AndConstraint<DateTimeAssertions> BeApproximately(
-            this DateTimeAssertions assertion, 
-            DateTime expected, 
+        // converted from a BeAfter(expected - epsilon) + BeBefore(expected + epsilon) assertion (strict bounds)
+        public static void BeApproximately(
+            this DateTime subject,
+            DateTime expected,
             TimeSpan epsilon)
         {
-            assertion.Subject.Should().BeAfter(expected - epsilon).And.BeBefore(expected + epsilon);
-            return new AndConstraint<DateTimeAssertions>(assertion);
+            Assert.True(subject > expected - epsilon);
+            Assert.True(subject < expected + epsilon);
         }
     }
 }

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/AkkaHostingSpec.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/AkkaHostingSpec.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
@@ -40,12 +39,12 @@ namespace Akka.Discovery.KubernetesApi.Tests
             var system = host.Services.GetRequiredService<ActorSystem>();
                 
             var settings = KubernetesDiscovery.Get(system).Settings;
-            settings.PodNamespace.Should().Be("underTest");
+            Assert.Equal("underTest", settings.PodNamespace);
                 
-            system.Settings.Config.GetString("akka.discovery.method").Should().Be("kubernetes-api");
+            Assert.Equal("kubernetes-api", system.Settings.Config.GetString("akka.discovery.method"));
             
             var config = system.Settings.Config.GetConfig("akka.discovery.kubernetes-api");
-            config.Should().NotBeNull();
+            Assert.NotNull(config);
         }
     }
 }

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/KubernetesApiServiceDiscoverySpec.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/KubernetesApiServiceDiscoverySpec.cs
@@ -8,10 +8,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Akka.Actor;
-using FluentAssertions;
 using k8s.Models;
 using Xunit;
 
@@ -58,13 +58,16 @@ namespace Akka.Discovery.KubernetesApi.Tests
 
             var result =
                 KubernetesApiServiceDiscovery.Targets(podList, "management", "default", "cluster.local", false, null);
-            result.Should().BeEquivalentTo(new List<ServiceDiscovery.ResolvedTarget>
-            {
-                new ServiceDiscovery.ResolvedTarget(
-                    host: "172-17-0-4.default.pod.cluster.local",
-                    port: 10001,
-                    address: IPAddress.Parse("172.17.0.4"))
-            });
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(
+                new List<ServiceDiscovery.ResolvedTarget>
+                {
+                    new ServiceDiscovery.ResolvedTarget(
+                        host: "172-17-0-4.default.pod.cluster.local",
+                        port: 10001,
+                        address: IPAddress.Parse("172.17.0.4"))
+                }.OrderBy(t => t.Host),
+                result.OrderBy(t => t.Host));
         }
 
         [Fact(DisplayName = "Issue #223: Targets should ignore containers with IP with no ports if port name is queried")]
@@ -120,13 +123,16 @@ namespace Akka.Discovery.KubernetesApi.Tests
 
             var result =
                 KubernetesApiServiceDiscovery.Targets(podList, "management", "default", "cluster.local", false, "akka-cluster-tooling-example");
-            result.Should().BeEquivalentTo(new List<ServiceDiscovery.ResolvedTarget>
-            {
-                new ServiceDiscovery.ResolvedTarget(
-                    host: "172-17-0-4.default.pod.cluster.local",
-                    port: 10001,
-                    address: IPAddress.Parse("172.17.0.4"))
-            });
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(
+                new List<ServiceDiscovery.ResolvedTarget>
+                {
+                    new ServiceDiscovery.ResolvedTarget(
+                        host: "172-17-0-4.default.pod.cluster.local",
+                        port: 10001,
+                        address: IPAddress.Parse("172.17.0.4"))
+                }.OrderBy(t => t.Host),
+                result.OrderBy(t => t.Host));
         }
         
         [Fact(DisplayName = "Targets should ignore deleted pods")]
@@ -150,9 +156,9 @@ namespace Akka.Discovery.KubernetesApi.Tests
 
             var result =
                 KubernetesApiServiceDiscovery.Targets(podList, "management", "default", "cluster.local", false, null);
-            result.Should().BeEquivalentTo(new List<ServiceDiscovery.ResolvedTarget>());
+            Assert.Empty(result); // converted from BeEquivalentTo(new List<ResolvedTarget>())
         }
-        
+
         // This test allows users to not declare the management port in their container spec,
         // which is not only convenient, it also is required in Istio where ports declared
         // in the container spec are redirected through Envoy, and in Knative, where only
@@ -204,21 +210,24 @@ namespace Akka.Discovery.KubernetesApi.Tests
 
             var result =
                 KubernetesApiServiceDiscovery.Targets(podList, null, "default", "cluster.local", false, null);
-            result.Should().BeEquivalentTo(new List<ServiceDiscovery.ResolvedTarget>
-            {
-                new ServiceDiscovery.ResolvedTarget(
-                    host: "172-17-0-4.default.pod.cluster.local",
-                    port: null,
-                    address: IPAddress.Parse("172.17.0.4")),
-                new ServiceDiscovery.ResolvedTarget(
-                    host: "172-17-0-5.default.pod.cluster.local",
-                    port: null,
-                    address: IPAddress.Parse("172.17.0.5")),
-                new ServiceDiscovery.ResolvedTarget(
-                    host: "172-17-0-6.default.pod.cluster.local",
-                    port: null,
-                    address: IPAddress.Parse("172.17.0.6")),
-            });
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(
+                new List<ServiceDiscovery.ResolvedTarget>
+                {
+                    new ServiceDiscovery.ResolvedTarget(
+                        host: "172-17-0-4.default.pod.cluster.local",
+                        port: null,
+                        address: IPAddress.Parse("172.17.0.4")),
+                    new ServiceDiscovery.ResolvedTarget(
+                        host: "172-17-0-5.default.pod.cluster.local",
+                        port: null,
+                        address: IPAddress.Parse("172.17.0.5")),
+                    new ServiceDiscovery.ResolvedTarget(
+                        host: "172-17-0-6.default.pod.cluster.local",
+                        port: null,
+                        address: IPAddress.Parse("172.17.0.6")),
+                }.OrderBy(t => t.Host),
+                result.OrderBy(t => t.Host));
         }
 
         [Fact(DisplayName = "Targets should ignore non-running pods")]
@@ -242,9 +251,9 @@ namespace Akka.Discovery.KubernetesApi.Tests
 
             var result =
                 KubernetesApiServiceDiscovery.Targets(podList, "management", "default", "cluster.local", false, null);
-            result.Should().BeEquivalentTo(new List<ServiceDiscovery.ResolvedTarget>());
+            Assert.Empty(result); // converted from BeEquivalentTo(new List<ResolvedTarget>())
         }
-        
+
         [Fact(DisplayName = "Targets should ignore running pods where the container is waiting")]
         public void IgnoreRunningPodsWhereContainerIsWaiting()
         {
@@ -255,30 +264,32 @@ namespace Akka.Discovery.KubernetesApi.Tests
             var podList = KubernetesJson.Deserialize<V1PodList>(json);
 #endif
 
-            KubernetesApiServiceDiscovery.Targets(
-                podList, 
+            // converted from BeEquivalentTo(new List<ResolvedTarget>())
+            Assert.Empty(KubernetesApiServiceDiscovery.Targets(
+                podList,
                 null,
                 "b58dbc88-3651-4fb4-8408-60c375592d1d",
                 "cluster.local",
-                false, 
-                "cloudstate-sidecar")
-                .Should().BeEquivalentTo(new List<ServiceDiscovery.ResolvedTarget>());
-            
+                false,
+                "cloudstate-sidecar"));
+
             // Nonsense for this example data, but to check we do find the other containers:
-            KubernetesApiServiceDiscovery.Targets(
-                    podList, 
-                    null,
-                    "b58dbc88-3651-4fb4-8408-60c375592d1d",
-                    "cluster.local",
-                    false, 
-                    "user-function")
-                .Should().BeEquivalentTo(new List<ServiceDiscovery.ResolvedTarget>
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(
+                new List<ServiceDiscovery.ResolvedTarget>
                 {
                     new ServiceDiscovery.ResolvedTarget(
                         host: "10-8-7-9.b58dbc88-3651-4fb4-8408-60c375592d1d.pod.cluster.local",
                         port: null,
                         address: IPAddress.Parse("10.8.7.9"))
-                });
+                }.OrderBy(t => t.Host),
+                KubernetesApiServiceDiscovery.Targets(
+                    podList,
+                    null,
+                    "b58dbc88-3651-4fb4-8408-60c375592d1d",
+                    "cluster.local",
+                    false,
+                    "user-function").OrderBy(t => t.Host));
         }
 
         [Fact(DisplayName = "Targets should use a ip instead of the host if requested")]
@@ -302,13 +313,16 @@ namespace Akka.Discovery.KubernetesApi.Tests
 
             var result =
                 KubernetesApiServiceDiscovery.Targets(podList, "management", "default", "cluster.local", true, null);
-            result.Should().BeEquivalentTo(new List<ServiceDiscovery.ResolvedTarget>
-            {
-                new ServiceDiscovery.ResolvedTarget(
-                    host: "172.17.0.4",
-                    port: 10001,
-                    address: IPAddress.Parse("172.17.0.4"))
-            });
+            // converted from BeEquivalentTo (order-insensitive)
+            Assert.Equal(
+                new List<ServiceDiscovery.ResolvedTarget>
+                {
+                    new ServiceDiscovery.ResolvedTarget(
+                        host: "172.17.0.4",
+                        port: 10001,
+                        address: IPAddress.Parse("172.17.0.4"))
+                }.OrderBy(t => t.Host),
+                result.OrderBy(t => t.Host));
         }
 
         [Fact(DisplayName = "The discovery loading mechanism should allow loading kubernetes-api discovery even if it is not the default")]
@@ -318,7 +332,7 @@ namespace Akka.Discovery.KubernetesApi.Tests
             
             // kubernetes-api-discovery
             var discovery = Discovery.Get(sys).LoadServiceDiscovery("kubernetes-api");
-            discovery.Should().BeOfType<KubernetesApiServiceDiscovery>();
+            Assert.IsType<KubernetesApiServiceDiscovery>(discovery);
             await sys.Terminate();
         }
 

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/KubernetesDiscoverySettingsSpec.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/KubernetesDiscoverySettingsSpec.cs
@@ -8,9 +8,7 @@
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Configuration;
-using FluentAssertions;
 using Xunit;
-using static FluentAssertions.FluentActions;
 
 namespace Akka.Discovery.KubernetesApi.Tests
 {
@@ -22,17 +20,17 @@ namespace Akka.Discovery.KubernetesApi.Tests
             var settings = KubernetesDiscoverySettings.Create(KubernetesDiscovery.DefaultConfiguration()
                 .GetConfig("akka.discovery.kubernetes-api"));
 
-            settings.ApiCaPath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt");
-            settings.ApiTokenPath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/token");
-            settings.ApiServiceHostEnvName.Should().Be("KUBERNETES_SERVICE_HOST");
-            settings.ApiServicePortEnvName.Should().Be("KUBERNETES_SERVICE_PORT");
-            settings.PodNamespacePath.Should().Be("/var/run/secrets/kubernetes.io/serviceaccount/namespace");
-            settings.PodNamespace.Should().BeNull();
-            settings.AllNamespaces.Should().BeFalse();
-            settings.PodDomain.Should().Be("cluster.local");
-            settings.PodLabelSelector("a").Should().Be("app=a");
-            settings.RawIp.Should().BeTrue();
-            settings.ContainerName.Should().BeNull();
+            Assert.Equal("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt", settings.ApiCaPath);
+            Assert.Equal("/var/run/secrets/kubernetes.io/serviceaccount/token", settings.ApiTokenPath);
+            Assert.Equal("KUBERNETES_SERVICE_HOST", settings.ApiServiceHostEnvName);
+            Assert.Equal("KUBERNETES_SERVICE_PORT", settings.ApiServicePortEnvName);
+            Assert.Equal("/var/run/secrets/kubernetes.io/serviceaccount/namespace", settings.PodNamespacePath);
+            Assert.Null(settings.PodNamespace);
+            Assert.False(settings.AllNamespaces);
+            Assert.Equal("cluster.local", settings.PodDomain);
+            Assert.Equal("app=a", settings.PodLabelSelector("a"));
+            Assert.True(settings.RawIp);
+            Assert.Null(settings.ContainerName);
         }
 
         [Fact(DisplayName = "Empty settings should contain default values")]
@@ -42,17 +40,17 @@ namespace Akka.Discovery.KubernetesApi.Tests
             var settings = KubernetesDiscoverySettings.Create(KubernetesDiscovery.DefaultConfiguration()
                 .GetConfig("akka.discovery.kubernetes-api"));
 
-            empty.ApiCaPath.Should().Be(settings.ApiCaPath);
-            empty.ApiTokenPath.Should().Be(settings.ApiTokenPath);
-            empty.ApiServiceHostEnvName.Should().Be(settings.ApiServiceHostEnvName);
-            empty.ApiServicePortEnvName.Should().Be(settings.ApiServicePortEnvName);
-            empty.PodNamespacePath.Should().Be(settings.PodNamespacePath);
-            empty.PodNamespace.Should().Be(settings.PodNamespace);
-            empty.AllNamespaces.Should().Be(settings.AllNamespaces);
-            empty.PodDomain.Should().Be(settings.PodDomain);
-            empty.PodLabelSelector("a").Should().Be(settings.PodLabelSelector("a"));
-            empty.RawIp.Should().Be(settings.RawIp);
-            empty.ContainerName.Should().Be(settings.ContainerName);
+            Assert.Equal(settings.ApiCaPath, empty.ApiCaPath);
+            Assert.Equal(settings.ApiTokenPath, empty.ApiTokenPath);
+            Assert.Equal(settings.ApiServiceHostEnvName, empty.ApiServiceHostEnvName);
+            Assert.Equal(settings.ApiServicePortEnvName, empty.ApiServicePortEnvName);
+            Assert.Equal(settings.PodNamespacePath, empty.PodNamespacePath);
+            Assert.Equal(settings.PodNamespace, empty.PodNamespace);
+            Assert.Equal(settings.AllNamespaces, empty.AllNamespaces);
+            Assert.Equal(settings.PodDomain, empty.PodDomain);
+            Assert.Equal(settings.PodLabelSelector("a"), empty.PodLabelSelector("a"));
+            Assert.Equal(settings.RawIp, empty.RawIp);
+            Assert.Equal(settings.ContainerName, empty.ContainerName);
         }
 
         [Fact(DisplayName = "Settings With override must work")]
@@ -71,17 +69,17 @@ namespace Akka.Discovery.KubernetesApi.Tests
                 .WithRawIp(false)
                 .WithContainerName("i");
                 
-            settings.ApiCaPath.Should().Be("a");
-            settings.ApiTokenPath.Should().Be("b");
-            settings.ApiServiceHostEnvName.Should().Be("c");
-            settings.ApiServicePortEnvName.Should().Be("d");
-            settings.PodNamespacePath.Should().Be("e");
-            settings.PodNamespace.Should().Be("f");
-            settings.AllNamespaces.Should().BeTrue();
-            settings.PodDomain.Should().Be("g");
-            settings.PodLabelSelector("a").Should().Be("h=a");
-            settings.RawIp.Should().BeFalse();
-            settings.ContainerName.Should().Be("i");
+            Assert.Equal("a", settings.ApiCaPath);
+            Assert.Equal("b", settings.ApiTokenPath);
+            Assert.Equal("c", settings.ApiServiceHostEnvName);
+            Assert.Equal("d", settings.ApiServicePortEnvName);
+            Assert.Equal("e", settings.PodNamespacePath);
+            Assert.Equal("f", settings.PodNamespace);
+            Assert.True(settings.AllNamespaces);
+            Assert.Equal("g", settings.PodDomain);
+            Assert.Equal("h=a", settings.PodLabelSelector("a"));
+            Assert.False(settings.RawIp);
+            Assert.Equal("i", settings.ContainerName);
         }
 
         [Fact(DisplayName = "Setup override should work")]
@@ -103,17 +101,17 @@ namespace Akka.Discovery.KubernetesApi.Tests
             };
             var settings = setup.Apply(KubernetesDiscoverySettings.Empty);
                 
-            settings.ApiCaPath.Should().Be("a");
-            settings.ApiTokenPath.Should().Be("b");
-            settings.ApiServiceHostEnvName.Should().Be("c");
-            settings.ApiServicePortEnvName.Should().Be("d");
-            settings.PodNamespacePath.Should().Be("e");
-            settings.PodNamespace.Should().Be("f");
-            settings.AllNamespaces.Should().BeTrue();
-            settings.PodDomain.Should().Be("g");
-            settings.PodLabelSelector("a").Should().Be("h=a");
-            settings.RawIp.Should().BeFalse();
-            settings.ContainerName.Should().Be("i");
+            Assert.Equal("a", settings.ApiCaPath);
+            Assert.Equal("b", settings.ApiTokenPath);
+            Assert.Equal("c", settings.ApiServiceHostEnvName);
+            Assert.Equal("d", settings.ApiServicePortEnvName);
+            Assert.Equal("e", settings.PodNamespacePath);
+            Assert.Equal("f", settings.PodNamespace);
+            Assert.True(settings.AllNamespaces);
+            Assert.Equal("g", settings.PodDomain);
+            Assert.Equal("h=a", settings.PodLabelSelector("a"));
+            Assert.False(settings.RawIp);
+            Assert.Equal("i", settings.ContainerName);
         }
         
         [Fact(DisplayName = "Setup override should work inside the module")]
@@ -139,17 +137,17 @@ namespace Akka.Discovery.KubernetesApi.Tests
             {
                 var settings = KubernetesDiscovery.Get(sys).Settings;
                 
-                settings.ApiCaPath.Should().Be("a");
-                settings.ApiTokenPath.Should().Be("b");
-                settings.ApiServiceHostEnvName.Should().Be("c");
-                settings.ApiServicePortEnvName.Should().Be("d");
-                settings.PodNamespacePath.Should().Be("e");
-                settings.PodNamespace.Should().Be("f");
-                settings.AllNamespaces.Should().BeTrue();
-                settings.PodDomain.Should().Be("g");
-                settings.PodLabelSelector("a").Should().Be("h=a");
-                settings.RawIp.Should().BeFalse();
-                settings.ContainerName.Should().Be("i");
+                Assert.Equal("a", settings.ApiCaPath);
+                Assert.Equal("b", settings.ApiTokenPath);
+                Assert.Equal("c", settings.ApiServiceHostEnvName);
+                Assert.Equal("d", settings.ApiServicePortEnvName);
+                Assert.Equal("e", settings.PodNamespacePath);
+                Assert.Equal("f", settings.PodNamespace);
+                Assert.True(settings.AllNamespaces);
+                Assert.Equal("g", settings.PodDomain);
+                Assert.Equal("h=a", settings.PodLabelSelector("a"));
+                Assert.False(settings.RawIp);
+                Assert.Equal("i", settings.ContainerName);
             }
         }
     }


### PR DESCRIPTION
**Part 2 of 3** of removing FluentAssertions. Migrates the **Discovery (AWS / Azure / Kubernetes)** and **Coordination (Azure / Kubernetes)** test projects to native xUnit `Assert.*`.

### Scope — 23 files, 474 converted call sites
- `src/coordination/azure/**` (6), `src/coordination/kubernetes/**` (4)
- `src/discovery/aws/**` (4), `src/discovery/azure/**` (6), `src/discovery/kubernetes/**` (3)

Only assertion calls changed. `FluentAssertions.Extensions` timing sugar → `TimeSpan.From*`; the three **Humanizer**-based files correctly keep `using Humanizer;` (that's Humanizer, not FA). The custom `BeApproximately` test helper was re-implemented on native `Assert` with its strict bounds preserved.

### Semantic equivalence — independently verified
Conversion and review were done by **separate agents**. The adversarial reviewer audited all 474 sites, "not equivalent until proven":

- **0 blocking findings.**
- **Dropped-assertion reconciliation:** 474 removed `.Should()` → **496** native assertions; every file's added ≥ removed. The +22 surplus is compound FA assertions split into multiple `Assert` calls (18 throw+message splits, 2 invalid-timeout throw+message, 1 task-equality chain, 1 helper-body split). **No assertion dropped.**
- **`BeEquivalentTo` (order-insensitive)** → sorted `Assert.Equal`; the EC2 `Filter` case (no value equality) via a `(Name, sorted-Values)` projection, and `ResolvedTarget` via its verified `IEquatable` members — both confirmed faithful against the **actual** test data (unique keys, total sort, no delimiter collisions).
- **Glob `WithMessage`** → `StartsWith`/`Contains`, verified against the real thrown messages (all `prefix*` or `*substr*`, no interior-`*` reductions).
- Exact-type throws, `NotThrow`→`Record.Exception`, `Assert.Equal` expected-first order, and the vacuous `ETag` `NotBeNull` no-op all verified equivalent.

### Tests — green on net10.0 (locally runnable projects)
AwsApi 42/42 · Discovery.Azure 18/18 (Azurite) · Discovery.K8s 14/14 · Coordination.Azure 54/54 (1 skip) · Coordination.K8s 54/54 (1 skip). (AwsApi.Integration.Tests compiles; it's AWS-creds-gated, so CI covers it.)

### Follow-up noted (not fixed here — out of scope for an equivalence-only migration)
The Azure discovery *"empty vs default settings"* spec compares two fields (`AzureTableEndpoint`, credential) to **themselves** instead of to `empty` — a vacuous no-op carried over verbatim from the original FA code. Worth a separate fix.

FluentAssertions is removed from `Directory.Packages.props` in part 3, once the last projects are migrated.
