### PR TITLE
Enable TreatWarningsAsErrors + fail on high/critical NuGet audit advisories

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,13 @@
   <PropertyGroup>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Fail the build on high/critical NuGet audit advisories. NU1902 (moderate) stays a warning
+         until the remaining OpenTelemetry.Api transitive is bumped separately. -->
+    <WarningsAsErrors>$(WarningsAsErrors);NU1903;NU1904</WarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902</WarningsNotAsErrors>
   </PropertyGroup>
+
   <PropertyGroup>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency;service discovery;cluster;clustering;</AkkaPackageTags>
     <LibraryFramework>netstandard2.0</LibraryFramework>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,10 @@
     <!-- Fail the build on high/critical NuGet audit advisories. NU1902 (moderate) stays a warning
          until the remaining OpenTelemetry.Api transitive is bumped separately. -->
     <WarningsAsErrors>$(WarningsAsErrors);NU1903;NU1904</WarningsAsErrors>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902</WarningsNotAsErrors>
+    <!-- NU1902 (moderate audit): stays a warning until OpenTelemetry.Api is bumped.
+         NU5048 (pack): 'PackageIconUrl' is deprecated in favour of an embedded 'PackageIcon';
+         keep it a warning here — migrating the package icon is a separate packaging change. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902;NU5048</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -111,13 +111,15 @@
     <PackageVersion Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
   </ItemGroup>
 
-  <!-- Security: pin vulnerable transitive dependencies to patched versions.
-       MessagePack 2.5.192 (high), Scriban.Signed 5.5.0 (critical), SSH.NET 2024.2.0 (high)
-       are pulled in transitively (mostly by test/example projects). -->
+  <!-- Security: pin vulnerable transitive dependencies (pulled in by test/example projects) to
+       genuinely-patched versions per the GitHub advisory DB:
+         MessagePack   2.5.192 (high)                -> 2.5.302
+         Scriban.Signed 5.5.0  (critical; fixed 7.0.0, DoS fixed 7.2.0) -> 7.2.6
+         SSH.NET       2024.2.0 (high; fixed 2026.0.0) -> 2026.0.0 -->
   <ItemGroup>
     <PackageVersion Include="MessagePack" Version="2.5.302" />
-    <PackageVersion Include="Scriban.Signed" Version="6.6.0" />
-    <PackageVersion Include="SSH.NET" Version="2025.1.0" />
+    <PackageVersion Include="Scriban.Signed" Version="7.2.6" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 
   <!-- Other packages -->

