### PR TITLE
Update RELEASE_NOTES.md and bump version for 1.5.70 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.68</VersionPrefix>
+    <VersionPrefix>1.5.70</VersionPrefix>
     <PackageReleaseNotes>* Update to [Akka.NET v1.5.68](https://github.com/akkadotnet/akka.net/releases/tag/1.5.68)
 * Update to [Akka.Hosting v1.5.68](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.68)</PackageReleaseNotes>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+#### 1.5.70 August 18th 2026 ####
+
+* Update to [Akka.NET v1.5.70](https://github.com/akkadotnet/akka.net/releases/tag/1.5.70)
+* Update to [Akka.Hosting v1.5.70](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.70)
+* **New package: [`Akka.Discovery.Redis`](https://www.nuget.org/packages/Akka.Discovery.Redis)** — Redis-based service discovery for Akka.Cluster.Bootstrap. Each node registers under a TTL key and refreshes it on a heartbeat; dead nodes expire automatically (no separate pruning process) and stale entries are filtered out of lookups. A lightweight alternative to `Akka.Discovery.Azure`, well suited to Redis-backed environments and .NET Aspire local development. ([#3444](https://github.com/akkadotnet/Akka.Management/pull/3444))
+* **New: .NET Aspire integration** — [`Akka.Aspire.Hosting`](https://www.nuget.org/packages/Akka.Aspire.Hosting) (AppHost side) and [`Akka.Aspire`](https://www.nuget.org/packages/Akka.Aspire) (service side) bring automated Akka.NET cluster formation to [.NET Aspire](https://learn.microsoft.com/dotnet/aspire). Declare the discovery backend and replica count in your AppHost, and each service replica auto-discovers its peers, forms a cluster, and reports readiness through a health check — no manual HOCON. ([#3445](https://github.com/akkadotnet/Akka.Management/pull/3445))
+
 #### 1.5.68 May 31st 2026 ####
 
 * Update to [Akka.NET v1.5.68](https://github.com/akkadotnet/akka.net/releases/tag/1.5.68)


### PR DESCRIPTION
Release **1.5.70**, adding the two new packages:

* **`Akka.Discovery.Redis`** — Redis-based service discovery for Akka.Cluster.Bootstrap ([#3444](https://github.com/akkadotnet/Akka.Management/pull/3444)).
* **.NET Aspire integration** — `Akka.Aspire.Hosting` + `Akka.Aspire` for automated cluster formation ([#3445](https://github.com/akkadotnet/Akka.Management/pull/3445)).

Bumps `VersionPrefix` 1.5.68 → 1.5.70 and adds the 1.5.70 `RELEASE_NOTES.md` section. The `1.5.70` tag is pushed after this merges to trigger the publish pipeline.