### PR TITLE
security: bump transitive OpenTelemetry.Api to 1.15.3; fail on moderate audit advisories

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,11 +16,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Fail the build on high/critical NuGet audit advisories. NU1902 (moderate) stays a warning
          until the remaining OpenTelemetry.Api transitive is bumped separately. -->
-    <WarningsAsErrors>$(WarningsAsErrors);NU1903;NU1904</WarningsAsErrors>
-    <!-- NU1902 (moderate audit): stays a warning until OpenTelemetry.Api is bumped.
-         NU5048 (pack): 'PackageIconUrl' is deprecated in favour of an embedded 'PackageIcon';
+    <!-- Fail the build on ALL NuGet audit advisories (moderate/high/critical) now that the
+         transitive OpenTelemetry.Api has been bumped past its advisory. -->
+    <WarningsAsErrors>$(WarningsAsErrors);NU1902;NU1903;NU1904</WarningsAsErrors>
+    <!-- NU5048 (pack): 'PackageIconUrl' is deprecated in favour of an embedded 'PackageIcon';
          keep it a warning here — migrating the package icon is a separate packaging change. -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902;NU5048</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU5048</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,6 +71,12 @@
 
   <!-- OpenTelemetry packages (Aspire samples) -->
   <ItemGroup>
+    <!-- OpenTelemetry.Api pinned to 1.15.3: Akka.Hosting floors the OpenTelemetry SDK at 1.10.0,
+         whose transitive OpenTelemetry.Api 1.10.0 is flagged by GHSA-g94r-2vxg-569j (moderate;
+         patched in 1.15.3). Only the Api is overridden (via a direct reference in every project that
+         pulls Akka.Hosting); pinning the full SDK would drag in Microsoft.Extensions 10.x. The SDK's
+         dependency on the Api is a >= floor, so 1.15.3 satisfies it. -->
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />

--- a/src/aspire/Akka.Aspire/Akka.Aspire.csproj
+++ b/src/aspire/Akka.Aspire/Akka.Aspire.csproj
@@ -26,4 +26,10 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/aspire/examples/Akka.Aspire.Sample.Azure.Service/Akka.Aspire.Sample.Azure.Service.csproj
+++ b/src/aspire/examples/Akka.Aspire.Sample.Azure.Service/Akka.Aspire.Sample.Azure.Service.csproj
@@ -19,4 +19,10 @@
     <ProjectReference Include="..\..\..\discovery\azure\Akka.Discovery.Azure\Akka.Discovery.Azure.csproj" />
   </ItemGroup>
 
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/aspire/examples/Akka.Aspire.Sample.Service/Akka.Aspire.Sample.Service.csproj
+++ b/src/aspire/examples/Akka.Aspire.Sample.Service/Akka.Aspire.Sample.Service.csproj
@@ -19,4 +19,10 @@
     <ProjectReference Include="..\..\..\discovery\redis\Akka.Discovery.Redis\Akka.Discovery.Redis.csproj" />
   </ItemGroup>
 
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/cluster.bootstrap/examples/discovery/dns/src/DnsCluster.csproj
+++ b/src/cluster.bootstrap/examples/discovery/dns/src/DnsCluster.csproj
@@ -36,4 +36,10 @@
     </Compile>
   </ItemGroup>
 
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
+++ b/src/coordination/azure/Akka.Coordination.Azure/Akka.Coordination.Azure.csproj
@@ -37,4 +37,10 @@
 	<ItemGroup>
 	  <InternalsVisibleTo Include="Akka.Coordination.Azure.Tests" />
 	</ItemGroup>
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
+++ b/src/coordination/kubernetes/Akka.Coordination.KubernetesApi/Akka.Coordination.KubernetesApi.csproj
@@ -27,4 +27,10 @@
     <ItemGroup>
       <InternalsVisibleTo Include="Akka.Coordination.KubernetesApi.Tests" />
     </ItemGroup>
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/discovery/aws/Akka.Discovery.AwsApi/Akka.Discovery.AwsApi.csproj
+++ b/src/discovery/aws/Akka.Discovery.AwsApi/Akka.Discovery.AwsApi.csproj
@@ -27,4 +27,10 @@
     <ItemGroup>
       <InternalsVisibleTo Include="Akka.Discovery.AwsApi.Tests" />
     </ItemGroup>
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/discovery/azure/Akka.Discovery.Azure/Akka.Discovery.Azure.csproj
+++ b/src/discovery/azure/Akka.Discovery.Azure/Akka.Discovery.Azure.csproj
@@ -41,4 +41,10 @@
     <ItemGroup>
       <InternalsVisibleTo Include="Akka.Discovery.Azure.Tests" />
     </ItemGroup>
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/discovery/dns/Akka.Discovery.Dns/Akka.Discovery.Dns.csproj
+++ b/src/discovery/dns/Akka.Discovery.Dns/Akka.Discovery.Dns.csproj
@@ -25,4 +25,10 @@
     <ItemGroup>
       <InternalsVisibleTo Include="Akka.Discovery.Dns.Tests" />
     </ItemGroup>
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
+++ b/src/discovery/kubernetes/Akka.Discovery.KubernetesApi/Akka.Discovery.KubernetesApi.csproj
@@ -26,4 +26,10 @@
     <ItemGroup>
       <InternalsVisibleTo Include="Akka.Discovery.KubernetesApi.Tests" />
     </ItemGroup>
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/discovery/redis/Akka.Discovery.Redis/Akka.Discovery.Redis.csproj
+++ b/src/discovery/redis/Akka.Discovery.Redis/Akka.Discovery.Redis.csproj
@@ -40,4 +40,10 @@
     <ItemGroup>
       <InternalsVisibleTo Include="Akka.Discovery.Redis.Tests" />
     </ItemGroup>
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>

