### PR TITLE
Fix flaky LeaseActor Windows test (decouple probe wait from operation-timeout budget)

### DIFF
--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/LeaseActorSpec.cs
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/LeaseActorSpec.cs
@@ -800,8 +800,12 @@ namespace Akka.Coordination.KubernetesApi.Tests
                     OwnerName,
                     CurrentVersion,
                     CurrentTime - LeaseSettings.TimeoutSettings.HeartbeatTimeout * 2));
-                SenderProbe.ExpectNoMsg(LeaseSettings.TimeoutSettings.HeartbeatTimeout / 3); // not granted yet
+                // Confirm the renewal write first: its arrival deterministically proves the actor took
+                // the granting/write path (rather than granting from cache). Then keep the "not granted
+                // yet" wait to HeartbeatInterval so it does not burn the actor's own HeartbeatTimeout/2
+                // operation-duration budget -- the longer HeartbeatTimeout/3 wait here flaked on slow CI.
                 UpdateProbe.ExpectMsg((OwnerName, CurrentVersion)); // Update time
+                SenderProbe.ExpectNoMsg(LeaseSettings.TimeoutSettings.HeartbeatInterval); // not granted yet
                 IncrementVersion();
                 UpdateProbe.Reply(
                     new Right<LeaseResource, LeaseResource>(


### PR DESCRIPTION
Fixes an intermittent Windows-CI failure in `LeaseActorSpec` → *"should renew time if lease is owned by client on initial acquire"*:

```
Expected a message of type ...LeaseActor+LeaseAcquired, but received
{Failure: LeaseTimeoutException: API server took too long to respond: 156.0311}
```

### Root cause
`LeaseActor` runs a **post-hoc soft-timeout self-check**: when a renewal write completes it computes `DateTime.UtcNow - operationStartTime` and, if it exceeds **`HeartbeatTimeout/2`** (`LeaseActor.cs:346-353`), replies `Status.Failure(LeaseTimeoutException)` instead of `LeaseAcquired`. `operationStartTime` is stamped when the write is *dispatched*.

The test fixture sets `HeartbeatTimeout = 250ms` → budget **125ms**. But the test deliberately held the write reply behind `SenderProbe.ExpectNoMsg(HeartbeatTimeout/3)` ≈ **83ms** to prove "not granted yet" — and that sleep sits *inside* the measured window. Absolute slack was only `HeartbeatTimeout × (1/2 − 1/3) = HeartbeatTimeout/6 ≈ **42ms**` for thread-pool hops, DEBUG logging, GC and JIT — which a slow/busy Windows agent blows past (observed 156ms > 125ms). Fast runs spend a few ms and pass. It's a **test bug, not a production bug** (the sibling test taking the same path *without* the sleep never flakes, and the intentional-timeout test is unaffected).

### Fix (test-only, no production change)
Retrieve the renewal write with `UpdateProbe.ExpectMsg(...)` **first** — its arrival is the deterministic proof the actor took the granting/write path — then keep the "not granted yet" wait to `HeartbeatInterval` (~25ms) instead of `HeartbeatTimeout/3`. Headroom under the 125ms budget goes from ~42ms to ~100ms. The test still proves an owned-but-expired lease renews via a write before replying `LeaseAcquired`, and does not grant prematurely.

### Verification
`LeaseActorSpec` passes **6/6** consecutive local runs (35 passed, 1 skipped each).

Root-caused with the Akka.NET + concurrency specialists; surfaced during the FluentAssertions migration when this test flaked on a PR-validation re-run.
