### PR TITLE
Migrate Management + DNS tests to xUnit Assert and remove FluentAssertions (3/3)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
     <Xunit3Version>3.2.2</Xunit3Version>
     <XUnitRunnerVersion>3.1.5</XUnitRunnerVersion>
     <CoverletVersion>10.0.1</CoverletVersion>
-    <FluentAssertionVersion>7.0.0</FluentAssertionVersion>
     <TestSdkVersion>17.13.0</TestSdkVersion>
     <WireMockVersion>1.8.4</WireMockVersion>
     <AkkaVersion>1.5.70</AkkaVersion>
@@ -94,7 +93,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageVersion Include="coverlet.collector" Version="$(CoverletVersion)" />
-    <PackageVersion Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
     <PackageVersion Include="WireMock.Net" Version="$(WireMockVersion)" />
     <PackageVersion Include="Testcontainers.Azurite" Version="4.4.0" />
     <PackageVersion Include="Testcontainers.LocalStack" Version="4.4.0" />

--- a/src/aspire/Akka.Aspire.Hosting.Tests/Akka.Aspire.Hosting.Tests.csproj
+++ b/src/aspire/Akka.Aspire.Hosting.Tests/Akka.Aspire.Hosting.Tests.csproj
@@ -8,7 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Aspire.Hosting.AppHost" />
         <PackageReference Include="Aspire.Hosting.Redis" />

--- a/src/aspire/Akka.Aspire.Tests/Akka.Aspire.Tests.csproj
+++ b/src/aspire/Akka.Aspire.Tests/Akka.Aspire.Tests.csproj
@@ -12,7 +12,6 @@
         <PackageReference Include="Akka.Hosting.TestKit" />
         <PackageReference Include="Akka.Cluster.Hosting" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/Akka.Coordination.Azure.Tests.csproj
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/Akka.Coordination.Azure.Tests.csproj
@@ -10,7 +10,6 @@
         <PackageReference Include="Akka.Hosting.TestKit" />
         <PackageReference Include="Akka.Cluster.Tools" />
         <PackageReference Include="Akka.TestKit.Xunit" />
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Testcontainers.Azurite" />
         <PackageReference Include="WireMock.Net" />

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/Akka.Coordination.KubernetesApi.Tests.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/Akka.Coordination.KubernetesApi.Tests.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit" />
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="WireMock.Net" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/Akka.Discovery.AwsApi.Integration.Tests.csproj
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/Akka.Discovery.AwsApi.Integration.Tests.csproj
@@ -13,7 +13,6 @@
         <PackageReference Include="AWSSDK.CloudFormation" />
         <PackageReference Include="AWSSDK.S3" />
         <PackageReference Include="Docker.DotNet" />
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Testcontainers.LocalStack" />
         <PackageReference Include="xunit.v3" />

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Akka.Discovery.AwsApi.Tests.csproj
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Akka.Discovery.AwsApi.Tests.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/Akka.Discovery.Azure.Tests.csproj
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/Akka.Discovery.Azure.Tests.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
         <PackageReference Include="Akka.Cluster.Hosting" />
         <PackageReference Include="Akka.TestKit.Xunit" />
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="Testcontainers.Azurite" />

--- a/src/discovery/dns/Akka.Discovery.Dns.Tests/Akka.Discovery.Dns.Tests.csproj
+++ b/src/discovery/dns/Akka.Discovery.Dns.Tests/Akka.Discovery.Dns.Tests.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Akka.TestKit.Xunit" />
         <PackageReference Include="xunit.v3" />