--- a/src/cluster.bootstrap/examples/discovery/azure/AzureCluster/Configuration/Extensions.cs
+++ b/src/cluster.bootstrap/examples/discovery/azure/AzureCluster/Configuration/Extensions.cs
@@ -24,7 +24,8 @@ public static class Extensions
         Action<ClusterOptions>? clusterConfiguration = null)
     {
         var configuration = provider.GetRequiredService<IConfiguration>();
-        var clusterConfigOptions = configuration.GetSection("cluster").Get<ClusterConfigOptions>();
+        var clusterConfigOptions = configuration.GetSection("cluster").Get<ClusterConfigOptions>()
+            ?? throw new InvalidOperationException("Missing 'cluster' configuration section.");
 
         var remoteOptions = new RemoteOptions
         {

--- a/src/cluster.bootstrap/examples/discovery/dns/src/Program.cs
+++ b/src/cluster.bootstrap/examples/discovery/dns/src/Program.cs
@@ -45,7 +45,8 @@ public static class Extensions
         Action<ClusterOptions>? clusterConfiguration = null)
     {
         var configuration = provider.GetRequiredService<IConfiguration>();
-        var clusterConfigOptions = configuration.GetSection("cluster").Get<ClusterConfigOptions>();
+        var clusterConfigOptions = configuration.GetSection("cluster").Get<ClusterConfigOptions>()
+            ?? throw new InvalidOperationException("Missing 'cluster' configuration section.");
 
         var remoteOptions = new RemoteOptions
         {

--- a/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/Configuration/Extensions.cs
+++ b/src/cluster.bootstrap/examples/discovery/kubernetes/src/KubernetesCluster/Configuration/Extensions.cs
@@ -24,7 +24,8 @@ public static class Extensions
         Action<ClusterOptions>? clusterConfiguration = null)
     {
         var configuration = provider.GetRequiredService<IConfiguration>();
-        var clusterConfigOptions = configuration.GetSection("cluster").Get<ClusterConfigOptions>();
+        var clusterConfigOptions = configuration.GetSection("cluster").Get<ClusterConfigOptions>()
+            ?? throw new InvalidOperationException("Missing 'cluster' configuration section.");
 
         var remoteOptions = new RemoteOptions
         {

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureApiSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/AzureApiSpec.cs
@@ -56,8 +56,6 @@ namespace Akka.Coordination.Azure.Tests
             Assert.Equal(Done.Instance, (await _underTest.RemoveLease(LeaseName)));
             var leaseRecord = await _underTest.ReadOrCreateLeaseResource(LeaseName);
             Assert.Null(leaseRecord.Owner);
-            // Version is a non-nullable ETag struct; FA's boxed NotBeNull() was vacuously true — preserved via boxing
-            Assert.NotNull((object)leaseRecord.Version);
         }
 
         [Fact(DisplayName = "Azure lease resource should update a lease successfully")]
@@ -120,8 +118,6 @@ namespace Akka.Coordination.Azure.Tests
             var secondInstance = new AzureApiImpl(Sys, _settings);
             var secondLease = await secondInstance.ReadOrCreateLeaseResource(LeaseName);
             Assert.Null(secondLease.Owner);
-            // Version is a non-nullable ETag struct; FA's boxed NotBeNull() was vacuously true — preserved via boxing
-            Assert.NotNull((object)secondLease.Version);
         }
 
         // Verifies that multiple independent AzureApiImpl instances can operate concurrently

--- a/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
+++ b/src/coordination/azure/Akka.Coordination.Azure.Tests/LeaseActorSpec.cs
@@ -645,7 +645,7 @@ namespace Akka.Coordination.Azure.Tests
                 var conflictVersion = new ETag((CurrentVersionCount + 5).ToString());
                 UpdateProbe.Reply(
                     new Left<LeaseResource, LeaseResource>(
-                        new LeaseResource(null, conflictVersion, CurrentTime)));
+                        new LeaseResource(null!, conflictVersion, CurrentTime)));
 
                 // Step 4: Retry write is dispatched — expect it with the new version
                 await UpdateProbe.ExpectMsgAsync((OwnerName, conflictVersion));
@@ -688,7 +688,7 @@ namespace Akka.Coordination.Azure.Tests
                 var conflictVersion = new ETag((CurrentVersionCount + 5).ToString());
                 UpdateProbe.Reply(
                     new Left<LeaseResource, LeaseResource>(
-                        new LeaseResource(null, conflictVersion, CurrentTime)));
+                        new LeaseResource(null!, conflictVersion, CurrentTime)));
 
                 // Step 4: Retry dispatched
                 await UpdateProbe.ExpectMsgAsync((OwnerName, conflictVersion));

