### PR TITLE
security: pin vulnerable transitive packages (Scriban.Signed critical, MessagePack, SSH.NET)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -111,6 +111,15 @@
     <PackageVersion Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
   </ItemGroup>
 
+  <!-- Security: pin vulnerable transitive dependencies to patched versions.
+       MessagePack 2.5.192 (high), Scriban.Signed 5.5.0 (critical), SSH.NET 2024.2.0 (high)
+       are pulled in transitively (mostly by test/example projects). -->
+  <ItemGroup>
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
+    <PackageVersion Include="Scriban.Signed" Version="6.6.0" />
+    <PackageVersion Include="SSH.NET" Version="2025.1.0" />
+  </ItemGroup>
+
   <!-- Other packages -->
   <ItemGroup>
     <PackageVersion Include="Ceen.Httpd" Version="0.9.9" />

--- a/src/aspire/Akka.Aspire.Hosting.Tests/Akka.Aspire.Hosting.Tests.csproj
+++ b/src/aspire/Akka.Aspire.Hosting.Tests/Akka.Aspire.Hosting.Tests.csproj
@@ -27,4 +27,9 @@
       <ProjectReference Include="..\Akka.Aspire.Hosting\Akka.Aspire.Hosting.csproj" />
       <ProjectReference Include="..\examples\Akka.Aspire.Sample.AppHost\Akka.Aspire.Sample.AppHost.csproj" IsAspireProjectResource="false" />
     </ItemGroup>
+
+  <!-- Security: override vulnerable transitive dependency with a patched version (version pinned centrally in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="MessagePack" />
+  </ItemGroup>
 </Project>

--- a/src/aspire/Akka.Aspire.Hosting/Akka.Aspire.Hosting.csproj
+++ b/src/aspire/Akka.Aspire.Hosting/Akka.Aspire.Hosting.csproj
@@ -23,4 +23,9 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+
+  <!-- Security: override vulnerable transitive dependency with a patched version (version pinned centrally in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="MessagePack" />
+  </ItemGroup>
 </Project>

--- a/src/aspire/examples/Akka.Aspire.Sample.AppHost/Akka.Aspire.Sample.AppHost.csproj
+++ b/src/aspire/examples/Akka.Aspire.Sample.AppHost/Akka.Aspire.Sample.AppHost.csproj
@@ -20,4 +20,9 @@
     <ProjectReference Include="..\Akka.Aspire.Sample.Service\Akka.Aspire.Sample.Service.csproj" />
   </ItemGroup>
 
+
+  <!-- Security: override vulnerable transitive dependency with a patched version (version pinned centrally in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="MessagePack" />
+  </ItemGroup>
 </Project>

--- a/src/aspire/examples/Akka.Aspire.Sample.Azure.AppHost/Akka.Aspire.Sample.Azure.AppHost.csproj
+++ b/src/aspire/examples/Akka.Aspire.Sample.Azure.AppHost/Akka.Aspire.Sample.Azure.AppHost.csproj
@@ -20,4 +20,9 @@
     <ProjectReference Include="..\Akka.Aspire.Sample.Azure.Service\Akka.Aspire.Sample.Azure.Service.csproj" />
   </ItemGroup>
 
+
+  <!-- Security: override vulnerable transitive dependency with a patched version (version pinned centrally in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="MessagePack" />
+  </ItemGroup>
 </Project>

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/Akka.Coordination.Azure.Tests.csproj
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/Akka.Coordination.Azure.Tests.csproj
@@ -35,4 +35,10 @@
       </Compile>
     </ItemGroup>
 
+
+  <!-- Security: override vulnerable transitive dependency with a patched version (version pinned centrally in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="Scriban.Signed" />
+    <PackageReference Include="SSH.NET" />
+  </ItemGroup>
 </Project>

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/Akka.Coordination.KubernetesApi.Tests.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi.Tests/Akka.Coordination.KubernetesApi.Tests.csproj
@@ -26,4 +26,9 @@
       <ProjectReference Include="..\..\..\discovery\kubernetes\Akka.Discovery.KubernetesApi\Akka.Discovery.KubernetesApi.csproj" />
       <ProjectReference Include="..\Akka.Coordination.KubernetesApi\Akka.Coordination.KubernetesApi.csproj" />
     </ItemGroup>
+
+  <!-- Security: override vulnerable transitive dependency with a patched version (version pinned centrally in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="Scriban.Signed" />
+  </ItemGroup>
 </Project>

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/Akka.Discovery.AwsApi.Integration.Tests.csproj
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/Akka.Discovery.AwsApi.Integration.Tests.csproj
@@ -34,4 +34,9 @@
       <None Remove="akka-cluster.json" />
       <EmbeddedResource Include="akka-cluster.json" />
     </ItemGroup>
+
+  <!-- Security: override vulnerable transitive dependency with a patched version (version pinned centrally in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="SSH.NET" />
+  </ItemGroup>
 </Project>

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/Akka.Discovery.Azure.Tests.csproj
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/Akka.Discovery.Azure.Tests.csproj
@@ -27,4 +27,9 @@
       <ProjectReference Include="..\..\..\management\Akka.Management\Akka.Management.csproj" />
       <ProjectReference Include="..\Akka.Discovery.Azure\Akka.Discovery.Azure.csproj" />
     </ItemGroup>
+
+  <!-- Security: override vulnerable transitive dependency with a patched version (version pinned centrally in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="SSH.NET" />
+  </ItemGroup>
 </Project>

--- a/src/discovery/redis/Akka.Discovery.Redis.Tests/Akka.Discovery.Redis.Tests.csproj
+++ b/src/discovery/redis/Akka.Discovery.Redis.Tests/Akka.Discovery.Redis.Tests.csproj
@@ -27,4 +27,9 @@
       <ProjectReference Include="..\..\..\management\Akka.Management\Akka.Management.csproj" />
       <ProjectReference Include="..\Akka.Discovery.Redis\Akka.Discovery.Redis.csproj" />
     </ItemGroup>
+
+  <!-- Security: override vulnerable transitive dependency with a patched version (version pinned centrally in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="SSH.NET" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The NuGet audit flags three transitively-pulled packages (mostly via test/example projects) with known advisories. This pins patched versions.

| Package | From → To | Advisories cleared |
|---|---|---|
| **Scriban.Signed** | 5.5.0 → 6.6.0 | 1 critical, 7 high, 4 moderate |
| **MessagePack** | 2.5.192 → 2.5.302 | 2 high, 9 moderate |
| **SSH.NET** | 2024.2.0 → 2025.1.0 | 1 high |

Patched versions are pinned in `Directory.Packages.props` with a direct `PackageReference` in each affected project (9 projects). `CentralPackageTransitivePinningEnabled` is deliberately **not** used — it turns every centrally-managed version into a transitive floor and collides (NU1109) with the newer versions Aspire 13.3.5 requires.

**Verified locally:** `dotnet restore` clean (no NU1109), `dotnet list package --vulnerable --include-transitive` clears all three, full solution builds with 0 errors.

**Out of scope (separate change):** `OpenTelemetry.Api 1.10.0` (moderate) comes in transitively via `Akka.Hosting → OpenTelemetry 1.10.0` across ~33 projects, so it's better fixed at the source than with 33 direct references.