--- a/src/discovery/dns/Akka.Discovery.Dns.Tests/AsyncDnsManagerSpec.cs
+++ b/src/discovery/dns/Akka.Discovery.Dns.Tests/AsyncDnsManagerSpec.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using Akka.Discovery.Dns.Internal;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Discovery.Dns.Tests;
@@ -13,9 +12,9 @@ public class AsyncDnsManagerSpec {
     {
         var result = AsyncDnsManager.ParseEndPoint("192.168.1.1:53");
         var ipEndPoint = result as IPEndPoint;
-        ipEndPoint.Should().NotBeNull();
-        ipEndPoint!.Address.ToString().Should().Be("192.168.1.1");
-        ipEndPoint.Port.Should().Be(53);
+        Assert.NotNull(ipEndPoint);
+        Assert.Equal("192.168.1.1", ipEndPoint!.Address.ToString());
+        Assert.Equal(53, ipEndPoint.Port);
     }
 
     [Fact]
@@ -23,11 +22,11 @@ public class AsyncDnsManagerSpec {
     {
         var result = AsyncDnsManager.ParseEndPoint("1dot1dot1dot1.cloudflare-dns.com:53");
         var ipEndPoint = result as IPEndPoint;
-        ipEndPoint.Should().NotBeNull();
+        Assert.NotNull(ipEndPoint);
         //can be 1.0.0.1 or 1.1.1.1
-        ipEndPoint!.Address.ToString().Should().StartWith("1.");
-        ipEndPoint!.Address.ToString().Should().EndWith(".1");
-        ipEndPoint.Port.Should().Be(53);
+        Assert.StartsWith("1.", ipEndPoint!.Address.ToString(), StringComparison.Ordinal);
+        Assert.EndsWith(".1", ipEndPoint!.Address.ToString(), StringComparison.Ordinal);
+        Assert.Equal(53, ipEndPoint.Port);
     }
 
     [Fact]
@@ -35,11 +34,11 @@ public class AsyncDnsManagerSpec {
     {
         var result = AsyncDnsManager.ParseEndPoint("1dot1dot1dot1.cloudflare-dns.com");
         var ipEndPoint = result as IPEndPoint;
-        ipEndPoint.Should().NotBeNull();
+        Assert.NotNull(ipEndPoint);
         //can be 1.0.0.1 or 1.1.1.1
-        ipEndPoint!.Address.ToString().Should().StartWith("1.");
-        ipEndPoint!.Address.ToString().Should().EndWith(".1");
-        ipEndPoint.Port.Should().Be(53); // Default port is now 53
+        Assert.StartsWith("1.", ipEndPoint!.Address.ToString(), StringComparison.Ordinal);
+        Assert.EndsWith(".1", ipEndPoint!.Address.ToString(), StringComparison.Ordinal);
+        Assert.Equal(53, ipEndPoint.Port); // Default port is now 53
     }
     
     [Fact]
@@ -47,9 +46,9 @@ public class AsyncDnsManagerSpec {
     {
         var result = AsyncDnsManager.ParseEndPoint("[2001:db8:1::2]:53");
         var ipEndPoint = result as IPEndPoint;
-        ipEndPoint.Should().NotBeNull();
-        ipEndPoint!.Address.ToString().Should().Be("2001:db8:1::2");
-        ipEndPoint.Port.Should().Be(53);
+        Assert.NotNull(ipEndPoint);
+        Assert.Equal("2001:db8:1::2", ipEndPoint!.Address.ToString());
+        Assert.Equal(53, ipEndPoint.Port);
     }
 
     [Fact]
@@ -81,9 +80,9 @@ public class AsyncDnsManagerSpec {
     {
         var result = AsyncDnsManager.ParseEndPoint("2001:db8:1::2");
         var ipEndPoint = result as IPEndPoint;
-        ipEndPoint.Should().NotBeNull();
-        ipEndPoint!.Address.ToString().Should().Be("2001:db8:1::2");
-        ipEndPoint.Port.Should().Be(53); // Default port is now 53
+        Assert.NotNull(ipEndPoint);
+        Assert.Equal("2001:db8:1::2", ipEndPoint!.Address.ToString());
+        Assert.Equal(53, ipEndPoint.Port); // Default port is now 53
     }
 
     [Fact]
@@ -91,9 +90,9 @@ public class AsyncDnsManagerSpec {
     {
         var result = AsyncDnsManager.ParseEndPoint("192.168.1.1");
         var ipEndPoint = result as IPEndPoint;
-        ipEndPoint.Should().NotBeNull();
-        ipEndPoint.Address.ToString().Should().Be("192.168.1.1");
-        ipEndPoint.Port.Should().Be(53);
+        Assert.NotNull(ipEndPoint);
+        Assert.Equal("192.168.1.1", ipEndPoint.Address.ToString());
+        Assert.Equal(53, ipEndPoint.Port);
     }
 
 }

--- a/src/discovery/dns/Akka.Discovery.Dns.Tests/DnsServiceDiscoverySpec.cs
+++ b/src/discovery/dns/Akka.Discovery.Dns.Tests/DnsServiceDiscoverySpec.cs
@@ -12,7 +12,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Discovery.Dns.Internal;
 using Akka.IO;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Discovery.Dns.Tests;
@@ -171,7 +170,7 @@ public abstract class DnsServiceDiscoveryBaseSpec(Configuration.Config config , 
     public void DnsServiceDiscoveryShouldBeLoadableViaConfig()
     {
         var serviceDiscovery = Discovery.Get(Sys).LoadServiceDiscovery("akka-dns");
-        serviceDiscovery.Should().BeOfType<Dns.DnsServiceDiscovery>();
+        Assert.IsType<Dns.DnsServiceDiscovery>(serviceDiscovery);
     }
 
     [Theory(DisplayName = "DnsServiceDiscovery should handle SRV lookup with real DNS")]
@@ -187,7 +186,7 @@ public abstract class DnsServiceDiscoveryBaseSpec(Configuration.Config config , 
         var lookup = new Lookup(serviceName, portName, protocol);
         var resolved = await serviceDiscovery.Lookup(lookup, TimeSpan.FromSeconds(60));
 
-        resolved.Addresses.Count.Should().BeGreaterThan(0, $"No SRV records found for {description}.");
+        Assert.True(resolved.Addresses.Count > 0, $"No SRV records found for {description}.");
         // Log information for diagnostic purposes
         Output.WriteLine($"Resolved targets: {resolved.Addresses.Count}");
         foreach (var addr in resolved.Addresses)
@@ -195,17 +194,17 @@ public abstract class DnsServiceDiscoveryBaseSpec(Configuration.Config config , 
             Output.WriteLine($"  Host: {addr.Host}, Address: {addr.Address}, Port: {addr.Port}");
         }
 
-        resolved.Addresses.Count.Should().BeGreaterThan(0, "At least one SRV record should be found");
+        Assert.True(resolved.Addresses.Count > 0, "At least one SRV record should be found");
         foreach (var address in resolved.Addresses)
         {
-            address.Host.Should().NotBeNullOrEmpty("Host should not be empty");
+            Assert.False(string.IsNullOrEmpty(address.Host), "Host should not be empty");
             if (serviceDiscovery.CanLookupSrv)
             {
-                address.Port.Should().BeGreaterThan(0, "Port should be specified for SRV lookup");
+                Assert.True(address.Port > 0, "Port should be specified for SRV lookup");
             }
             else
             {
-                address.Port.Should().BeNull( "Port should not be specified if resolver doesn't support SRV lookup");
+                Assert.True(address.Port is null, "Port should not be specified if resolver doesn't support SRV lookup");
             }
         }
     }
@@ -224,7 +223,7 @@ public abstract class DnsServiceDiscoveryBaseSpec(Configuration.Config config , 
         var lookup = new Lookup(serviceName);
         var resolved = await serviceDiscovery.Lookup(lookup, TimeSpan.FromSeconds(60));
 
-        resolved.Addresses.Count.Should().BeGreaterThan(0, $"No A/AAAA records found for {description}.");
+        Assert.True(resolved.Addresses.Count > 0, $"No A/AAAA records found for {description}.");
 
         // Log information for diagnostic purposes
         Output.WriteLine($"Resolved targets: {resolved.Addresses.Count}");
@@ -232,25 +231,25 @@ public abstract class DnsServiceDiscoveryBaseSpec(Configuration.Config config , 
         {
             Output.WriteLine($"  Host: {addr.Host}, Address: {addr.Address}, Port: {addr.Port}");
         }
-        
-        // skip this on windows for inet-resolver as it doesn't return AAAA 
+
+        // skip this on windows for inet-resolver as it doesn't return AAAA
         if (!DoNotExpectAAAARecordsFromInetResolver)
         {
-            resolved.Addresses
-                .Sum(x => x.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6 ? 1 : 0)
-                .Should().BeGreaterThan(0, "At least one IPv6 record should be found");
+            Assert.True(resolved.Addresses
+                .Sum(x => x.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6 ? 1 : 0) > 0,
+                "At least one IPv6 record should be found");
         }
 
-        resolved.Addresses
-            .Sum(x => x.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork ? 1 : 0)
-            .Should().BeGreaterThan(0, "At least one IPv4 record should be found");
+        Assert.True(resolved.Addresses
+            .Sum(x => x.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork ? 1 : 0) > 0,
+            "At least one IPv4 record should be found");
 
-        
-        resolved.Addresses.Count.Should().BeGreaterThan(0, "At least one SRV record should be found");
+
+        Assert.True(resolved.Addresses.Count > 0, "At least one SRV record should be found");
         foreach (var address in resolved.Addresses)
         {
-            address.Host.Should().NotBeNullOrEmpty("Host should not be empty");
-            address.Port.Should().BeNull( "Port should be specified for SRV lookup");
+            Assert.False(string.IsNullOrEmpty(address.Host), "Host should not be empty");
+            Assert.True(address.Port is null, "Port should be specified for SRV lookup");
         }
     }
 }

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/Akka.Discovery.KubernetesApi.Tests.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/Akka.Discovery.KubernetesApi.Tests.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="xunit.v3" />

--- a/src/discovery/redis/Akka.Discovery.Redis.Tests/Akka.Discovery.Redis.Tests.csproj
+++ b/src/discovery/redis/Akka.Discovery.Redis.Tests/Akka.Discovery.Redis.Tests.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
         <PackageReference Include="Akka.Cluster.Hosting" />
         <PackageReference Include="Akka.TestKit.Xunit" />
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="Testcontainers.Redis" />

--- a/src/management/Akka.Http.Shim.Tests/Akka.Http.Shim.Tests.csproj
+++ b/src/management/Akka.Http.Shim.Tests/Akka.Http.Shim.Tests.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit" />
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/src/management/Akka.Http.Shim.Tests/HttpSpec.cs
+++ b/src/management/Akka.Http.Shim.Tests/HttpSpec.cs
@@ -15,7 +15,6 @@ using Akka.Event;
 using Akka.Http.Dsl;
 using Akka.Http.Dsl.Settings;
 using Akka.Http.Extensions;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Http.Shim.Tests
@@ -67,7 +66,7 @@ namespace Akka.Http.Shim.Tests
             {
                 Output.WriteLine(await result.Content.ReadAsStringAsync());
             }
-            result.StatusCode.Should().Be(expectedResult);
+            Assert.Equal(expectedResult, result.StatusCode);
         }
 
         internal class RouteHandler : HttpModuleBase

--- a/src/management/Akka.Http.Shim.Tests/UtilSpec.cs
+++ b/src/management/Akka.Http.Shim.Tests/UtilSpec.cs
@@ -7,7 +7,6 @@
 
 using System.Linq;
 using Akka.Http.Extensions;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Http.Shim.Tests;
@@ -19,10 +18,10 @@ public class UtilSpec
     {
         var list = Enumerable.Range(0, 100).ToList();
         list.Shuffle();
-        list.Count.Should().Be(100);
+        Assert.Equal(100, list.Count);
         foreach (var i in Enumerable.Range(0, 100))
         {
-            list.Should().Contain(i);
+            Assert.Contains(i, list);
         }
     }
 }

--- a/src/management/Akka.Management.Tests/Akka.Management.Tests.csproj
+++ b/src/management/Akka.Management.Tests/Akka.Management.Tests.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Akka.Hosting.TestKit" />
     <PackageReference Include="Akka.Cluster.Hosting" />
     <PackageReference Include="Akka.Remote.Hosting" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/src/management/Akka.Management.Tests/AkkaManagementHttpEndpointSpec.cs
+++ b/src/management/Akka.Management.Tests/AkkaManagementHttpEndpointSpec.cs
@@ -12,7 +12,6 @@ using Akka.Http.Dsl;
 using Akka.IO;
 using Akka.Management.Dsl;
 using Akka.TestKit.Xunit.Internals;
-using FluentAssertions;
 using Xunit;
 using Route = System.ValueTuple<string, Akka.Http.Dsl.HttpModuleBase>;
 
@@ -111,13 +110,13 @@ namespace Akka.Management.Tests
             logger.Tell(new InitializeLogger(system.EventStream));
             
             var management = AkkaManagement.Get(system);
-            management.Settings.Http.RouteProviders.Should().Contain(new NamedRouteProvider("test1", null));
-            management.Settings.Http.RouteProviders.Should().Contain(new NamedRouteProvider("test2",
-                "Akka.Management.Tests.HttpManagementEndpointSpecRoutesNetFxDsl, Akka.Management.Tests"));
-            
+            Assert.Contains(new NamedRouteProvider("test1", null), management.Settings.Http.RouteProviders);
+            Assert.Contains(new NamedRouteProvider("test2",
+                "Akka.Management.Tests.HttpManagementEndpointSpecRoutesNetFxDsl, Akka.Management.Tests"), management.Settings.Http.RouteProviders);
+
             await management.Start();
-            HttpManagementEndpointSpecRoutesDotNetDsl.Started.Should().BeFalse();
-            HttpManagementEndpointSpecRoutesNetFxDsl.Started.Should().BeTrue();
+            Assert.False(HttpManagementEndpointSpecRoutesDotNetDsl.Started);
+            Assert.True(HttpManagementEndpointSpecRoutesNetFxDsl.Started);
         }
         
         [Fact]
@@ -138,10 +137,10 @@ namespace Akka.Management.Tests
             logger.Tell(new InitializeLogger(system.EventStream));
 
             var management = AkkaManagement.Get(system);
-            management.Settings.Http.RouteProviders.Should().Contain(new NamedRouteProvider("test1",
-                "Akka.Management.Tests.HttpManagementEndpointSpecRoutesDotNetDsl, Akka.Management.Tests"));
-            management.Settings.Http.RouteProviders.Should().Contain(new NamedRouteProvider("test2",
-                "Akka.Management.Tests.HttpManagementEndpointSpecRoutesNetFxDsl, Akka.Management.Tests"));
+            Assert.Contains(new NamedRouteProvider("test1",
+                "Akka.Management.Tests.HttpManagementEndpointSpecRoutesDotNetDsl, Akka.Management.Tests"), management.Settings.Http.RouteProviders);
+            Assert.Contains(new NamedRouteProvider("test2",
+                "Akka.Management.Tests.HttpManagementEndpointSpecRoutesNetFxDsl, Akka.Management.Tests"), management.Settings.Http.RouteProviders);
 
             // Start() should be idempotent, it should return the same Task on multiple invocation
             var tasks = new List<Task<Uri?>>();
@@ -151,18 +150,18 @@ namespace Akka.Management.Tests
                 tasks.Add(management.Start());
                 tasks.Add(management.Start());
 
-                tasks[1].Should().Be(tasks[0]);
-                tasks[2].Should().Be(tasks[0]);
-                
+                Assert.Equal(tasks[0], tasks[1]);
+                Assert.Equal(tasks[0], tasks[2]);
+
                 var results = await Task.WhenAll(tasks).WithCancellation(cts.Token);
 
-                results[1].Should().Be(results[0]);
-                results[2].Should().Be(results[0]);
+                Assert.Equal(results[0], results[1]);
+                Assert.Equal(results[0], results[2]);
 
                 var task = management.Start();
-                task.Should().Be(tasks[0]);
+                Assert.Equal(tasks[0], task);
                 var result = await task.WithCancellation(cts.Token);
-                result.Should().Be(results[0]);
+                Assert.Equal(results[0], result);
             }
 
             var client = new HttpClient
@@ -174,13 +173,13 @@ namespace Akka.Management.Tests
 
             _output.WriteLine(await response.Content.ReadAsStringAsync());
             
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            (await response.Content.ReadAsStringAsync()).Should().Be("hello .NET Core");
-            
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("hello .NET Core", await response.Content.ReadAsStringAsync());
+
             response = await client.GetAsync($"http://127.0.0.1:{httpPort}/netfx");
             _output.WriteLine(await response.Content.ReadAsStringAsync());
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            (await response.Content.ReadAsStringAsync()).Should().Be("hello .NET Framework");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("hello .NET Framework", await response.Content.ReadAsStringAsync());
 
             try
             {

--- a/src/management/Akka.Management.Tests/AkkaManagementSettingsSpec.cs
+++ b/src/management/Akka.Management.Tests/AkkaManagementSettingsSpec.cs
@@ -13,10 +13,8 @@ using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Http.Dsl;
 using Akka.Management.Dsl;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using static FluentAssertions.FluentActions;
 using Route = System.ValueTuple<string, Akka.Http.Dsl.HttpModuleBase>;
 
 namespace Akka.Management.Tests
@@ -34,23 +32,23 @@ namespace Akka.Management.Tests
                 .First(ip => !Equals(ip, IPAddress.Any) && !Equals(ip, IPAddress.IPv6Any))
                 .ToString();
 
-            http.Hostname.Should().Be(defaultHostname);
-            http.Port.Should().Be(8558);
-            http.EffectiveBindHostname.Should().Be(defaultHostname);
-            http.EffectiveBindPort.Should().Be(8558);
-            http.BasePath.Should().BeEmpty();
-            http.RouteProviders.Count.Should().Be(3);
-            
-            http.RouteProviders[0].Name.Should().Be("cluster-bootstrap");
-            http.RouteProviders[0].FullyQualifiedClassName.Should().Be("Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management");
-            
-            http.RouteProviders[1].Name.Should().Be("remote-address");
-            http.RouteProviders[1].FullyQualifiedClassName.Should().Be("Akka.Management.Routes.AddressRouteProvider, Akka.Management");
-            
-            http.RouteProviders[2].Name.Should().Be("cluster-client-receptionist");
-            http.RouteProviders[2].FullyQualifiedClassName.Should().Be("Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management");
-            
-            http.RouteProvidersReadOnly.Should().BeTrue();
+            Assert.Equal(defaultHostname, http.Hostname);
+            Assert.Equal(8558, http.Port);
+            Assert.Equal(defaultHostname, http.EffectiveBindHostname);
+            Assert.Equal(8558, http.EffectiveBindPort);
+            Assert.Empty(http.BasePath);
+            Assert.Equal(3, http.RouteProviders.Count);
+
+            Assert.Equal("cluster-bootstrap", http.RouteProviders[0].Name);
+            Assert.Equal("Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management", http.RouteProviders[0].FullyQualifiedClassName);
+
+            Assert.Equal("remote-address", http.RouteProviders[1].Name);
+            Assert.Equal("Akka.Management.Routes.AddressRouteProvider, Akka.Management", http.RouteProviders[1].FullyQualifiedClassName);
+
+            Assert.Equal("cluster-client-receptionist", http.RouteProviders[2].Name);
+            Assert.Equal("Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management", http.RouteProviders[2].FullyQualifiedClassName);
+
+            Assert.True(http.RouteProvidersReadOnly);
         }
 
         [Fact(DisplayName = "AkkaManagementOptions should contain default values")]
@@ -67,25 +65,25 @@ namespace Akka.Management.Tests
                 .First(ip => !Equals(ip, IPAddress.Any) && !Equals(ip, IPAddress.IPv6Any))
                 .ToString();
 
-            http.Hostname.Should().Be(defaultHostname);
-            http.Port.Should().Be(8558);
-            http.EffectiveBindHostname.Should().Be(defaultHostname);
-            http.EffectiveBindPort.Should().Be(8558);
-            http.BasePath.Should().BeEmpty();
-            http.RouteProviders.Count.Should().Be(3);
-            
-            http.RouteProviders[0].Name.Should().Be("cluster-bootstrap");
-            http.RouteProviders[0].FullyQualifiedClassName.Should().Be("Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management");
-            
-            http.RouteProviders[1].Name.Should().Be("remote-address");
-            http.RouteProviders[1].FullyQualifiedClassName.Should().Be("Akka.Management.Routes.AddressRouteProvider, Akka.Management");
-            
-            http.RouteProviders[2].Name.Should().Be("cluster-client-receptionist");
-            http.RouteProviders[2].FullyQualifiedClassName.Should().Be("Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management");
-            
-            http.RouteProvidersReadOnly.Should().BeTrue();
+            Assert.Equal(defaultHostname, http.Hostname);
+            Assert.Equal(8558, http.Port);
+            Assert.Equal(defaultHostname, http.EffectiveBindHostname);
+            Assert.Equal(8558, http.EffectiveBindPort);
+            Assert.Empty(http.BasePath);
+            Assert.Equal(3, http.RouteProviders.Count);
+
+            Assert.Equal("cluster-bootstrap", http.RouteProviders[0].Name);
+            Assert.Equal("Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management", http.RouteProviders[0].FullyQualifiedClassName);
+
+            Assert.Equal("remote-address", http.RouteProviders[1].Name);
+            Assert.Equal("Akka.Management.Routes.AddressRouteProvider, Akka.Management", http.RouteProviders[1].FullyQualifiedClassName);
+
+            Assert.Equal("cluster-client-receptionist", http.RouteProviders[2].Name);
+            Assert.Equal("Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management", http.RouteProviders[2].FullyQualifiedClassName);
+
+            Assert.True(http.RouteProvidersReadOnly);
         }
-        
+
         [Fact(DisplayName = "AkkaManagementSetup should override AkkaManagementSettings value")]
         public void SetupOverrideSettings()
         {
@@ -102,21 +100,18 @@ namespace Akka.Management.Tests
             var settings = setup.Apply(AkkaManagementSettings.Create(AkkaManagementProvider.DefaultConfiguration()));
             var http = settings.Http;
             
-            http.Hostname.Should().Be("a");
-            http.Port.Should().Be(1234);
-            http.EffectiveBindHostname.Should().Be("b");
-            http.EffectiveBindPort.Should().Be(1235);
-            http.BasePath.Should().Be("c");
-            http.RouteProviders.Count.Should().Be(4);
-            http.RouteProviders[0].Should()
-                .BeEquivalentTo(new NamedRouteProvider("cluster-bootstrap", "Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management"));
-            http.RouteProviders[1].Should()
-                .BeEquivalentTo(new NamedRouteProvider("remote-address", "Akka.Management.Routes.AddressRouteProvider, Akka.Management"));
-            http.RouteProviders[2].Should()
-                .BeEquivalentTo(new NamedRouteProvider("cluster-client-receptionist", "Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management"));
-            http.RouteProviders[3].Should()
-                .BeEquivalentTo(new NamedRouteProvider("test", typeof(FakeRouteProvider).AssemblyQualifiedName));
-            http.RouteProvidersReadOnly.Should().BeFalse();
+            Assert.Equal("a", http.Hostname);
+            Assert.Equal(1234, http.Port);
+            Assert.Equal("b", http.EffectiveBindHostname);
+            Assert.Equal(1235, http.EffectiveBindPort);
+            Assert.Equal("c", http.BasePath);
+            Assert.Equal(4, http.RouteProviders.Count);
+            // converted from BeEquivalentTo (NamedRouteProvider has value equality over Name + FullyQualifiedClassName)
+            Assert.Equal(new NamedRouteProvider("cluster-bootstrap", "Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management"), http.RouteProviders[0]);
+            Assert.Equal(new NamedRouteProvider("remote-address", "Akka.Management.Routes.AddressRouteProvider, Akka.Management"), http.RouteProviders[1]);
+            Assert.Equal(new NamedRouteProvider("cluster-client-receptionist", "Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management"), http.RouteProviders[2]);
+            Assert.Equal(new NamedRouteProvider("test", typeof(FakeRouteProvider).AssemblyQualifiedName), http.RouteProviders[3]);
+            Assert.False(http.RouteProvidersReadOnly);
         }
 
         [Fact(DisplayName = "AkkaManagementOptions should override default values")]
@@ -139,21 +134,18 @@ namespace Akka.Management.Tests
             var settings = AkkaManagementSettings.Create(builder.Configuration.Value);
             var http = settings.Http;
 
-            http.Hostname.Should().Be("a");
-            http.Port.Should().Be(1234);
-            http.EffectiveBindHostname.Should().Be("b");
-            http.EffectiveBindPort.Should().Be(1235);
-            http.BasePath.Should().Be("c");
-            http.RouteProviders.Count.Should().Be(4);
-            http.RouteProviders[0].Should()
-                .BeEquivalentTo(new NamedRouteProvider("cluster-bootstrap", "Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management"));
-            http.RouteProviders[1].Should()
-                .BeEquivalentTo(new NamedRouteProvider("remote-address", "Akka.Management.Routes.AddressRouteProvider, Akka.Management"));
-            http.RouteProviders[2].Should()
-                .BeEquivalentTo(new NamedRouteProvider("cluster-client-receptionist", "Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management"));
-            http.RouteProviders[3].Should()
-                .BeEquivalentTo(new NamedRouteProvider("test", typeof(FakeRouteProvider).AssemblyQualifiedName));
-            http.RouteProvidersReadOnly.Should().BeFalse();
+            Assert.Equal("a", http.Hostname);
+            Assert.Equal(1234, http.Port);
+            Assert.Equal("b", http.EffectiveBindHostname);
+            Assert.Equal(1235, http.EffectiveBindPort);
+            Assert.Equal("c", http.BasePath);
+            Assert.Equal(4, http.RouteProviders.Count);
+            // converted from BeEquivalentTo (NamedRouteProvider has value equality over Name + FullyQualifiedClassName)
+            Assert.Equal(new NamedRouteProvider("cluster-bootstrap", "Akka.Management.Cluster.Bootstrap.ClusterBootstrapProvider, Akka.Management"), http.RouteProviders[0]);
+            Assert.Equal(new NamedRouteProvider("remote-address", "Akka.Management.Routes.AddressRouteProvider, Akka.Management"), http.RouteProviders[1]);
+            Assert.Equal(new NamedRouteProvider("cluster-client-receptionist", "Akka.Management.Routes.ClusterClientReceptionistRouteProvider, Akka.Management"), http.RouteProviders[2]);
+            Assert.Equal(new NamedRouteProvider("test", typeof(FakeRouteProvider).AssemblyQualifiedName), http.RouteProviders[3]);
+            Assert.False(http.RouteProvidersReadOnly);
         }
 
         [Fact(DisplayName = "AkkaManagementSetup.Apply should throw on invalid route provider type")]