--- a/src/coordination/examples/azure/Azure.StressTest/Configuration/Extensions.cs
+++ b/src/coordination/examples/azure/Azure.StressTest/Configuration/Extensions.cs
@@ -18,7 +18,8 @@ public static class Extensions
         Action<ClusterOptions>? clusterConfiguration = null)
     {
         var configuration = provider.GetRequiredService<IConfiguration>();
-        var clusterConfigOptions = configuration.GetSection("cluster").Get<ClusterConfigOptions>();
+        var clusterConfigOptions = configuration.GetSection("cluster").Get<ClusterConfigOptions>()
+            ?? throw new InvalidOperationException("Missing 'cluster' configuration section.");
 
         var remoteOptions = new RemoteOptions
         {

--- a/src/coordination/examples/azure/Azure.StressTest/Program.cs
+++ b/src/coordination/examples/azure/Azure.StressTest/Program.cs
@@ -58,7 +58,8 @@ using var host = new HostBuilder()
             
             // Add Akka.Management support
             var configuration = provider.GetRequiredService<IConfiguration>();
-            var clusterConfigOptions = configuration.GetSection("cluster").Get<ClusterConfigOptions>();
+            var clusterConfigOptions = configuration.GetSection("cluster").Get<ClusterConfigOptions>()
+                ?? throw new InvalidOperationException("Missing 'cluster' configuration section.");
             builder.WithAkkaManagement(setup =>
             {
                 setup.Http.HostName = clusterConfigOptions.Ip;

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/LocalStackFixture.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Integration.Tests/LocalStackFixture.cs
@@ -29,7 +29,7 @@ public sealed class LocalStackFixture: IAsyncLifetime
     private readonly LocalStackContainer _container;
 
     public bool IsWindows { get; private set; }
-    public string Endpoint { get; private set; }
+    public string Endpoint { get; private set; } = string.Empty;
     public AmazonCloudFormationClient? CfCClient { get; private set; }
     public AmazonEC2Client? Ec2Client { get; private set; }
     public AmazonS3Client? S3Client { get; private set; }

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Ec2TagBasedServiceDiscoverySpec.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Tests/Ec2TagBasedServiceDiscoverySpec.cs
@@ -18,7 +18,7 @@ namespace Akka.Discovery.AwsApi.Tests
         public void ParseEmptyString()
         {
             var result = Ec2TagBasedServiceDiscovery.ParseFiltersString("");
-            Assert.Equal(0, result.Count);
+            Assert.Empty(result);
         }
         
         [Fact(DisplayName = "Can parse simple filter")]
@@ -26,9 +26,9 @@ namespace Akka.Discovery.AwsApi.Tests
         {
             var filters = "tag:purpose=demo";
             var result = Ec2TagBasedServiceDiscovery.ParseFiltersString(filters);
-            Assert.Equal(1, result.Count);
+            Assert.Single(result);
             Assert.Equal("tag:purpose", result[0].Name);
-            Assert.Equal(1, result[0].Values.Count);
+            Assert.Single(result[0].Values);
             Assert.Equal("demo", result[0].Values[0]);
         }
 

--- a/src/discovery/aws/Akka.Discovery.AwsApi.Tests/UtilsSpec.cs
+++ b/src/discovery/aws/Akka.Discovery.AwsApi.Tests/UtilsSpec.cs
@@ -21,7 +21,7 @@ namespace Akka.Discovery.AwsApi.Tests
         {
             var list = Enumerable.Range(0, 10).Select(i => i.ToString());
             var chunked = list.ChunkBy(20).ToList();
-            Assert.Equal(1, chunked.Count);
+            Assert.Single(chunked);
             // converted from BeEquivalentTo (order-insensitive)
             Assert.Equal(Enumerable.Range(0, 10).Select(i => i.ToString()).OrderBy(x => x), chunked[0].OrderBy(x => x));
         }

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/ActorSpec.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/ActorSpec.cs
@@ -90,7 +90,7 @@ akka.remote.dot-netty.tcp.port = 0
             });
 
             var members = await GetEntriesAsync();
-            Assert.Equal(1, members.Count);
+            Assert.Single(members);
 
             Assert.True(members[0].LastUpdate > firstEntry.LastUpdate);
         }

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/ClusterMemberTableClientSpec.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/ClusterMemberTableClientSpec.cs
@@ -71,7 +71,7 @@ namespace Akka.Discovery.Azure.Tests
             {
                 entries.Add(entry);
             }
-            Assert.Equal(1, entries.Count);
+            Assert.Single(entries);
 
             var tableEntity = ClusterMember.FromEntity(entries[0]);
             Assert.Equal(tableEntity, entity);

--- a/src/discovery/azure/Akka.Discovery.Azure.Tests/XUnitLogger.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure.Tests/XUnitLogger.cs
@@ -58,7 +58,7 @@ namespace Akka.Discovery.Azure.Tests
             };
         }
 
-        public IDisposable BeginScope<TState>(TState state)
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
         {
             throw new NotImplementedException();
         }

--- a/src/discovery/azure/Akka.Discovery.Azure/Model/ClusterMember.cs
+++ b/src/discovery/azure/Akka.Discovery.Azure/Model/ClusterMember.cs
@@ -106,7 +106,7 @@ namespace Akka.Discovery.Azure.Model
             return (parts[0], IPAddress.Parse(parts[1]), int.Parse(parts[2]));
         }
 