--- a/src/management/Akka.Management/Akka.Management.csproj
+++ b/src/management/Akka.Management/Akka.Management.csproj
@@ -29,4 +29,10 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Akka.Management.Tests" />
   </ItemGroup>
+
+  <!-- Security: override the OpenTelemetry version pulled transitively via Akka.Hosting
+       (OpenTelemetry.Api 1.10.0 advisory GHSA-g94r-2vxg-569j; version pinned in Directory.Packages.props). -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves the last outstanding NuGet audit advisory and completes the audit gate started in the warnings-as-errors PR.

### The advisory
`OpenTelemetry.Api 1.10.0` — pulled transitively via `Akka.Hosting → OpenTelemetry 1.10.0` across ~33 projects — is flagged by [`GHSA-g94r-2vxg-569j`](https://github.com/advisories/GHSA-g94r-2vxg-569j) (moderate; patched in **1.15.3**). An Akka.Hosting version bump doesn't help — both 1.5.68 and 1.5.70 floor OpenTelemetry at 1.10.0.

### The fix (Api-only override)
Override just **`OpenTelemetry.Api` → 1.15.3** with a direct reference in the 12 projects that pull `Akka.Hosting`; the tests/examples inherit it via project references.

Pinning the full **SDK** to 1.15.3 instead trips **NU1605** — it drags `Microsoft.Extensions.*` to 10.x against the repo's 9.0.0 floor. `OpenTelemetry.Api` only depends on `System.Diagnostics.DiagnosticSource`, supports netstandard2.0, and the SDK's dependency on the Api is a `>=` floor — so 1.15.3 satisfies it without disturbing the rest of the graph.

### Completes the audit gate
With no vulnerable transitives left, **NU1902 (moderate)** moves from `WarningsNotAsErrors` to `WarningsAsErrors` — the audit now fails the build on **every** severity (moderate/high/critical).

### Verified locally
Restore clean, `dotnet list package --vulnerable --include-transitive` reports **zero** vulnerable packages, and the full solution **builds and packs** with 0 errors under warnings-as-errors.