@@ -168,13 +160,19 @@ namespace Akka.Management.Tests
                 }
             });
 
-            Invoking(() => setup.Apply(AkkaManagementSettings.Create(AkkaManagementProvider.DefaultConfiguration())))
-                .Should().ThrowExactly<ConfigurationException>()
-                .WithMessage("*invalid-route*").WithMessage("*InvalidRouteProvider*");
+            // ThrowExactly<ConfigurationException> -> Assert.Throws (exact type); WithMessage globs are case-insensitive (FA MatchEquivalentOf)
+            var ex = Assert.Throws<ConfigurationException>(() =>
+            {
+                setup.Apply(AkkaManagementSettings.Create(AkkaManagementProvider.DefaultConfiguration()));
+            });
+            Assert.Contains("invalid-route", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("InvalidRouteProvider", ex.Message, StringComparison.OrdinalIgnoreCase);
 
-            Invoking(() => setup.Http.WithRouteProvider<FakeRouteProvider>("test2"))
-                .Should().ThrowExactly<ConfigurationException>()
-                .WithMessage("*already added");
+            var ex2 = Assert.Throws<ConfigurationException>(() =>
+            {
+                setup.Http.WithRouteProvider<FakeRouteProvider>("test2");
+            });
+            Assert.EndsWith("already added", ex2.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact(DisplayName = "AkkaManagementOptions.Apply should throw on invalid route provider type")]
@@ -190,13 +188,19 @@ namespace Akka.Management.Tests
             };
             var builder = new AkkaConfigurationBuilder(new ServiceCollection(), "test");
 
