### PR TITLE
Bump Incrementalist from 1.2.1 to 1.2.2

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "incrementalist.cmd": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "commands": [
         "incrementalist"
       ],


### PR DESCRIPTION
Incrementalist 1.2.2 properly resolves the .NET 10 SDK / bundled-MSBuild crash that 1.2.1 was pinned around.

Validated locally: `dotnet incrementalist run --config .incrementalist/incrementalist.json --dry` completes the full MSBuild solution dependency analysis on the net10 SDK with no crash (267 files, exit 0).