-        public bool Equals(ClusterMember other)
+        public bool Equals(ClusterMember? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
@@ -120,7 +120,7 @@ namespace Akka.Discovery.Azure.Model
                 LastUpdate.Equals(other.LastUpdate);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is ClusterMember entity && Equals(entity);
 
         public override int GetHashCode()

--- a/src/discovery/dns/Akka.Discovery.Dns.Tests/DnsServiceDiscoverySpec.cs
+++ b/src/discovery/dns/Akka.Discovery.Dns.Tests/DnsServiceDiscoverySpec.cs
@@ -180,7 +180,7 @@ public abstract class DnsServiceDiscoveryBaseSpec(Configuration.Config config , 
     public async Task DnsServiceDiscoveryShouldHandleLookup(string serviceName, string? portName, string? protocol,
         string description)
     {
-        Output.WriteLine($"Testing SRV lookup for {description}: _{portName}._{protocol}.{serviceName}");
+        Output!.WriteLine($"Testing SRV lookup for {description}: _{portName}._{protocol}.{serviceName}");
         var serviceDiscovery = new Dns.DnsServiceDiscovery((ExtendedActorSystem)Sys);
 
         var lookup = new Lookup(serviceName, portName, protocol);
@@ -217,7 +217,7 @@ public abstract class DnsServiceDiscoveryBaseSpec(Configuration.Config config , 
     public async Task DnsServiceDiscoveryShouldHandleLookupOfA(string serviceName,
         string description)
     {
-        Output.WriteLine($"Testing A/AAAA lookup for {description}: {serviceName}");
+        Output!.WriteLine($"Testing A/AAAA lookup for {description}: {serviceName}");
         var serviceDiscovery = new Dns.DnsServiceDiscovery((ExtendedActorSystem)Sys);
 
         var lookup = new Lookup(serviceName);

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/AkkaHostingSpec.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/AkkaHostingSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Discovery.KubernetesApi.Tests
                 
             var system = host.Services.GetRequiredService<ActorSystem>();
                 
-            var settings = KubernetesDiscovery.Get(system).Settings;
+            var settings = KubernetesDiscoverySettings.Create(system);
             Assert.Equal("underTest", settings.PodNamespace);
                 
             Assert.Equal("kubernetes-api", system.Settings.Config.GetString("akka.discovery.method"));

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/KubernetesDiscoverySettingsSpec.cs
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi.Tests/KubernetesDiscoverySettingsSpec.cs
@@ -135,8 +135,14 @@ namespace Akka.Discovery.KubernetesApi.Tests
 
             using (var sys = ActorSystem.Create(nameof(KubernetesDiscoverySettingsSpec), setup))
             {
+                // TODO: KubernetesDiscovery.Settings is obsolete since 1.5.26, but this test deliberately
+                // verifies that a KubernetesDiscoverySetup is applied to the resolved settings — behavior
+                // that only the extension performs. KubernetesDiscoverySettings.Create(sys) reads config
+                // only and would not apply the Setup, so we intentionally exercise the obsolete member here.
+#pragma warning disable CS0618 // Type or member is obsolete
                 var settings = KubernetesDiscovery.Get(sys).Settings;
-                
+#pragma warning restore CS0618
+
                 Assert.Equal("a", settings.ApiCaPath);
                 Assert.Equal("b", settings.ApiTokenPath);
                 Assert.Equal("c", settings.ApiServiceHostEnvName);

--- a/src/management/Akka.Http.Shim.Tests/HttpSpec.cs
+++ b/src/management/Akka.Http.Shim.Tests/HttpSpec.cs
@@ -64,7 +64,7 @@ namespace Akka.Http.Shim.Tests
             var result = await client.GetAsync(url);
             if (result.StatusCode != expectedResult)
             {
-                Output.WriteLine(await result.Content.ReadAsStringAsync());
+                Output!.WriteLine(await result.Content.ReadAsStringAsync());
             }
             Assert.Equal(expectedResult, result.StatusCode);
         }

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/ContactPoint/ClusterBootstrapAutostartIntegrationSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/ContactPoint/ClusterBootstrapAutostartIntegrationSpec.cs
@@ -187,7 +187,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.ContactPoint
             {
                 var (coordinatorProbe, coordinator) = tuple;
                 coordinatorProbe.ExpectTerminated(coordinator);
-                Assert.Equal(0, ((RepointableActorRef) coordinator).Children.ToList().Count);
+                Assert.Empty(((RepointableActorRef) coordinator).Children.ToList());
             }
         }
         

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/Internal/BootstrapCoordinatorSpec.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/Internal/BootstrapCoordinatorSpec.cs
@@ -77,7 +77,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
                 Assert.True(targetsToCheck.Count >= 2);
                 Assert.Contains("host1", targetsToCheck.Select(t => t.Host));
                 Assert.Contains("host2", targetsToCheck.Select(t => t.Host));
-                Assert.Equal(0, targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet().Count);
+                Assert.Empty(targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet());
             });
             
             coordinator.Tell(new JoinOtherSeedNodes(new [] {Akka.Cluster.Cluster.Get(Sys).SelfAddress}.ToImmutableHashSet()));
@@ -111,7 +111,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
                 Assert.True(targetsToCheck.Count >= 2);
                 Assert.Contains("host1", targetsToCheck.Select(t => t.Host));
                 Assert.Contains("host2", targetsToCheck.Select(t => t.Host));
-                Assert.Equal(0, targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet().Count);
+                Assert.Empty(targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet());
             });
             
             coordinator.Tell(JoinSelf.Instance);