-            Invoking(() => options.Apply(builder))
-                .Should().ThrowExactly<ConfigurationException>()
-                .WithMessage("*invalid-route*").WithMessage("*InvalidRouteProvider*");
+            // ThrowExactly<ConfigurationException> -> Assert.Throws (exact type); WithMessage globs are case-insensitive (FA MatchEquivalentOf)
+            var ex = Assert.Throws<ConfigurationException>(() =>
+            {
+                options.Apply(builder);
+            });
+            Assert.Contains("invalid-route", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("InvalidRouteProvider", ex.Message, StringComparison.OrdinalIgnoreCase);
 
-            Invoking(() => options.WithRouteProvider<FakeRouteProvider>("test2"))
-                .Should().ThrowExactly<ConfigurationException>()
-                .WithMessage("*already added");
+            var ex2 = Assert.Throws<ConfigurationException>(() =>
+            {
+                options.WithRouteProvider<FakeRouteProvider>("test2");
+            });
+            Assert.EndsWith("already added", ex2.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         private class InvalidRouteProvider

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/ClusterBootstrapSettingsSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/ClusterBootstrapSettingsSpec.cs
@@ -9,8 +9,6 @@ using System;
 using Akka.Event;
 using Akka.Management.Cluster.Bootstrap;
 using Akka.Management.Dsl;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Akka.Management.Tests.Cluster.Bootstrap
@@ -24,28 +22,28 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                 .WithFallback(AkkaManagementProvider.DefaultConfiguration());
             
             var settings = ClusterBootstrapSettings.Create(config, NoLogger.Instance);
-            settings.NewClusterEnabled.Should().BeTrue();
-            
-            settings.ContactPointDiscovery.ServiceName.Should().BeNull();
-            settings.ContactPointDiscovery.PortName.Should().BeNull();
-            settings.ContactPointDiscovery.Protocol.Should().Be("tcp");
-            settings.ContactPointDiscovery.ServiceNamespace.Should().BeNull();
-            settings.ContactPointDiscovery.DiscoveryMethod.Should().Be("akka.discovery");
-            settings.ContactPointDiscovery.StableMargin.Should().Be(TimeSpan.FromSeconds(5));
-            settings.ContactPointDiscovery.Interval.Should().Be(TimeSpan.FromSeconds(1));
-            settings.ContactPointDiscovery.ExponentialBackoffRandomFactor.Should().Be(0.2);
-            settings.ContactPointDiscovery.ExponentialBackoffMax.Should().Be(TimeSpan.FromSeconds(15));
-            settings.ContactPointDiscovery.RequiredContactPointsNr.Should().Be(2);
-            settings.ContactPointDiscovery.ResolveTimeout.Should().Be(TimeSpan.FromSeconds(3));
-            settings.ContactPointDiscovery.ContactWithAllContactPoints.Should().BeTrue();
+            Assert.True(settings.NewClusterEnabled);
 
-            settings.ContactPoint.FallbackPort.Should().BeNull();
-            settings.ContactPoint.FilterOnFallbackPort.Should().BeTrue();
-            settings.ContactPoint.ProbingFailureTimeout.Should().Be(TimeSpan.FromSeconds(3));
-            settings.ContactPoint.ProbeInterval.Should().Be(TimeSpan.FromSeconds(5));
-            settings.ContactPoint.ProbeIntervalJitter.Should().Be(0.2);
-            settings.JoinDecider.ImplClass.Should()
-                .Be("Akka.Management.Cluster.Bootstrap.LowestAddressJoinDecider, Akka.Management");
+            Assert.Null(settings.ContactPointDiscovery.ServiceName);
+            Assert.Null(settings.ContactPointDiscovery.PortName);
+            Assert.Equal("tcp", settings.ContactPointDiscovery.Protocol);
+            Assert.Null(settings.ContactPointDiscovery.ServiceNamespace);
+            Assert.Equal("akka.discovery", settings.ContactPointDiscovery.DiscoveryMethod);
+            Assert.Equal(TimeSpan.FromSeconds(5), settings.ContactPointDiscovery.StableMargin);
+            Assert.Equal(TimeSpan.FromSeconds(1), settings.ContactPointDiscovery.Interval);
+            Assert.Equal(0.2, settings.ContactPointDiscovery.ExponentialBackoffRandomFactor);
+            Assert.Equal(TimeSpan.FromSeconds(15), settings.ContactPointDiscovery.ExponentialBackoffMax);
+            Assert.Equal(2, settings.ContactPointDiscovery.RequiredContactPointsNr);
+            Assert.Equal(TimeSpan.FromSeconds(3), settings.ContactPointDiscovery.ResolveTimeout);
+            Assert.True(settings.ContactPointDiscovery.ContactWithAllContactPoints);
+
+            Assert.Null(settings.ContactPoint.FallbackPort);
+            Assert.True(settings.ContactPoint.FilterOnFallbackPort);
+            Assert.Equal(TimeSpan.FromSeconds(3), settings.ContactPoint.ProbingFailureTimeout);
+            Assert.Equal(TimeSpan.FromSeconds(5), settings.ContactPoint.ProbeInterval);
+            Assert.Equal(0.2, settings.ContactPoint.ProbeIntervalJitter);
+            Assert.Equal("Akka.Management.Cluster.Bootstrap.LowestAddressJoinDecider, Akka.Management",
+                settings.JoinDecider.ImplClass);
         }
         
         [Fact(DisplayName = "ClusterBootstrapSetup should override ClusterBootstrapSettings")]
@@ -65,20 +63,20 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                     Protocol = "c",
                     ServiceNamespace = "d",
                     DiscoveryMethod = "e",
-                    StableMargin = 1.Seconds(),
-                    Interval = 2.Seconds(),
+                    StableMargin = TimeSpan.FromSeconds(1),
+                    Interval = TimeSpan.FromSeconds(2),
                     ExponentialBackoffRandomFactor = 1.0,
-                    ExponentialBackoffMax = 3.Seconds(),
+                    ExponentialBackoffMax = TimeSpan.FromSeconds(3),
                     RequiredContactPointsNr = 1,
-                    ResolveTimeout = 4.Seconds(),
+                    ResolveTimeout = TimeSpan.FromSeconds(4),
                     ContactWithAllContactPoints = false
                 },
                 ContactPoint = new ContactPointSetup
                 {
                     FallbackPort = 1234,
                     FilterOnFallbackPort = false,
-                    ProbeInterval = 2.Seconds(),
-                    ProbingFailureTimeout = 4.Seconds(),
+                    ProbeInterval = TimeSpan.FromSeconds(2),
+                    ProbingFailureTimeout = TimeSpan.FromSeconds(4),
                     ProbeIntervalJitter = 1.0
                 },
                 JoinDecider = new JoinDeciderSetup
