### PR TITLE
Add READMEs for the Akka.Aspire packages; root-README fallback for the rest

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,28 @@
+<Project>
+
+  <!--
+    README fallback for packaging.
+
+    A packable project that does NOT ship its own README.md (in its project directory) falls back to
+    the repository's root README.md on its NuGet page, instead of shipping with no readme at all.
+
+    Projects that provide their own README.md and wire <PackageReadmeFile> themselves are left
+    untouched (the '$(PackageReadmeFile)' == '' and !Exists(local README) guards both exclude them).
+    Test and sample projects are excluded because they set <IsPackable>false</IsPackable>.
+
+    This lives in Directory.Build.targets (imported after the project body) so that $(IsPackable),
+    set inside each .csproj, is resolved before these conditions are evaluated.
+  -->
+  <!-- '$(IsPackable)' != 'false' matches both explicit true and the default (empty): packable
+       unless a project opts out with IsPackable=false, which is how test/sample projects exclude
+       themselves. -->
+  <PropertyGroup Condition=" '$(IsPackable)' != 'false' AND '$(PackageReadmeFile)' == '' AND !Exists('$(MSBuildProjectDirectory)/README.md') ">
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <_UseRootReadmeFallback>true</_UseRootReadmeFallback>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(_UseRootReadmeFallback)' == 'true' ">
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/aspire/Akka.Aspire.Hosting/Akka.Aspire.Hosting.csproj
+++ b/src/aspire/Akka.Aspire.Hosting/Akka.Aspire.Hosting.csproj
@@ -8,6 +8,7 @@
     <IsAspireSharedProject>true</IsAspireSharedProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +17,10 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/aspire/Akka.Aspire.Hosting/README.md