@@ -174,7 +174,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap.Internal
                 Assert.True(targetsToCheck.Count >= 2);
                 Assert.Contains("host1", targetsToCheck.Select(t => t.Host));
                 Assert.Contains("host2", targetsToCheck.Select(t => t.Host));
-                Assert.Equal(0, targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet().Count);
+                Assert.Empty(targetsToCheck.Where(t => t.Port != null).Select(t => t.Port).ToImmutableHashSet());
             });
         }
         

--- a/src/management/Akka.Management.Tests/Cluster/Bootstrap/XUnitLogger.cs
+++ b/src/management/Akka.Management.Tests/Cluster/Bootstrap/XUnitLogger.cs
@@ -58,7 +58,7 @@ namespace Akka.Management.Tests.Cluster.Bootstrap
             };
         }
 
-        public IDisposable BeginScope<TState>(TState state)
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
         {
             throw new NotImplementedException();
         }

--- a/src/management/Akka.Management.Tests/XUnitLogger.cs
+++ b/src/management/Akka.Management.Tests/XUnitLogger.cs
@@ -58,7 +58,7 @@ namespace Akka.Management.Tests
             };
         }
 
-        public IDisposable BeginScope<TState>(TState state)
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Turns on `TreatWarningsAsErrors` across the repo, after fixing the warnings that were in the way, and makes the NuGet audit fail the build on **high/critical** advisories.

### Code warnings fixed (~30, at the source)
- **xUnit2013** → `Assert.Single`/`Assert.Empty`; **xUnit2002** → removed asserts on the value-type `ETag`
- **CS8602** null-deref → throw on unbound config options / null-forgiving where the value is ctor-guaranteed
- **CS8625 / CS8618 / CS8767 / CS8765 / CS8633** nullability annotations (incl. production `ClusterMember.Equals`, behavior unchanged)
- **CS0618** `KubernetesDiscovery.Settings` → `KubernetesDiscoverySettings.Create` (one spec keeps the obsolete member behind a scoped `#pragma` because it drives a `Setup` that `Create()` would silently drop)

### Warnings-as-errors config (`Directory.Build.props`)
```xml
<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
<WarningsAsErrors>$(WarningsAsErrors);NU1903;NU1904</WarningsAsErrors>
<WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902</WarningsNotAsErrors>
```
`NU1902` (moderate) stays a warning until the remaining **OpenTelemetry.Api** transitive (via `Akka.Hosting` across ~33 projects) is bumped in a separate change.

### Completes the transitive security pins
The audit gate can only be honest if the pins are actually patched. Per the GitHub advisory DB the previously-pinned versions were **still vulnerable**, so this bumps them to genuinely-patched releases (no advisory suppression):
- **Scriban.Signed** → **7.2.6** (critical fixed in 7.0.0, DoS in 7.2.0)
- **SSH.NET** → **2026.0.0** (high fixed in 2026.0.0)
- MessagePack 2.5.302 was already clean.

### Verified locally
Restore clean, `dotnet list package --vulnerable --include-transitive` shows only the deferred `OpenTelemetry.Api` (moderate), and the full solution builds **0 errors** under warnings-as-errors.