@@ -87,29 +85,29 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                 }
             };
             var settings = setup.Apply(original);
-            settings.NewClusterEnabled.Should().BeFalse();
-            
-            settings.ContactPointDiscovery.ServiceName.Should().Be("a");
-            settings.ContactPointDiscovery.PortName.Should().Be("b");
-            settings.ContactPointDiscovery.Protocol.Should().Be("c");
-            settings.ContactPointDiscovery.ServiceNamespace.Should().Be("d");
-            settings.ContactPointDiscovery.DiscoveryMethod.Should().Be("e");
-            settings.ContactPointDiscovery.StableMargin.Should().Be(1.Seconds());
-            settings.ContactPointDiscovery.Interval.Should().Be(2.Seconds());
-            settings.ContactPointDiscovery.ExponentialBackoffRandomFactor.Should().Be(1.0);
-            settings.ContactPointDiscovery.ExponentialBackoffMax.Should().Be(3.Seconds());
-            settings.ContactPointDiscovery.RequiredContactPointsNr.Should().Be(1);
-            settings.ContactPointDiscovery.ResolveTimeout.Should().Be(4.Seconds());
-            settings.ContactPointDiscovery.ContactWithAllContactPoints.Should().BeFalse();
+            Assert.False(settings.NewClusterEnabled);
 
-            settings.ContactPoint.FallbackPort.Should().Be(1234);
-            settings.ContactPoint.FilterOnFallbackPort.Should().BeFalse();
-            settings.ContactPoint.ProbeInterval.Should().Be(2.Seconds());
-            settings.ContactPoint.ProbingFailureTimeout.Should().Be(4.Seconds());
-            settings.ContactPoint.ProbeIntervalJitter.Should().Be(1.0);
-            
-            settings.JoinDecider.ImplClass.Should()
-                .Be(typeof(ClusterBootstrap).AssemblyQualifiedName);
+            Assert.Equal("a", settings.ContactPointDiscovery.ServiceName);
+            Assert.Equal("b", settings.ContactPointDiscovery.PortName);
+            Assert.Equal("c", settings.ContactPointDiscovery.Protocol);
+            Assert.Equal("d", settings.ContactPointDiscovery.ServiceNamespace);
+            Assert.Equal("e", settings.ContactPointDiscovery.DiscoveryMethod);
+            Assert.Equal(TimeSpan.FromSeconds(1), settings.ContactPointDiscovery.StableMargin);
+            Assert.Equal(TimeSpan.FromSeconds(2), settings.ContactPointDiscovery.Interval);
+            Assert.Equal(1.0, settings.ContactPointDiscovery.ExponentialBackoffRandomFactor);
+            Assert.Equal(TimeSpan.FromSeconds(3), settings.ContactPointDiscovery.ExponentialBackoffMax);
+            Assert.Equal(1, settings.ContactPointDiscovery.RequiredContactPointsNr);
+            Assert.Equal(TimeSpan.FromSeconds(4), settings.ContactPointDiscovery.ResolveTimeout);
+            Assert.False(settings.ContactPointDiscovery.ContactWithAllContactPoints);
+
+            Assert.Equal(1234, settings.ContactPoint.FallbackPort);
+            Assert.False(settings.ContactPoint.FilterOnFallbackPort);
+            Assert.Equal(TimeSpan.FromSeconds(2), settings.ContactPoint.ProbeInterval);
+            Assert.Equal(TimeSpan.FromSeconds(4), settings.ContactPoint.ProbingFailureTimeout);
+            Assert.Equal(1.0, settings.ContactPoint.ProbeIntervalJitter);
+
+            Assert.Equal(typeof(ClusterBootstrap).AssemblyQualifiedName,
+                settings.JoinDecider.ImplClass);
         }
     }
 }

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/ContactPoint/ClusterBootstrapAutostartIntegrationSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/ContactPoint/ClusterBootstrapAutostartIntegrationSpec.cs
@@ -21,7 +21,6 @@ using Akka.Management.Cluster.Bootstrap;
 using Akka.TestKit;
 using Akka.TestKit.Xunit.Internals;
 using Akka.Util.Internal;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Management.Tests.Cluster.Bootstrap.ContactPoint
@@ -149,7 +148,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.ContactPoint
             {
                 var _ = ClusterBootstrapSettings.Create(_systems[0].Settings.Config, NoLogger.Instance);
             });
-            exception.Should().BeNull();
+            Assert.Null(exception);
         }
 
         // join three DNS discovered nodes by forming new cluster (happy path)
@@ -168,7 +167,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.ContactPoint
                     selection.Tell(new Identify(null));
                     var response = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10));
                     coordinator = response.Subject;
-                    coordinator.Should().NotBeNull();
+                    Assert.NotNull(coordinator);
                     coordinatorProbe.Watch(coordinator);
                 });
                 probeList.Add((coordinatorProbe, coordinator!));
@@ -179,8 +178,8 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.ContactPoint
             var cluster = _clusters[0];
             probe.AwaitAssert(() =>
             {
-                cluster.State.Members.Count.Should().Be(ClusterSize);
-                cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(ClusterSize);
+                Assert.Equal(ClusterSize, cluster.State.Members.Count);
+                Assert.Equal(ClusterSize, cluster.State.Members.Count(m => m.Status == MemberStatus.Up));
             }, RemainingOrDefault * ClusterSize * 2);
             
             // cluster bootstrap coordinator should stop after joining
@@ -188,7 +187,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.ContactPoint
             {
                 var (coordinatorProbe, coordinator) = tuple;
                 coordinatorProbe.ExpectTerminated(coordinator);
-                ((RepointableActorRef) coordinator).Children.ToList().Count.Should().Be(0);
+                Assert.Equal(0, ((RepointableActorRef) coordinator).Children.ToList().Count);
             }
         }
         

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/ContactPoint/HttpContactPointRoutesSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/ContactPoint/HttpContactPointRoutesSpec.cs
@@ -21,7 +21,6 @@ using Akka.Management.Cluster.Bootstrap;
 using Akka.Management.Cluster.Bootstrap.ContactPoint;
 using Akka.Management.Dsl;
 using Ceen;
-using FluentAssertions;
 using Newtonsoft.Json;
 using Xunit;
 using static Akka.Management.Cluster.Bootstrap.ContactPoint.HttpBootstrapJsonProtocol;