+++ b/src/aspire/Akka.Aspire.Hosting/README.md
@@ -1,0 +1,75 @@
+# Akka.Aspire.Hosting
+
+.NET Aspire **hosting integration** for Akka.NET clusters. Add it to your Aspire AppHost to declare a
+cluster's topology — discovery backend, replica count, ports — and every service replica wired with
+`WithReference` will automatically discover its peers, form a cluster, and report health.
+
+Pair it with the service-side [`Akka.Aspire`](https://www.nuget.org/packages/Akka.Aspire) package,
+which reads the configuration this package injects.
+
+## Installation
+
+```
+dotnet add package Akka.Aspire.Hosting
+```
+
+## Usage (AppHost)
+
+```csharp
+using Akka.Aspire.Hosting;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+// A discovery-backend Aspire resource (Redis here; Azure Table Storage is also supported)
+var redis = builder.AddRedis("akka-discovery");
+
+// Declare the Akka.NET cluster and bind its discovery backend
+var akka = builder.AddAkka("my-cluster")
+    .WithClustering(redis);
+
+// Wire the cluster into a replicated service
+builder.AddProject<Projects.MyService>("service")
+    .WithHttpEndpoint(name: "http")
+    .WithReplicas(3)
+    .WithReference(akka);
+
+builder.Build().Run();
+```
+
+`AddAkka` declares the cluster; `WithClustering(resource)` binds the discovery backend (the provider
+type is auto-detected from the resource — e.g. `Redis`, `AzureTableStorage`); and `WithReference(akka)`
+injects the resulting configuration into each service replica.
+
+## What it injects
+
+`WithReference(akka)` sets these environment variables on each replica, which the service-side
+`Akka.Aspire` package reads via `IConfiguration`:
+
+| Variable | Purpose |
+|----------|---------|
+| `Akka__Cluster__Enabled` | Enables clustering |
+| `Akka__Cluster__RemotePort` / `Akka__Cluster__ManagementPort` | Unique ports per replica |
+| `Akka__Cluster__PublicHostName` / `Akka__Cluster__ServiceName` | Discovery identity |
+| `Akka__Cluster__RequiredContactPointsNr` | Derived from the replica count |
+| `Akka__Cluster__Clustering__ProviderType` | Auto-detected from the resource type |
+| `Akka__Cluster__Clustering__ConnectionStringName` | The Aspire resource name for the discovery backend |
+| `ConnectionStrings__<name>` | The connection string for that backend |
+
+## Supported discovery backends
+
+- **Redis** — `builder.AddRedis(...)` + service-side [`Akka.Discovery.Redis`](https://www.nuget.org/packages/Akka.Discovery.Redis)
+- **Azure Table Storage** — `builder.AddAzureStorage(...).AddTables(...)` + [`Akka.Discovery.Azure`](https://www.nuget.org/packages/Akka.Discovery.Azure)
+- **Kubernetes** — service-side [`Akka.Discovery.KubernetesApi`](https://www.nuget.org/packages/Akka.Discovery.KubernetesApi) (no connection string needed)
+
+Complete Redis and Azure Table Storage samples live under `src/aspire/examples/` in the
+[Akka.Management](https://github.com/akkadotnet/Akka.Management) repository.
+
+## Learn more
+
+- [Akka.NET Clustering](https://getakka.net/articles/clustering/cluster-overview.html)
+- [Akka.Management & Cluster Bootstrap](https://github.com/akkadotnet/Akka.Management)
+- [.NET Aspire](https://learn.microsoft.com/dotnet/aspire)
+
+## License
+
+Apache-2.0

--- a/src/aspire/Akka.Aspire/Akka.Aspire.csproj
+++ b/src/aspire/Akka.Aspire/Akka.Aspire.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +20,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\management\Akka.Management\Akka.Management.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/aspire/Akka.Aspire/README.md
+++ b/src/aspire/Akka.Aspire/README.md
@@ -1,0 +1,94 @@
+# Akka.Aspire
+
+.NET Aspire **service (client) integration** for Akka.NET clusters. Call `WithAspireClusterBootstrap`
+in your service and it configures Akka.Remote, Akka.Cluster, Akka.Management, Cluster Bootstrap, and a
+cluster-membership health check from the configuration that the
+[`Akka.Aspire.Hosting`](https://www.nuget.org/packages/Akka.Aspire.Hosting) AppHost package injects —
+no manual HOCON required.
+
+## Installation
+
+```
+dotnet add package Akka.Aspire
+```
+
+## Usage (service)
+
+```csharp
+using Akka.Aspire;
+using Akka.Discovery.Redis;
+using Akka.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAkka("MySystem", (akkaBuilder, sp) =>
+{
+    akkaBuilder.WithAspireClusterBootstrap(sp,
+        configureDiscovery: (b, config) =>
+        {
+            // The AppHost injects the discovery resource's name; fall back to a literal for clarity.
+            var connectionStringName = config["Akka:Cluster:Clustering:ConnectionStringName"] ?? "akka-discovery";
+            var redisConn = config.GetConnectionString(connectionStringName);
+            if (!string.IsNullOrEmpty(redisConn))
+                b.WithRedisDiscovery(redisConn, config["Akka:Cluster:ServiceName"]);
+        },
+        clusterConfigure: c => c.Roles = ["my-service"]);
+});
+
+builder.Services.AddHealthChecks();
+
+var app = builder.Build();
+app.MapHealthChecks("/healthz");
+app.MapGet("/", () => "Hello from Akka.NET Aspire!");
+app.Run();
+```
+
+`WithAspireClusterBootstrap` reads the Aspire-injected environment variables and stands up the full
+cluster stack. The `configureDiscovery` callback wires the discovery plugin using the same
+`IConfiguration` that Aspire populates, and `clusterConfigure` sets roles and other cluster options.
+
+## Swapping discovery providers
+
+Only the AppHost resource and the `configureDiscovery` callback change between environments — the rest
+of the service stays identical.
+
+**Azure Table Storage** (local dev via Azurite, production via real Azure):
+```csharp
+akkaBuilder.WithAspireClusterBootstrap(sp,
+    configureDiscovery: (b, config) =>
+    {
+        var name = config["Akka:Cluster:Clustering:ConnectionStringName"] ?? "akka-discovery";
+        var conn = config.GetConnectionString(name);
+        if (!string.IsNullOrEmpty(conn))
+            b.WithAzureDiscovery(conn, config["Akka:Cluster:ServiceName"]);
+    },
+    clusterConfigure: c => c.Roles = ["my-service"]);
+```
+
+**Kubernetes** (no connection string needed):
+```csharp
+akkaBuilder.WithAspireClusterBootstrap(sp,
+    configureDiscovery: (b, config) => b.WithKubernetesDiscovery(),
+    clusterConfigure: c => c.Roles = ["my-service"]);
+```
+
+## Health checks
+
+`WithAspireClusterBootstrap` registers a cluster-membership health check tagged `readiness`, so a
+`/healthz/ready` probe reports Healthy only once the node has joined the cluster (`MemberStatus.Up`):
+
+```csharp
+app.MapHealthChecks("/healthz/ready",
+    new HealthCheckOptions { Predicate = c => c.Tags.Contains("readiness") });
+```
+
+## Learn more
+
+- [Akka.NET Clustering](https://getakka.net/articles/clustering/cluster-overview.html)
+- [Akka.Management & Cluster Bootstrap](https://github.com/akkadotnet/Akka.Management)
+- [Akka.Hosting](https://github.com/akkadotnet/Akka.Hosting)
+- [.NET Aspire](https://learn.microsoft.com/dotnet/aspire)
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Adds README documentation for the two Aspire packages and a root-README fallback for the rest, ahead of the 1.5.70 release that ships `Akka.Discovery.Redis` and the Aspire integration.

### What
- **`Akka.Aspire.Hosting/README.md`** (hosting/AppHost side) and **`Akka.Aspire/README.md`** (service/client side) — new per-package READMEs adapted from the repo the Aspire integration was ported from, grounded in the in-repo `src/aspire/examples/` sample code. Each covers usage, the injected `Akka__Cluster__*` env-var contract, discovery providers (Redis / Azure Table Storage / Kubernetes), and the readiness membership health check. Both wired via `<PackageReadmeFile>`.
- **`Directory.Build.targets`** — a packable project without its own `README.md` now falls back to the repository root README on its NuGet page instead of shipping with none. Applies to `Akka.Http.Shim` today; projects with their own README, and test/sample projects (`IsPackable=false`), are untouched.

### Verified
`dotnet pack` on four representative projects embeds the expected readme:

| Package | README in `.nupkg` |
|---------|--------------------|
| `Akka.Aspire` | its own (`# Akka.Aspire`) |
| `Akka.Aspire.Hosting` | its own (`# Akka.Aspire.Hosting`) |
| `Akka.Discovery.Redis` | its own (unchanged) |
| `Akka.Http.Shim` | root README fallback (`# Akka Management`) |

No double-includes; the other 8 packages already ship their own READMEs and are unaffected.