@@ -68,15 +67,15 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.ContactPoint
                     {
                         handled = true;
                         var response = (FakeResponse)context.Response;
-                        response.Response.Should().Contain("\"Nodes\":[]");
+                        Assert.Contains("\"Nodes\":[]", response.Response, StringComparison.Ordinal);
                     }
                 }
             }
 
-            handled.Should().BeTrue("At least one handler has to handle the request");
+            Assert.True(handled, "At least one handler has to handle the request");
         }
 
-        [Fact( 
+        [Fact(
             Skip = "Extremely racy in CI/CD",
             DisplayName = "Http Bootstrap routes should include seed nodes when part of a cluster")]
         public async Task IncludeSeedsWhenPartOfCluster()
@@ -122,17 +121,18 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.ContactPoint
                             throw new Exception($"Could not deserialize response. Response: {response.Response}");
                         
                         var seedNodes = nodes.Nodes.Select(n => n.Node).ToList();
-                        seedNodes.Contains(cluster.SelfAddress).Should()
-                            .BeTrue(
+                        Assert.True(
+                            seedNodes.Contains(cluster.SelfAddress),
+                            string.Format(
                                 "Seed nodes should contain self address but it does not. Self address: [{0}], seed nodes: [{1}], response string: [{2}]",
                                 cluster.SelfAddress,
                                 string.Join(", ", seedNodes),
-                                response.Response);
+                                response.Response));
                     }
                 }
             }
 
-            handled.Should().BeTrue("At least one handler has to handle the request");
+            Assert.True(handled, "At least one handler has to handle the request");
         }
     }
 

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/HostingSpecs.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/HostingSpecs.cs
@@ -14,8 +14,6 @@ using Akka.Management.Cluster.Bootstrap;
 using Akka.Management.Dsl;
 using Akka.Remote.Hosting;
 using Akka.Util;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -92,7 +90,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                 tcs.SetResult(Done.Instance);
             });
 
-            await tcs.Task.WaitAsync(30.Seconds());
+            await tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
             
             await host.StopAsync();
         }

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/InactiveAkkaManagementSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/InactiveAkkaManagementSpec.cs
@@ -12,10 +12,7 @@ using Akka.Discovery;
 using Akka.Event;
 using Akka.Management.Cluster.Bootstrap;
 using Akka.TestKit.Extensions;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
-using static FluentAssertions.FluentActions;
 
 namespace Akka.Management.Tests.Cluster.Bootstrap
 {
@@ -42,15 +39,15 @@ akka.remote.dot-netty.tcp.port = 0
             var probe = CreateTestProbe();
             Sys.EventStream.Subscribe(probe.Ref, typeof(Error));
 
-            await Awaiting(() => ClusterBootstrap.Get(Sys).Start())
-                .Should().ThrowAsync<Exception>()
-                .WithMessage("Awaiting ClusterBootstrap.SelfContactPointUri timed out.")
-                .WaitAsync(15.Seconds());
+            var ex = await Assert.ThrowsAnyAsync<Exception>(() => ClusterBootstrap.Get(Sys).Start())
+                .WaitAsync(TimeSpan.FromSeconds(15));
+            // converted from WithMessage glob (FA MatchEquivalentOf is case-insensitive, full-string, no wildcards)
+            Assert.Equal("Awaiting ClusterBootstrap.SelfContactPointUri timed out.", ex.Message, ignoreCase: true);
 
             await AwaitAssertAsync(() =>
             {
-                probe.ExpectMsg<Error>().Message.ToString().Should()
-                    .StartWith("'Bootstrap.selfContactPoint' was NOT set, but is required for the bootstrap to work");
+                Assert.StartsWith("'Bootstrap.selfContactPoint' was NOT set, but is required for the bootstrap to work",
+                    probe.ExpectMsg<Error>().Message.ToString(), StringComparison.Ordinal);
             });
         }
     }

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/Internal/BootstrapCoordinatorSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/Internal/BootstrapCoordinatorSpec.cs
@@ -18,7 +18,6 @@ using Akka.Management.Cluster.Bootstrap;
 using Akka.Management.Cluster.Bootstrap.Internal;
 using Akka.Management.Dsl;
 using Akka.Util;
-using FluentAssertions;
 using Xunit;
 using static Akka.Discovery.ServiceDiscovery;
 using static Akka.Management.Cluster.Bootstrap.Internal.BootstrapCoordinator.Protocol;
@@ -75,10 +74,10 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
             AwaitAssert(() =>
             {
                 var targetsToCheck = targets.Value;
-                targetsToCheck.Count.Should().BeGreaterOrEqualTo(2);
-                targetsToCheck.Select(t => t.Host).Should().Contain("host1");
-                targetsToCheck.Select(t => t.Host).Should().Contain("host2");
-                targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet().Count.Should().Be(0);
+                Assert.True(targetsToCheck.Count >= 2);
+                Assert.Contains("host1", targetsToCheck.Select(t => t.Host));
+                Assert.Contains("host2", targetsToCheck.Select(t => t.Host));
+                Assert.Equal(0, targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet().Count);
             });
             
             coordinator.Tell(new JoinOtherSeedNodes(new [] {Akka.Cluster.Cluster.Get(Sys).SelfAddress}.ToImmutableHashSet()));
@@ -109,10 +108,10 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
             AwaitAssert(() =>
             {
                 var targetsToCheck = targets.Value;
-                targetsToCheck.Count.Should().BeGreaterOrEqualTo(2);
-                targetsToCheck.Select(t => t.Host).Should().Contain("host1");
-                targetsToCheck.Select(t => t.Host).Should().Contain("host2");
-                targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet().Count.Should().Be(0);
+                Assert.True(targetsToCheck.Count >= 2);
+                Assert.Contains("host1", targetsToCheck.Select(t => t.Host));
+                Assert.Contains("host2", targetsToCheck.Select(t => t.Host));
+                Assert.Equal(0, targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet().Count);
             });
             
             coordinator.Tell(JoinSelf.Instance);
@@ -141,10 +140,11 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
             AwaitAssert(() =>
             {
                 var targetsToCheck = targets.Value;
-                targetsToCheck.Count.Should().BeGreaterOrEqualTo(2);
-                targetsToCheck.Select(t => t.Host).Should().Contain("host1");
-                targetsToCheck.Select(t => t.Host).Should().Contain("host2");
-                targetsToCheck.Select(t => t.Port).ToImmutableHashSet().Should().BeEquivalentTo(new HashSet<int> {8558});
+                Assert.True(targetsToCheck.Count >= 2);
+                Assert.Contains("host1", targetsToCheck.Select(t => t.Host));
+                Assert.Contains("host2", targetsToCheck.Select(t => t.Host));
+                // converted from BeEquivalentTo: set must equal { 8558 } (exactly one distinct port, value 8558)
+                Assert.Equal((int?)8558, Assert.Single(targetsToCheck.Select(t => t.Port).ToImmutableHashSet()));
             });
         }
 
@@ -171,10 +171,10 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
             AwaitAssert(() =>
             {
                 var targetsToCheck = targets.Value;
-                targetsToCheck.Count.Should().BeGreaterOrEqualTo(2);
-                targetsToCheck.Select(t => t.Host).Should().Contain("host1");
-                targetsToCheck.Select(t => t.Host).Should().Contain("host2");
-                targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet().Count.Should().Be(0);
+                Assert.True(targetsToCheck.Count >= 2);
+                Assert.Contains("host1", targetsToCheck.Select(t => t.Host));
+                Assert.Contains("host2", targetsToCheck.Select(t => t.Host));
+                Assert.Equal(0, targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet().Count);
             });
         }
         
@@ -189,8 +189,11 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
                 new ResolvedTarget("host2", 3, null),
                 new ResolvedTarget("host2", 4, null),
             }.ToImmutableList();
-            BootstrapCoordinator.SelectHosts(new Lookup("service", "cats"), 8558, false, beforeFiltering)
-                .Should().BeEquivalentTo(beforeFiltering);
+            // converted from BeEquivalentTo (order-insensitive); ResolvedTarget has value equality (Host, Port, Address)
+            Assert.Equal(
+                beforeFiltering.OrderBy(t => t.Host).ThenBy(t => t.Port).ToList(),
+                BootstrapCoordinator.SelectHosts(new Lookup("service", "cats"), 8558, false, beforeFiltering)
+                    .OrderBy(t => t.Host).ThenBy(t => t.Port).ToList());
         }
         
         // For example when using DNS A-record-based discovery in K8s
@@ -205,12 +208,15 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
                 new ResolvedTarget("host2", 8558, null),
                 new ResolvedTarget("host2", 4, null),
             }.ToImmutableList();
-            BootstrapCoordinator.SelectHosts(new Lookup("service"), 8558, true, beforeFiltering)
-                .Should().BeEquivalentTo(new []
+            // converted from BeEquivalentTo (order-insensitive); ResolvedTarget has value equality (Host, Port, Address)
+            Assert.Equal(
+                new []
                 {
                     new ResolvedTarget("host1", 8558, null),
                     new ResolvedTarget("host2", 8558, null),
-                }.ToImmutableList());
+                }.OrderBy(t => t.Host).ThenBy(t => t.Port).ToList(),
+                BootstrapCoordinator.SelectHosts(new Lookup("service"), 8558, true, beforeFiltering)
+                    .OrderBy(t => t.Host).ThenBy(t => t.Port).ToList());
         }
         
         // For example when using ECS service discovery
@@ -225,8 +231,11 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
                 new ResolvedTarget("host2", 8558, null),
                 new ResolvedTarget("host2", 4, null),
             }.ToImmutableList();
-            BootstrapCoordinator.SelectHosts(new Lookup("service"), 8558, false, beforeFiltering)
-                .Should().BeEquivalentTo(beforeFiltering);
+            // converted from BeEquivalentTo (order-insensitive); ResolvedTarget has value equality (Host, Port, Address)
+            Assert.Equal(
+                beforeFiltering.OrderBy(t => t.Host).ThenBy(t => t.Port).ToList(),
+                BootstrapCoordinator.SelectHosts(new Lookup("service"), 8558, false, beforeFiltering)
+                    .OrderBy(t => t.Host).ThenBy(t => t.Port).ToList());
         }
         
         [Fact(DisplayName =
@@ -240,8 +249,11 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
                 new ResolvedTarget("host3", 8558, null),
                 new ResolvedTarget("host4", 4, null),
             }.ToImmutableList();
-            BootstrapCoordinator.SelectHosts(new Lookup("service"), 8558, true, beforeFiltering)
-                .Should().BeEquivalentTo(beforeFiltering);
+            // converted from BeEquivalentTo (order-insensitive); ResolvedTarget has value equality (Host, Port, Address)
+            Assert.Equal(
+                beforeFiltering.OrderBy(t => t.Host).ThenBy(t => t.Port).ToList(),
+                BootstrapCoordinator.SelectHosts(new Lookup("service"), 8558, true, beforeFiltering)
+                    .OrderBy(t => t.Host).ThenBy(t => t.Port).ToList());
         }
         
         private class TestBootstrapCoordinator : BootstrapCoordinator

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/Internal/HttpContactPointBootstrapSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/Internal/HttpContactPointBootstrapSpec.cs
@@ -7,7 +7,6 @@
 
 using Akka.Actor;
 using Akka.Management.Cluster.Bootstrap.Internal;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
@@ -18,7 +17,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
         public void ShouldUseSafeName()
         {
             var name = HttpContactPointBootstrap.Name("[fe80::1013:2070:258a:c662]", 443);
-            ActorPath.IsValidPathElement(name).Should().BeTrue();
+            Assert.True(ActorPath.IsValidPathElement(name));
         }
     }
 }

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/JoinDeciderSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/JoinDeciderSpec.cs
@@ -18,7 +18,6 @@ using Akka.Management.Cluster.Bootstrap;
 using Akka.Management.Cluster.Bootstrap.Util;
 using Akka.Management.Dsl;
 using Akka.TestKit.Xunit.Internals;
-using FluentAssertions;
 using Xunit;
 using static Akka.Discovery.ServiceDiscovery;
 
@@ -115,7 +114,8 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
 
             for (var i = 0; i < expected.Count; i++)
             {
-                expected[i].Should().BeEquivalentTo(actual[i]);
+                // converted from BeEquivalentTo (ResolvedTarget has value equality over Host, Port, Address)
+                Assert.Equal(expected[i], actual[i]);
             }
         }
     }
@@ -222,7 +222,10 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                         addr,
                         new[] { addr }.ToImmutableHashSet())
                 }.ToImmutableHashSet());
-            (await decider.Decide(info)).Should().BeEquivalentTo(new JoinOtherSeedNodes(new []{addr}.ToImmutableHashSet()));
+            // converted from BeEquivalentTo: JoinOtherSeedNodes uses reference equality, so compare member-wise (its SeedNodes set)
+            var decision = await decider.Decide(info);
+            var join = Assert.IsType<JoinOtherSeedNodes>(decision);
+            Assert.Equal(new []{addr}.ToImmutableHashSet(), join.SeedNodes);
         }
 
         [Fact(DisplayName = "LowestAddressJoinDecider should keep probing when contact points changed within stable-margin")]
@@ -252,7 +255,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                         new Address("akka", "join-decider-spec-system", "c", 2552),
                         ImmutableHashSet<Address>.Empty),
                 }.ToImmutableHashSet());
-            (await decider.Decide(info)).Should().Be(KeepProbing.Instance);
+            Assert.Equal(KeepProbing.Instance, await decider.Decide(info));
         }
 
         [Fact(DisplayName = "LowestAddressJoinDecider should keep probing when not enough contact points")]
@@ -277,7 +280,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                         new Address("akka", "join-decider-spec-system", "b", 2552),
                         ImmutableHashSet<Address>.Empty),
                 }.ToImmutableHashSet());
-            (await decider.Decide(info)).Should().Be(KeepProbing.Instance);
+            Assert.Equal(KeepProbing.Instance, await decider.Decide(info));
         }
 
         [Fact(DisplayName = "LowestAddressJoinDecider should keep probing when not enough confirmed contact points")]
@@ -302,13 +305,13 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                         new Address("akka", "join-decider-spec-system", "b", 2552),
                         ImmutableHashSet<Address>.Empty),
                 }.ToImmutableHashSet()); // << 2 < required-contact-point-nr
-            (await decider.Decide(info)).Should().Be(KeepProbing.Instance);
+            Assert.Equal(KeepProbing.Instance, await decider.Decide(info));
         }
         
         [Fact(DisplayName = "LowestAddressJoinDecider should join self when all conditions met and self has the lowest address")]
         public async Task JoinSelfWhenAllConditionsMetAndSelfHasTheLowestAddress()
         {
-            _settings!.NewClusterEnabled.Should().BeTrue();
+            Assert.True(_settings!.NewClusterEnabled);
             ClusterBootstrap.Get(System!).SetSelfContactPoint(new Uri($"http://10.0.0.2:{ManagementPort}/test"));
             var decider = new LowestAddressJoinDecider(System!, _settings);
             var now = DateTimeOffset.Now;
@@ -334,7 +337,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                         new Address("akka", "join-decider-spec-system", "c", 2552),
                         ImmutableHashSet<Address>.Empty),
                 }.ToImmutableHashSet());
-            (await decider.Decide(info)).Should().Be(JoinSelf.Instance);
+            Assert.Equal(JoinSelf.Instance, await decider.Decide(info));
         }
         
     }
@@ -401,7 +404,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
             var targetList = info.SeedNodesObservations.Select(o => o.ContactPoint).ToList();
             targetList.Sort(ResolvedTargetComparer.Instance);
             var target = targetList.First();
-            decider.MatchesSelf(target, selfContactPoint).Should().BeTrue();
+            Assert.True(decider.MatchesSelf(target, selfContactPoint));
         }
         
         [Fact(DisplayName = "SelfAwareJoinDecider should be able to join self if all conditions met")]
@@ -413,16 +416,16 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
             var targetList = info.SeedNodesObservations.Select(o => o.ContactPoint).ToList();
             targetList.Sort(ResolvedTargetComparer.Instance);
             var target = targetList.First();
-            decider.CanJoinSelf(target, info).Should().BeTrue();
+            Assert.True(decider.CanJoinSelf(target, info));
         }
         
         [Fact(DisplayName = "SelfAwareJoinDecider should not join self if `new-cluster-enabled=off`, even if all conditions met")]
         public async Task NotJoinSelfIfNewClusterEnabledIsSetToOffEvenWhenAllConditionsMet()
         {
-            _settings!.NewClusterEnabled.Should().BeFalse();
+            Assert.False(_settings!.NewClusterEnabled);
             ClusterBootstrap.Get(System!).SetSelfContactPoint(new Uri($"http://10.0.0.2:{ManagementPort}/test"));
             var decider = new LowestAddressJoinDecider(System!, _settings);
-            (await decider.Decide(_seedNodes)).Should().Be(KeepProbing.Instance);
+            Assert.Equal(KeepProbing.Instance, await decider.Decide(_seedNodes));
         }
 
         [Fact(DisplayName = "SelfAwareJoinDecider should match hostnames with different case")]
@@ -439,7 +442,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                 address: null);
             
             // Should match despite case difference
-            decider.MatchesSelf(targetWithUppercaseHost, selfContactPoint).Should().BeTrue();
+            Assert.True(decider.MatchesSelf(targetWithUppercaseHost, selfContactPoint));
             
             // Create a target with mixed case hostname
             var targetWithMixedCaseHost = new ResolvedTarget(
@@ -448,7 +451,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                 address: null);
             
             // Should match despite case difference
-            decider.MatchesSelf(targetWithMixedCaseHost, selfContactPoint).Should().BeTrue();
+            Assert.True(decider.MatchesSelf(targetWithMixedCaseHost, selfContactPoint));
             
             // Create a target with completely different hostname
             var targetWithDifferentHost = new ResolvedTarget(
@@ -457,7 +460,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                 address: null);
             
             // Should not match
-            decider.MatchesSelf(targetWithDifferentHost, selfContactPoint).Should().BeFalse();
+            Assert.False(decider.MatchesSelf(targetWithDifferentHost, selfContactPoint));
         }
 
         protected override Task Start()
@@ -514,7 +517,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
             var targetList = info.SeedNodesObservations.Select(o => o.ContactPoint).ToList();
             targetList.Sort(ResolvedTargetComparer.Instance);
             var target = targetList.First();
-            decider.MatchesSelf(target, selfContactPoint).Should().BeTrue();
+            Assert.True(decider.MatchesSelf(target, selfContactPoint));
         }
         
         [Fact(DisplayName = "SelfAwareJoinDecider (IPv6) should be able to join self if all conditions met")]
@@ -526,16 +529,16 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
             var targetList = info.SeedNodesObservations.Select(o => o.ContactPoint).ToList();
             targetList.Sort(ResolvedTargetComparer.Instance);
             var target = targetList.First();
-            decider.CanJoinSelf(target, info).Should().BeTrue();
+            Assert.True(decider.CanJoinSelf(target, info));
         }
         
         [Fact(DisplayName = "SelfAwareJoinDecider (IPv6) should not join self if `new-cluster-enabled=off`, even if all conditions met")]
         public async Task NotJoinSelfIfNewClusterEnabledIsSetToOffEvenWhenAllConditionsMet()
         {
-            _settings!.NewClusterEnabled.Should().BeFalse();
+            Assert.False(_settings!.NewClusterEnabled);
             ClusterBootstrap.Get(System!).SetSelfContactPoint(new Uri($"http://10.0.0.2:{ManagementPort}/test"));
             var decider = new LowestAddressJoinDecider(System!, _settings);
-            (await decider.Decide(_seedNodes)).Should().Be(KeepProbing.Instance);
+            Assert.Equal(KeepProbing.Instance, await decider.Decide(_seedNodes));
         }
 
         [Fact(DisplayName = "SelfAwareJoinDecider should match hostnames with different case")]
@@ -552,7 +555,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                 address: null);
             
             // Should match despite case difference
-            decider.MatchesSelf(targetWithUppercaseHost, selfContactPoint).Should().BeTrue();
+            Assert.True(decider.MatchesSelf(targetWithUppercaseHost, selfContactPoint));
             
             // Create a target with mixed case hostname
             var targetWithMixedCaseHost = new ResolvedTarget(
@@ -561,7 +564,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                 address: null);
             
             // Should match despite case difference
-            decider.MatchesSelf(targetWithMixedCaseHost, selfContactPoint).Should().BeTrue();
+            Assert.True(decider.MatchesSelf(targetWithMixedCaseHost, selfContactPoint));
             
             // Create a target with completely different hostname
             var targetWithDifferentHost = new ResolvedTarget(
@@ -570,7 +573,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
                 address: null);
             
             // Should not match
-            decider.MatchesSelf(targetWithDifferentHost, selfContactPoint).Should().BeFalse();
+            Assert.False(decider.MatchesSelf(targetWithDifferentHost, selfContactPoint));
         }
 
         protected override Task Start()

--- a/src/management/Akka.Management.Tests/Discovery/Config/ConfigServiceConfigSpec.cs
+++ b/src/management/Akka.Management.Tests/Discovery/Config/ConfigServiceConfigSpec.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using Akka.Discovery.Config;
 using Akka.Discovery.Config.Hosting;
 using Akka.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -35,9 +34,13 @@ public class ConfigServiceConfigSpec
         var systemConfig = builder.Configuration.Value;
         var config = systemConfig.GetConfig(ConfigServiceDiscoveryOptions.DefaultConfigPath);
 
-        Type.GetType(config.GetString("class")).Should().Be(typeof(ConfigServiceDiscovery));
-        config.GetString("services-path").Should().Be("akka.discovery.config.services");
-        config.GetStringList("services.Test.endpoints").Should().BeEquivalentTo("abc:1", "def:2");
+        Assert.Equal(typeof(ConfigServiceDiscovery), Type.GetType(config.GetString("class")));
+        Assert.Equal("akka.discovery.config.services", config.GetString("services-path"));
+        // converted from BeEquivalentTo (order-insensitive)
+        var defaultEndpoints = config.GetStringList("services.Test.endpoints");
+        Assert.Equal(2, defaultEndpoints.Count);
+        Assert.Contains("abc:1", defaultEndpoints);
+        Assert.Contains("def:2", defaultEndpoints);
     }
     
     [Fact(DisplayName = "ConfigServiceDiscoveryOptions should generate proper HOCON config on the correct config path")]
@@ -59,11 +62,15 @@ public class ConfigServiceConfigSpec
         var systemConfig = builder.Configuration.Value;
         var config = systemConfig.GetConfig(ConfigServiceDiscoveryOptions.FullPath("new-config"));
 
-        Type.GetType(config.GetString("class")).Should().Be(typeof(ConfigServiceDiscovery));
-        config.GetString("services-path").Should().Be("akka.discovery.new-config.services");
-        config.GetStringList("services.Test.endpoints").Should().BeEquivalentTo("abc:1", "def:2");
+        Assert.Equal(typeof(ConfigServiceDiscovery), Type.GetType(config.GetString("class")));
+        Assert.Equal("akka.discovery.new-config.services", config.GetString("services-path"));
+        // converted from BeEquivalentTo (order-insensitive)
+        var endpoints = config.GetStringList("services.Test.endpoints");
+        Assert.Equal(2, endpoints.Count);
+        Assert.Contains("abc:1", endpoints);
+        Assert.Contains("def:2", endpoints);
 
-        systemConfig.GetConfig(ConfigServiceDiscoveryOptions.DefaultConfigPath).Should().BeNull();
+        Assert.Null(systemConfig.GetConfig(ConfigServiceDiscoveryOptions.DefaultConfigPath));
     }
     
 }

--- a/src/management/Akka.Management.Tests/HostingSpecs.cs
+++ b/src/management/Akka.Management.Tests/HostingSpecs.cs
@@ -15,7 +15,6 @@ using Akka.Actor;
 using Akka.Hosting;
 using Akka.Http.Dsl;
 using Akka.Management.Dsl;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -124,7 +123,7 @@ namespace Akka.Management.Tests
             await testKit.AwaitAssertAsync(async () =>
             {
                 var response = await client.GetAsync($"http://localhost:{port}/bootstrap/seed-nodes");
-                response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+                Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
             }, TimeSpan.FromSeconds(5));
         }
 


### PR DESCRIPTION
**Part 3 of 3 — finishes the FluentAssertions removal.** Migrates the last test projects (**Management + Http.Shim + DNS**) to native xUnit `Assert.*` and **removes FluentAssertions from the repo entirely**.

### Scope
- **16 test files** converted: `src/discovery/dns/**` (2), `src/management/Akka.Http.Shim.Tests/**` (2), `src/management/Akka.Management.Tests/**` (12).
- **FluentAssertions fully removed:** the `<PackageReference Include="FluentAssertions" />` dropped from all **12** test csprojs, and both the `FluentAssertions` `PackageVersion` and the `FluentAssertionVersion` property removed from `Directory.Packages.props`.

After this PR the repo has **zero** `using FluentAssertions`, **zero** `.Should(`, and **zero** FluentAssertions package references.

### Semantic equivalence — independently verified
Conversion and review were done by **separate agents**. The adversarial reviewer decompiled FA 7.0.0 and xUnit v3 to verify semantics rather than trust the converter:

- **Confirmed faithful:** FA `WithMessage` is a case-insensitive full-string wildcard → mapped to `OrdinalIgnoreCase` `Contains`/`EndsWith` and `ignoreCase` `Assert.Equal`; `.ThrowAsync<Exception>()` (accepts derived) → `Assert.ThrowsAnyAsync<Exception>`; `NamedRouteProvider`/`ResolvedTarget` value-equality vs `JoinOtherSeedNodes` reference-equality handled correctly; `BeEquivalentTo` order-insensitive lists converted with total, tie-free sort keys; no dropped assertions (202 removed `.Should()` reconcile with 216 added, from throw+message and multiset expansions).
- **6 findings — fixed:** FA's *plain* `StartWith`/`EndWith`/`Contain` use `StringComparison.Ordinal`, but xUnit v3's defaults are `CurrentCulture` (strictly looser). Not observable with the current ASCII data, but to preserve exact equivalence, `StringComparison.Ordinal` was appended to all 6 sites (DNS spec ×4, `InactiveAkkaManagementSpec` ×1, `HttpContactPointRoutesSpec` ×1).

### Verification
- Full-solution `dotnet build -c Release`: **0 errors** (proves the FA removal breaks nothing repo-wide).
- Affected suites green on net10.0: Dns 43/43, Http.Shim 2/2, Akka.Management.Tests 55/55 (1 skip).

### Follow-ups (tracked separately, not in this PR)
- A pre-existing flaky Windows `LeaseActor` timing test (root-caused: the test's `ExpectNoMsg` sits inside the actor's `HeartbeatTimeout/2` self-timeout window).
- Optional: tighten the same plain-string `Ordinal` drift in the already-merged parts 1–2 (latent, ASCII-only).
